### PR TITLE
Add "Stable" condition to resources late initialized and up-to-date

### DIFF
--- a/pkg/resource/conditions.go
+++ b/pkg/resource/conditions.go
@@ -5,9 +5,11 @@ Copyright 2021 Upbound Inc.
 package resource
 
 import (
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	tferrors "github.com/upbound/upjet/pkg/terraform/errors"
 )
@@ -17,11 +19,12 @@ const (
 	TypeLastAsyncOperation = "LastAsyncOperation"
 	TypeAsyncOperation     = "AsyncOperation"
 
-	ReasonApplyFailure   xpv1.ConditionReason = "ApplyFailure"
-	ReasonDestroyFailure xpv1.ConditionReason = "DestroyFailure"
-	ReasonSuccess        xpv1.ConditionReason = "Success"
-	ReasonOngoing        xpv1.ConditionReason = "Ongoing"
-	ReasonFinished       xpv1.ConditionReason = "Finished"
+	ReasonApplyFailure     xpv1.ConditionReason = "ApplyFailure"
+	ReasonDestroyFailure   xpv1.ConditionReason = "DestroyFailure"
+	ReasonSuccess          xpv1.ConditionReason = "Success"
+	ReasonOngoing          xpv1.ConditionReason = "Ongoing"
+	ReasonFinished         xpv1.ConditionReason = "Finished"
+	ReasonResourceUpToDate xpv1.ConditionReason = "UpToDate"
 )
 
 // LastAsyncOperationCondition returns the condition depending on the content
@@ -81,5 +84,26 @@ func AsyncOperationOngoingCondition() xpv1.Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonOngoing,
+	}
+}
+
+// UpToDateCondition returns the condition TypeAsyncOperation Ongoing
+// if the operation is still running
+func UpToDateCondition() xpv1.Condition {
+	return xpv1.Condition{
+		Type:               "Test",
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonResourceUpToDate,
+	}
+}
+
+// SetUpToDateCondition sets UpToDate condition if the resource is a test resource and up-to-date
+func SetUpToDateCondition(mg xpresource.Managed, upToDate bool) {
+	// At this point, we know that late initialization is done
+	// After running refresh, if the resource is up-to-date and a test resource
+	// we can set the UpToDate condition
+	if upToDate && IsTest(mg) {
+		mg.SetConditions(UpToDateCondition())
 	}
 }

--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,6 +23,9 @@ const (
 	// of the Terraform State. It's non-sensitive and used by provider to store
 	// arbitrary metadata, usually details about schema version.
 	AnnotationKeyPrivateRawAttribute = "upjet.crossplane.io/provider-meta"
+
+	// AnnotationKeyTestResource is used for marking an MR as test for automated tests
+	AnnotationKeyTestResource = "upjet.upbound.io/test"
 
 	// CNameWildcard can be used as the canonical name of a value filter option
 	// that will apply to all fields of a struct
@@ -390,4 +394,9 @@ func getCanonicalName(parent, child string) string {
 	}
 
 	return fmt.Sprintf(fmtCanonical, parent, child)
+}
+
+// IsTest returns true if the managed resource has upjet.upbound.io/test= "true" annotation
+func IsTest(mg xpresource.Managed) bool {
+	return mg.GetAnnotations()[AnnotationKeyTestResource] == "true"
 }


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
With this PR we start to set "Stable" condition after late initialization is done and the resource is up-to-date. We can assert on this condition in our automated tests to make sure that the late initialization configuration is correct. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Created one resource with missing late init configuration and one resource with correct configuration:
```
NAME                                   READY   SYNCED   EXTERNAL-NAME   AGE
bucket.s3.aws.upbound.io/ezgi-bucket   True    True     ezgi-bucket     5m27s

NAME                                                                    READY   SYNCED   EXTERNAL-NAME
  AGE
bucketwebsiteconfiguration.s3.aws.upbound.io/ezgi-bucket-website-conf   True    False    ezgi-bucket
  5m27s
```
Checked their condition statuses:
```shell
ezgis-mbp:~ ezgidemirel$ kg bucket.s3.aws.upbound.io/ezgi-bucket -ojsonpath='{.status.conditions}'|jq .
[
  {
    "lastTransitionTime": "2022-06-30T11:21:53Z",
    "reason": "ReconcileSuccess",
    "status": "True",
    "type": "Synced"
  },
  {
    "lastTransitionTime": "2022-06-30T11:22:03Z",
    "reason": "Available",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2022-06-30T11:24:57Z",
    "reason": "UpToDate",
    "status": "True",
    "type": "Test"
  }
]
ezgis-mbp:~ ezgidemirel$ kg bucketwebsiteconfiguration.s3.aws.upbound.io/ezgi-bucket-website-conf -ojsonpath='{.status.conditions}'|jq .
[
  {
    "lastTransitionTime": "2022-06-29T08:35:55Z",
    "reason": "Available",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2022-06-29T09:06:50Z",
    "message": "observe failed: cannot run refresh: refresh failed: Conflicting configuration arguments: \"routing_rule\": conflicts with routing_rules: File name: main.tf.json\nConflicting configuration arguments: \"routing_rules\": conflicts with routing_rule: File name: main.tf.json",
    "reason": "ReconcileError",
    "status": "False",
    "type": "Synced"
  }
]
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
