### PR TITLE
Add "apis/v1beta1" folder for provider config version bump

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -57,6 +57,7 @@ var (
 		APIVersion: []string{
 			// Default package for ProviderConfig APIs
 			"apis/v1alpha1",
+			"apis/v1beta1",
 		},
 		Controller: []string{
 			// Default package for ProviderConfig controllers


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This change adds "apis/v1beta1" folder for provider config schema registration. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].

### How has this code been tested

A follow up PR will come from official-providers repository. I've bumped provider config of provider-aws and tested with s3 bucket resource. 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
