### PR TITLE
terraform: do not print tf file name in the errors

### DIFF
--- a/pkg/terraform/errors/errors.go
+++ b/pkg/terraform/errors/errors.go
@@ -37,12 +37,6 @@ type LogDiagnostic struct {
 	Severity string `json:"severity"`
 	Summary  string `json:"summary"`
 	Detail   string `json:"detail"`
-	Range    Range  `json:"range"`
-}
-
-// Range represents a line range in a Terraform workspace file
-type Range struct {
-	FileName string `json:"filename"`
 }
 
 func (t *tfError) Error() string {
@@ -68,9 +62,6 @@ func newTFError(message string, logs []byte) (string, *tfError) {
 		m := l.Message
 		if l.Diagnostic.Severity == levelError && l.Diagnostic.Summary != "" {
 			m = fmt.Sprintf("%s: %s", l.Diagnostic.Summary, l.Diagnostic.Detail)
-			if len(l.Diagnostic.Range.FileName) != 0 {
-				m = m + ": File name: " + l.Diagnostic.Range.FileName
-			}
 		}
 		messages = append(messages, m)
 	}

--- a/pkg/terraform/errors/errors_test.go
+++ b/pkg/terraform/errors/errors_test.go
@@ -218,7 +218,7 @@ func TestNewApplyFailed(t *testing.T) {
 			args: args{
 				logs: errorLog,
 			},
-			wantErrMessage: "apply failed: Missing required argument: The argument \"location\" is required, but no definition was found.: File name: main.tf.json\nMissing required argument: The argument \"name\" is required, but no definition was found.: File name: main.tf.json",
+			wantErrMessage: "apply failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
 		},
 	}
 	for name, tt := range tests {
@@ -247,7 +247,7 @@ func TestNewDestroyFailed(t *testing.T) {
 			args: args{
 				logs: errorLog,
 			},
-			wantErrMessage: "destroy failed: Missing required argument: The argument \"location\" is required, but no definition was found.: File name: main.tf.json\nMissing required argument: The argument \"name\" is required, but no definition was found.: File name: main.tf.json",
+			wantErrMessage: "destroy failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
 		},
 	}
 	for name, tt := range tests {
@@ -276,7 +276,7 @@ func TestNewRefreshFailed(t *testing.T) {
 			args: args{
 				logs: errorLog,
 			},
-			wantErrMessage: "refresh failed: Missing required argument: The argument \"location\" is required, but no definition was found.: File name: main.tf.json\nMissing required argument: The argument \"name\" is required, but no definition was found.: File name: main.tf.json",
+			wantErrMessage: "refresh failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
 		},
 	}
 	for name, tt := range tests {
@@ -305,7 +305,7 @@ func TestNewPlanFailed(t *testing.T) {
 			args: args{
 				logs: errorLog,
 			},
-			wantErrMessage: "plan failed: Missing required argument: The argument \"location\" is required, but no definition was found.: File name: main.tf.json\nMissing required argument: The argument \"name\" is required, but no definition was found.: File name: main.tf.json",
+			wantErrMessage: "plan failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
### Description of your changes

We never really go to workspace folder anymore, so it's not worth printing the file name for every error.

Fixes https://github.com/upbound/upjet/issues/82

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually with AWS.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
