### PR TITLE
Make UseAsync=true by default

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -68,6 +68,7 @@ func DefaultResource(name string, terraformSchema *schema.Resource, terraformReg
 		ExternalName:      NameAsIdentifier,
 		References:        map[string]Reference{},
 		Sensitive:         NopSensitive,
+		UseAsync:          true,
 	}
 	for _, f := range opts {
 		f(r)

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -40,6 +40,7 @@ func TestDefaultResource(t *testing.T) {
 				ExternalName: NameAsIdentifier,
 				References:   map[string]Reference{},
 				Sensitive:    NopSensitive,
+				UseAsync:     true,
 			},
 		},
 		"TwoSectionsName": {
@@ -55,6 +56,7 @@ func TestDefaultResource(t *testing.T) {
 				ExternalName: NameAsIdentifier,
 				References:   map[string]Reference{},
 				Sensitive:    NopSensitive,
+				UseAsync:     true,
 			},
 		},
 		"NameWithPrefixAcronym": {
@@ -70,6 +72,7 @@ func TestDefaultResource(t *testing.T) {
 				ExternalName: NameAsIdentifier,
 				References:   map[string]Reference{},
 				Sensitive:    NopSensitive,
+				UseAsync:     true,
 			},
 		},
 		"NameWithSuffixAcronym": {
@@ -85,6 +88,7 @@ func TestDefaultResource(t *testing.T) {
 				ExternalName: NameAsIdentifier,
 				References:   map[string]Reference{},
 				Sensitive:    NopSensitive,
+				UseAsync:     true,
 			},
 		},
 		"NameWithMultipleAcronyms": {
@@ -100,6 +104,7 @@ func TestDefaultResource(t *testing.T) {
 				ExternalName: NameAsIdentifier,
 				References:   map[string]Reference{},
 				Sensitive:    NopSensitive,
+				UseAsync:     true,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
In this PR, we're changing default `UseAsync` value to true. Details can be found [here](https://upboundio.slack.com/archives/C01PK1SMYNN/p1662111447644739). 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Consumed it in provider-aws and applied following manifests. Checked AWS console to make sure there is only one NAT gateway exists. 

```
---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: NATGateway
metadata:
  name: ezgi-aws-cluster-nat-a
spec:
  forProvider:
    allocationIdRef:
      name: ezgi-aws-cluster-nat-eip-a
    region: us-west-2
    subnetIdRef:
      name: ezgi-aws-cluster-subnet-public-a
    tags:
      ResourceType: natgateway
      Name: ezgiAWSClusterNatGateway1
---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: EIP
metadata:
  name: ezgi-aws-cluster-nat-eip-a
spec:
  forProvider:
    region: us-west-2
    tags:
      ResourceType: elastic-ip
      Name: ezgiAWSClusterNatEip1
---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: Subnet
metadata:
  name: ezgi-aws-cluster-subnet-public-a
spec:
  forProvider:
    availabilityZone: us-west-2a
    cidrBlock: 10.0.101.0/24
    region: us-west-2
    mapPublicIpOnLaunch: true
    tags:
      ResourceType: subnet
      kubernetes.io/role/elb: "1"
      Name: ezgiAWSClusterPublicSubnet1
    vpcIdRef:
      name: ezgi-aws-cluster
---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
metadata:
  name: ezgi-aws-cluster
spec:
  forProvider:
    cidrBlock: 10.0.0.0/16
    enableDnsHostnames: true
    enableDnsSupport: true
    region: us-west-2
    tags:
      ResourceType: vpc
      Name: ezgiAWSClusterVPC

```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
