### PR TITLE
Do not generate references for status fields

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -91,7 +91,8 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 	for _, snakeFieldName := range keys {
 		var reference *config.Reference
 		ref, ok := cfg.References[fieldPath(append(tfPath, snakeFieldName))]
-		if ok {
+		// if a reference is configured and the field does not belong to status
+		if ok && !isObservation(res.Schema[snakeFieldName]) {
 			reference = &ref
 		}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #35

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually configured a reference for the `subnet.security_group` argument of the `azurerm_virtual_network` resource. Without that fix, although the `subnet` argument is moved to status by configuration, it reappears in `spec`. With this PR, we prevent this.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
