### PR TITLE
Fix field comments

### DIFF
--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -41,11 +41,11 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 	// Use registry descriptions for fields if exists
 	// Otherwise, use schema as source
 	var commentText string
-	if cfg.MetaResource != nil && cfg.MetaResource.ArgumentDocs[f.Name.Snake] != "" {
-		commentText = cfg.MetaResource.ArgumentDocs[f.Name.Snake]
-	} else {
-		commentText = f.Schema.Description
+	if cfg.MetaResource != nil {
+		commentText = cfg.MetaResource.ArgumentDocs[f.Name.Snake] + "\n"
 	}
+	commentText += f.Schema.Description
+
 	comment, err := comments.New(commentText)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot build comment for description: %s", commentText)


### PR DESCRIPTION
### Description of your changes

Latest change about the API Docs causes that removing of the terrajet tag comments. This PR fixes the mentioned issue.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`make generate` in `provider-aws`

[contribution process]: https://git.io/fj2m9
