### PR TITLE
types.reference: calculate reference field name correctly

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -294,8 +294,8 @@ func (r *resource) addObservationField(f *Field, field *types.Var) {
 	r.obsTags = append(r.obsTags, fmt.Sprintf(`json:"%s" tf:"%s"`, f.JSONTag, f.TFTag))
 }
 
-func (r *resource) addReferenceFields(g *Builder, paramName *types.TypeName, field *types.Var, f *Field) {
-	refFields, refTags := g.generateReferenceFields(paramName, field, f)
+func (r *resource) addReferenceFields(g *Builder, paramName *types.TypeName, field *Field) {
+	refFields, refTags := g.generateReferenceFields(paramName, field)
 	r.paramTags = append(r.paramTags, refTags...)
 	r.paramFields = append(r.paramFields, refFields...)
 }

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -151,7 +151,7 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames) {
 	}
 
 	if f.Reference != nil {
-		r.addReferenceFields(g, typeNames.ParameterTypeName, field, f)
+		r.addReferenceFields(g, typeNames.ParameterTypeName, f)
 	}
 
 	g.comments.AddFieldComment(typeNames.ParameterTypeName, f.FieldNameCamel, f.Comment.Build())

--- a/pkg/types/reference_test.go
+++ b/pkg/types/reference_test.go
@@ -9,6 +9,7 @@ import (
 	twtypes "github.com/muvaf/typewriter/pkg/types"
 
 	"github.com/upbound/upjet/pkg/config"
+	"github.com/upbound/upjet/pkg/types/name"
 )
 
 func TestBuilder_generateReferenceFields(t *testing.T) {
@@ -16,8 +17,7 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 
 	type args struct {
 		t *types.TypeName
-		f *types.Var
-		r config.Reference
+		f *Field
 	}
 	type want struct {
 		outFields   []*types.Var
@@ -31,9 +31,12 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 		"OnlyRefType": {
 			args: args{
 				t: types.NewTypeName(token.NoPos, tp, "Params", types.Universe.Lookup("string").Type()),
-				f: types.NewField(token.NoPos, tp, "TestField", types.Universe.Lookup("string").Type(), false),
-				r: config.Reference{
-					Type: "testObject",
+				f: &Field{
+					Name: name.NewFromCamel("TestField"),
+					Reference: &config.Reference{
+						Type: "testObject",
+					},
+					FieldType: types.Universe.Lookup("string").Type(),
 				},
 			}, want: want{
 				outFields: []*types.Var{
@@ -53,9 +56,12 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 		"OnlyRefTypeSlice": {
 			args: args{
 				t: types.NewTypeName(token.NoPos, tp, "Params", types.Universe.Lookup("string").Type()),
-				f: types.NewField(token.NoPos, tp, "TestField", types.NewSlice(types.Universe.Lookup("string").Type()), false),
-				r: config.Reference{
-					Type: "testObject",
+				f: &Field{
+					Name: name.NewFromCamel("TestField"),
+					Reference: &config.Reference{
+						Type: "testObject",
+					},
+					FieldType: types.NewSlice(types.Universe.Lookup("string").Type()),
 				},
 			}, want: want{
 				outFields: []*types.Var{
@@ -75,10 +81,13 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 		"WithCustomFieldName": {
 			args: args{
 				t: types.NewTypeName(token.NoPos, tp, "Params", types.Universe.Lookup("string").Type()),
-				f: types.NewField(token.NoPos, tp, "TestField", types.Universe.Lookup("string").Type(), false),
-				r: config.Reference{
-					Type:         "TestObject",
-					RefFieldName: "CustomRef",
+				f: &Field{
+					Name: name.NewFromCamel("TestField"),
+					Reference: &config.Reference{
+						Type:         "TestObject",
+						RefFieldName: "CustomRef",
+					},
+					FieldType: types.Universe.Lookup("string").Type(),
 				},
 			}, want: want{
 				outFields: []*types.Var{
@@ -98,10 +107,13 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 		"WithCustomSelectorName": {
 			args: args{
 				t: types.NewTypeName(token.NoPos, tp, "Params", types.Universe.Lookup("string").Type()),
-				f: types.NewField(token.NoPos, tp, "TestField", types.Universe.Lookup("string").Type(), false),
-				r: config.Reference{
-					Type:              "TestObject",
-					SelectorFieldName: "CustomSelector",
+				f: &Field{
+					Name: name.NewFromCamel("TestField"),
+					Reference: &config.Reference{
+						Type:              "TestObject",
+						SelectorFieldName: "CustomSelector",
+					},
+					FieldType: types.Universe.Lookup("string").Type(),
 				},
 			}, want: want{
 				outFields: []*types.Var{
@@ -124,7 +136,7 @@ func TestBuilder_generateReferenceFields(t *testing.T) {
 			g := &Builder{
 				comments: twtypes.Comments{},
 			}
-			gotFields, gotTags := g.generateReferenceFields(tc.args.t, tc.args.f, &Field{Reference: &tc.args.r})
+			gotFields, gotTags := g.generateReferenceFields(tc.args.t, tc.args.f)
 			if diff := cmp.Diff(tc.want.outFields, gotFields, cmp.Comparer(func(a, b *types.Var) bool {
 				return a.String() == b.String()
 			})); diff != "" {


### PR DESCRIPTION
### Description of your changes

This is currently blocking https://github.com/upbound/official-providers/pull/457 to go through.

Fixes https://github.com/upbound/upjet/issues/45

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

In https://github.com/upbound/official-providers/pull/457 , I've confirmed that the ref tags are produced as `apiIdRef` instead of `apiidRef`.

However, there is another change in some resources in AWS. In cases we give custom ref and selector field names, like `VpcSecurityGroupIdRefs` so that it doesn't end up being `VpcSecurityGroupIdsRefs`, we run into errors since with the new calculation we always default to using `.Camel` property of the name, which is in line with the CRD type builder but those custom overrides [are given](https://github.com/upbound/official-providers/blob/f71b3c2/provider-aws/config/overrides.go#L119) as camel computed, i.e. given as `VpcSecurityGroupIdRefs` instead of `VPCSecurityGroupIDRefs`. What we end up with without this change is the following:
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/7584126/181525944-21bc8957-0d4d-4d01-a0b7-60e3fbddd767.png">

With this change we produce the fields with `.Camel` but then the reference comments don't match. So, we should either opt for `.CamelComputed` for all fields or change the custom overrides and I'm leaning towards the latter. Azure and GCP are not affected since apparently they haven't overridden any ref or selector fields.

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/7584126/181590879-2e951115-2450-4e02-b305-9d9eb0915286.png">


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
