### PR TITLE
Do not override annotations of generated example manifests

### DIFF
--- a/pkg/examples/example.go
+++ b/pkg/examples/example.go
@@ -134,9 +134,7 @@ func paveCRManifest(exampleParams map[string]any, r *config.Resource, eName, gro
 		},
 	}
 	if len(r.MetaResource.ExternalName) != 0 {
-		metadata["annotations"] = map[string]string{
-			xpmeta.AnnotationKeyExternalName: r.MetaResource.ExternalName,
-		}
+		metadata["annotations"].(map[string]string)[xpmeta.AnnotationKeyExternalName] = r.MetaResource.ExternalName
 	}
 	return &reference.PavedWithManifest{
 		Paved:        fieldpath.Pave(example),


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We currently override market-place dependency grouping annotations for resources that have a unique external-name configuration. This PR proposes a fix for this.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually tested on `provider-aws`.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
