### PR TITLE
config: add a new common external name config

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -38,6 +38,20 @@ var (
 		DisableNameInitializer:  true,
 	}
 
+	// ParameterAsIdentifier uses the given field name in the arguments as the
+	// identifier of the resource.
+	ParameterAsIdentifier = func(param string) ExternalName {
+		e := NameAsIdentifier
+		e.SetIdentifierArgumentFn = func(base map[string]interface{}, name string) {
+			base[param] = name
+		}
+		e.OmittedFields = []string{
+			param,
+			param + "_prefix",
+		}
+		return e
+	}
+
 	DefaultBasePackages = BasePackages{
 		APIVersion: []string{
 			// Default package for ProviderConfig APIs


### PR DESCRIPTION


Signed-off-by: Muvaffak Onus <me@muvaf.com>

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Add a new common external name config for resoruces whose identifier is named differently than 'name', such as `repository_name`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
