### PR TITLE
config.provider: load registry data before DefaultResource call similar to schema

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/upbound/upjet/pkg/registry"
 	tjname "github.com/upbound/upjet/pkg/types/name"
 )
 
@@ -44,7 +45,7 @@ type ResourceOption func(*Resource)
 
 // DefaultResource keeps an initial default configuration for all resources of a
 // provider.
-func DefaultResource(name string, terraformSchema *schema.Resource, opts ...ResourceOption) *Resource {
+func DefaultResource(name string, terraformSchema *schema.Resource, terraformRegistry *registry.Resource, opts ...ResourceOption) *Resource {
 	words := strings.Split(name, "_")
 	// As group name we default to the second element if resource name
 	// has at least 3 elements, otherwise, we took the first element as
@@ -67,6 +68,7 @@ func DefaultResource(name string, terraformSchema *schema.Resource, opts ...Reso
 	r := &Resource{
 		Name:              name,
 		TerraformResource: terraformSchema,
+		MetaResource:      terraformRegistry,
 		ShortGroup:        group,
 		Kind:              kind,
 		Version:           "v1alpha1",

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/upbound/upjet/pkg/registry"
 )
 
 func TestDefaultResource(t *testing.T) {
 	type args struct {
 		name string
 		sch  *schema.Resource
+		reg  *registry.Resource
 		opts []ResourceOption
 	}
 
@@ -112,7 +115,7 @@ func TestDefaultResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := DefaultResource(tc.args.name, tc.args.sch, tc.args.opts...)
+			r := DefaultResource(tc.args.name, tc.args.sch, tc.args.reg, tc.args.opts...)
 			if diff := cmp.Diff(tc.want, r, ignoreUnexported...); diff != "" {
 				t.Errorf("\n%s\nDefaultResource(...): -want, +got:\n%s", tc.reason, diff)
 			}

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -322,7 +322,7 @@ func TestObserve(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &external{workspace: tc.w, config: config.DefaultResource("upjet_resource", nil)}
+			e := &external{workspace: tc.w, config: config.DefaultResource("upjet_resource", nil, nil)}
 			_, err := e.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -122,7 +122,7 @@ func TestGetConnectionDetails(t *testing.T) {
 		"NoConnectionDetails": {
 			args: args{
 				tr:  &fake.Terraformed{},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 			},
 		},
 		"OnlyDefaultConnectionDetails": {
@@ -134,7 +134,7 @@ func TestGetConnectionDetails(t *testing.T) {
 						},
 					},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 				data: map[string]interface{}{
 					"top_level_secret": "sensitive-data-top-level-secret",
 				},
@@ -154,7 +154,7 @@ func TestGetConnectionDetails(t *testing.T) {
 						},
 					},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 				data: map[string]interface{}{
 					"top_level_secrets": []interface{}{
 						"val1",
@@ -180,7 +180,7 @@ func TestGetConnectionDetails(t *testing.T) {
 						},
 					},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 				data: map[string]interface{}{
 					"top_level_secrets": map[string]interface{}{
 						"key1": "val1",

--- a/pkg/terraform/files_test.go
+++ b/pkg/terraform/files_test.go
@@ -60,7 +60,7 @@ func TestWriteTFState(t *testing.T) {
 						"obs": "obsval",
 					}},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 			},
 			want: want{
 				tfstate: `{"version":4,"terraform_version":"","serial":1,"lineage":"","outputs":null,"resources":[{"mode":"managed","type":"","name":"","provider":"provider[\"registry.terraform.io/\"]","instances":[{"schema_version":0,"attributes":{"id":"some-id","name":"some-id","obs":"obsval","param":"paramval"},"private":"cHJpdmF0ZXJhdw=="}]}]}`,
@@ -85,7 +85,7 @@ func TestWriteTFState(t *testing.T) {
 						"obs": "obsval",
 					}},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil, func(r *config.Resource) {
+				cfg: config.DefaultResource("upjet_resource", nil, nil, func(r *config.Resource) {
 					r.OperationTimeouts.Read = 2 * time.Minute
 				}),
 			},
@@ -148,7 +148,7 @@ func TestWriteMainTF(t *testing.T) {
 						"obs": "obsval",
 					}},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil, func(r *config.Resource) {
+				cfg: config.DefaultResource("upjet_resource", nil, nil, func(r *config.Resource) {
 					r.OperationTimeouts = config.OperationTimeouts{
 						Read:   30 * time.Second,
 						Update: 2 * time.Minute,
@@ -186,7 +186,7 @@ func TestWriteMainTF(t *testing.T) {
 						"obs": "obsval",
 					}},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 				s: Setup{
 					Requirement: ProviderRequirement{
 						Source:  "hashicorp/provider-test",
@@ -219,7 +219,7 @@ func TestWriteMainTF(t *testing.T) {
 						"obs": "obsval",
 					}},
 				},
-				cfg: config.DefaultResource("upjet_resource", nil),
+				cfg: config.DefaultResource("upjet_resource", nil, nil),
 				s: Setup{
 					Requirement: ProviderRequirement{
 						Source:  "my-company/namespace/provider-test",


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Otherwise, it's not available for common configurators passed to `DefaultResource` as seen [here](https://github.com/upbound/official-providers/pull/383#discussion_r924138542). This also makes the metadata file required since registry representation of the resource is just as important as schema and there is no official provider without a TF registry documentation to date so far.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

In https://github.com/upbound/official-providers/pull/452

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
