### PR TITLE
config: make Provider accept a list of options instead of exposing DefaultResourceFn

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -94,7 +94,6 @@ be quite similar for any other Terraform provider.
 
    ```go
    pc := tjconfig.NewProviderWithSchema([]byte(providerSchema), resourcePrefix, modulePath,
-       tjconfig.WithDefaultResourceFn(defaultResourceFn),
        tjconfig.WithIncludeList([]string{
            "github_repository$",
            "github_branch$",


### PR DESCRIPTION
### Description of your changes

All providers make it return a function like this [[1]](https://github.com/upbound/official-providers/blob/74a254b/provider-aws/config/provider.go#L235) [[2]](https://github.com/upbound/official-providers/blob/d6c65c5/provider-azure/config/provider.go#L208) already for provider-wide defaultings, so we can just make this shape default.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

By importing it in https://github.com/upbound/official-provider-template

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
