### PR TITLE
Do not include arguments moved to status in generated example manifests

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -13,12 +13,6 @@ import (
 	tjname "github.com/upbound/upjet/pkg/types/name"
 )
 
-const (
-	errFmtFieldNotFound       = "field %s is not found"
-	errFmtElemNil             = "field %s does not have an element type"
-	errFmtElemTypeNotResource = "element type of %s is not *schema.Resource"
-)
-
 // Commonly used resource configurations.
 var (
 	DefaultBasePackages = BasePackages{

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -7,8 +7,6 @@ package config
 import (
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -367,8 +365,7 @@ func TestGetSchema(t *testing.T) {
 		fieldpath string
 	}
 	type want struct {
-		sch      *schema.Schema
-		panicErr error
+		sch *schema.Schema
 	}
 	schLeaf := &schema.Schema{
 		Type: schema.TypeString,
@@ -415,8 +412,7 @@ func TestGetSchema(t *testing.T) {
 				sch:       res,
 			},
 			want: want{
-				sch:      schLeaf,
-				panicErr: errors.Errorf(errFmtFieldNotFound, "topB"),
+				sch: nil,
 			},
 		},
 		"LeafFieldNotFound": {
@@ -425,8 +421,7 @@ func TestGetSchema(t *testing.T) {
 				sch:       res,
 			},
 			want: want{
-				sch:      schLeaf,
-				panicErr: errors.Errorf(errFmtFieldNotFound, "topA.olala"),
+				sch: nil,
 			},
 		},
 		"TopFieldIsNotMap": {
@@ -439,8 +434,7 @@ func TestGetSchema(t *testing.T) {
 				},
 			},
 			want: want{
-				sch:      schLeaf,
-				panicErr: errors.Errorf(errFmtElemNil, "topA"),
+				sch: nil,
 			},
 		},
 		"MiddleFieldIsNotResource": {
@@ -461,19 +455,13 @@ func TestGetSchema(t *testing.T) {
 				},
 			},
 			want: want{
-				sch:      schLeaf,
-				panicErr: errors.Errorf(errFmtElemTypeNotResource, "topA.topB"),
+				sch: nil,
 			},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if diff := cmp.Diff(tc.want.panicErr, recover(), test.EquateErrors()); diff != "" {
-					t.Errorf("\n%s\nGetSchema(...): -want panic err, +got panic err:\n%s", tc.reason, diff)
-				}
-			}()
 			sch := GetSchema(tc.args.sch, tc.args.fieldpath)
 			if diff := cmp.Diff(tc.want.sch, sch); diff != "" {
 				t.Errorf("\n%s\nGetSchema(...): -want, +got:\n%s", tc.reason, diff)

--- a/pkg/pipeline/example.go
+++ b/pkg/pipeline/example.go
@@ -119,7 +119,7 @@ func isStatus(r *config.Resource, attr string) bool {
 	if s == nil {
 		return false
 	}
-	return !s.Optional && s.Computed
+	return tjtypes.IsObservation(s)
 }
 
 func transformFields(r *config.Resource, params map[string]interface{}, omittedFields []string, t map[string]tjtypes.Transformation, namePrefix string) { // nolint:gocyclo

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -92,7 +92,7 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		var reference *config.Reference
 		ref, ok := cfg.References[fieldPath(append(tfPath, snakeFieldName))]
 		// if a reference is configured and the field does not belong to status
-		if ok && !isObservation(res.Schema[snakeFieldName]) {
+		if ok && !IsObservation(res.Schema[snakeFieldName]) {
 			reference = &ref
 		}
 
@@ -197,7 +197,7 @@ func (g *Builder) buildSchema(f *Field, cfg *config.Resource, t map[string]Trans
 			}
 
 			switch {
-			case isObservation(f.Schema):
+			case IsObservation(f.Schema):
 				if obsType == nil {
 					return nil, errors.Errorf("element type of %s is computed but the underlying schema does not return observation type", fieldPath(names))
 				}
@@ -326,7 +326,9 @@ func generateTypeName(suffix string, pkg *types.Package, names ...string) (strin
 	return "", errors.Errorf("could not generate a unique name for %s", n)
 }
 
-func isObservation(s *schema.Schema) bool {
+// IsObservation returns whether the specified Schema belongs to an observed
+// attribute, i.e., whether it's a required computed field.
+func IsObservation(s *schema.Schema) bool {
 	// NOTE(muvaf): If a field is not optional but computed, then it's
 	// definitely an observation field.
 	// If it's optional but also computed, then it means the field has a server

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -80,7 +80,7 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 		return nil, false, err
 	}
 
-	if isObservation(f.Schema) {
+	if IsObservation(f.Schema) {
 		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "status.atProvider."+fieldPathWithWildcard(f.CRDPaths))
 		// Drop an observation field from schema if it is sensitive.
 		// Data will be stored in connection details secret
@@ -141,7 +141,7 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames) {
 
 	field := types.NewField(token.NoPos, g.Package, f.FieldNameCamel, f.FieldType, false)
 	switch {
-	case isObservation(f.Schema):
+	case IsObservation(f.Schema):
 		r.addObservationField(f, field)
 	default:
 		if f.AsBlocksMode {


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Currently, we do not honor `MoveToStatus` configurations in generated example manifests. This PR excludes arguments that have manually been moved to status from the generated example manifests.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
With this PR, generated `azurerm_virtual_network` example manifest now correctly lacks the `subnet` section, which has been moved to status:
```yaml
apiVersion: network.azure.upbound.io/v1beta1
kind: VirtualNetwork
metadata:
  name: example
spec:
  forProvider:
    addressSpace:
    - 10.0.0.0/16
    dnsServers:
    - 10.0.0.4
    - 10.0.0.5
    location: West Europe
    resourceGroupNameRef:
      name: example
    tags:
      environment: Production
```

[contribution process]: https://git.io/fj2m9
