### PR TITLE
Generate hierarchical names under argumentDocs in scraped provider metadata

### DIFF
--- a/pkg/common.go
+++ b/pkg/common.go
@@ -17,5 +17,8 @@ func FilterDescription(description, keyword string) string {
 			result = append(result, s)
 		}
 	}
+	if len(result) == 0 {
+		return strings.ReplaceAll(strings.ToLower(description), keyword, "Upbound official provider")
+	}
 	return strings.Join(result, descriptionSeparator)
 }

--- a/pkg/registry/meta.go
+++ b/pkg/registry/meta.go
@@ -252,7 +252,7 @@ func (r *Resource) scrapeFieldDocs(doc *html.Node, fieldXPath string) {
 			conflictedFields[attrName] = true
 			continue
 		}
-		r.ArgumentDocs[attrName] = docStr
+		r.ArgumentDocs[attrName] = strings.TrimSpace(docStr)
 	}
 
 	// Remove descriptions for repeating fields in the registry.

--- a/pkg/registry/testdata/aws/pm.yaml
+++ b/pkg/registry/testdata/aws/pm.yaml
@@ -1,149 +1,148 @@
 name: test-provider
 resources:
-  aws_accessanalyzer_analyzer:
-    subCategory: IAM Access Analyzer
-    description: Manages an Access Analyzer Analyzer
-    name: aws_accessanalyzer_analyzer
-    title: aws_accessanalyzer_analyzer
-    examples:
-      - name: example
-        manifest: |-
-          {
-            "analyzer_name": "example"
-          }
-        references: {}
-        dependencies: {}
-      - name: example
-        manifest: |-
-          {
-            "analyzer_name": "example",
-            "depends_on": [
-              "${aws_organizations_organization.example}"
-            ],
-            "type": "ORGANIZATION"
-          }
-        references: {}
-        dependencies:
-          aws_organizations_organization.example: |-
-            {
-              "aws_service_access_principals": [
-                "access-analyzer.amazonaws.com"
-              ]
-            }
-    argumentDocs:
-      analyzer_name: ' - (Required) Name of the Analyzer.'
-      arn: ' - The Amazon Resource Name (ARN) of the Analyzer.'
-      id: ' - Analyzer name.'
-      tags: ' - (Optional) Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.'
-      tags_all: ' - A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block.'
-      type: ' - (Optional) Type of Analyzer. Valid values are ACCOUNT or ORGANIZATION. Defaults to ACCOUNT.'
-  aws_ebs_volume:
-    subCategory: EBS (EC2)
-    description: Provides an elastic block storage resource.
-    name: aws_ebs_volume
-    title: aws_ebs_volume
-    examples:
-      - name: example
-        manifest: |-
-          {
-            "availability_zone": "us-west-2a",
-            "size": 40,
-            "tags": {
-              "Name": "HelloWorld"
-            }
-          }
-        references: {}
-        dependencies: {}
-    argumentDocs:
-      arn: ' - The volume ARN (e.g., arn:aws:ec2:us-east-1:0123456789012:volume/vol-59fcb34e).'
-      availability_zone: ' - (Required) The AZ where the EBS volume will exist.'
-      create: ' - (Default 5 minutes) Used for creating volumes. This includes the time required for the volume to become available'
-      delete: ' - (Default 5 minutes) Used for destroying volumes'
-      encrypted: ' - (Optional) If true, the disk will be encrypted.'
-      id: ' - The volume ID (e.g., vol-59fcb34e).'
-      iops: ' - (Optional) The amount of IOPS to provision for the disk. Only valid for type of io1, io2 or gp3.'
-      kms_key_id: ' - (Optional) The ARN for the KMS encryption key. When specifying kms_key_id, encrypted needs to be set to true. Note: Terraform must be running with credentials which have the GenerateDataKeyWithoutPlaintext permission on the specified KMS key as required by the EBS KMS CMK volume provisioning process to prevent a volume from being created and almost immediately deleted.'
-      multi_attach_enabled: ' - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on io1 and io2 volumes.'
-      outpost_arn: ' - (Optional) The Amazon Resource Name (ARN) of the Outpost.'
-      size: ' - (Optional) The size of the drive in GiBs.'
-      snapshot_id: ' (Optional) A snapshot to base the EBS volume off of.'
-      tags: ' - (Optional) A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.'
-      tags_all: ' - A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block.'
-      throughput: ' - (Optional) The throughput that the volume supports, in MiB/s. Only valid for type of gp3.'
-      type: ' - (Optional) The type of EBS volume. Can be standard, gp2, gp3, io1, io2, sc1 or st1 (Default: gp2).'
-      update: ' - (Default 5 minutes) Used for size, type, or iops volume changes'
-  aws_s3_bucket_acl:
-    subCategory: S3 (Simple Storage)
-    description: Provides an S3 bucket ACL resource.
-    name: aws_s3_bucket_acl
-    title: aws_s3_bucket_acl
-    examples:
-      - name: example_bucket_acl
-        manifest: |-
-          {
-            "acl": "private",
-            "bucket": "${aws_s3_bucket.example.id}"
-          }
-        references:
-          bucket: aws_s3_bucket.example.id
-        dependencies:
-          aws_s3_bucket.example: |-
-            {
-              "bucket": "my-tf-example-bucket"
-            }
-      - name: example
-        manifest: |-
-          {
-            "access_control_policy": [
-              {
-                "grant": [
-                  {
-                    "grantee": [
-                      {
-                        "id": "${data.aws_canonical_user_id.current.id}",
-                        "type": "CanonicalUser"
-                      }
-                    ],
-                    "permission": "READ"
-                  },
-                  {
-                    "grantee": [
-                      {
-                        "type": "Group",
-                        "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
-                      }
-                    ],
-                    "permission": "READ_ACP"
+    aws_accessanalyzer_analyzer:
+        subCategory: IAM Access Analyzer
+        description: Manages an Access Analyzer Analyzer
+        name: aws_accessanalyzer_analyzer
+        title: aws_accessanalyzer_analyzer
+        examples:
+            - name: example
+              manifest: |-
+                {
+                  "analyzer_name": "example"
+                }
+            - name: example
+              manifest: |-
+                {
+                  "analyzer_name": "example",
+                  "depends_on": [
+                    "${aws_organizations_organization.example}"
+                  ],
+                  "type": "ORGANIZATION"
+                }
+              dependencies:
+                aws_organizations_organization.example: |-
+                    {
+                      "aws_service_access_principals": [
+                        "access-analyzer.amazonaws.com"
+                      ]
+                    }
+        argumentDocs:
+            analyzer_name: '- (Required) Name of the Analyzer.'
+            arn: '- The Amazon Resource Name (ARN) of the Analyzer.'
+            id: '- Analyzer name.'
+            tags: '- (Optional) Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.'
+            tags_all: '- A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block.'
+            type: '- (Optional) Type of Analyzer. Valid values are ACCOUNT or ORGANIZATION. Defaults to ACCOUNT.'
+        importStatements: []
+    aws_ebs_volume:
+        subCategory: EBS (EC2)
+        description: Provides an elastic block storage resource.
+        name: aws_ebs_volume
+        title: aws_ebs_volume
+        examples:
+            - name: example
+              manifest: |-
+                {
+                  "availability_zone": "us-west-2a",
+                  "size": 40,
+                  "tags": {
+                    "Name": "HelloWorld"
                   }
-                ],
-                "owner": [
-                  {
-                    "id": "${data.aws_canonical_user_id.current.id}"
-                  }
-                ]
-              }
-            ],
-            "bucket": "${aws_s3_bucket.example.id}"
-          }
-        references:
-          access_control_policy.grant.grantee.id: data.aws_canonical_user_id.current.id
-          access_control_policy.owner.id: data.aws_canonical_user_id.current.id
-          bucket: aws_s3_bucket.example.id
-        dependencies:
-          aws_s3_bucket.example: |-
-            {
-              "bucket": "my-tf-example-bucket"
-            }
-    argumentDocs:
-      access_control_policy: ' - (Optional, Conflicts with acl) A configuration block that sets the ACL permissions for an object per grantee documented below.'
-      acl: ' - (Optional, Conflicts with access_control_policy) The canned ACL to apply to the bucket.'
-      bucket: ' - (Required, Forces new resource) The name of the bucket.'
-      display_name: ' - (Optional) The display name of the owner.'
-      email_address: ' - (Optional) Email address of the grantee. See Regions and Endpoints for supported AWS regions where this argument can be specified.'
-      expected_bucket_owner: ' - (Optional, Forces new resource) The account ID of the expected bucket owner.'
-      grant: ' - (Required) Set of grant configuration blocks documented below.'
-      grantee: ' - (Required) Configuration block for the person being granted permissions documented below.'
-      owner: ' - (Required) Configuration block of the bucket owner''s display name and ID documented below.'
-      permission: ' - (Required) Logging permissions assigned to the grantee for the bucket.'
-      type: ' - (Required) Type of grantee. Valid values: CanonicalUser, AmazonCustomerByEmail, Group.'
-      uri: ' - (Optional) URI of the grantee group.'
+                }
+        argumentDocs:
+            arn: '- The volume ARN (e.g., arn:aws:ec2:us-east-1:0123456789012:volume/vol-59fcb34e).'
+            availability_zone: '- (Required) The AZ where the EBS volume will exist.'
+            create: '- (Default 5 minutes) Used for creating volumes. This includes the time required for the volume to become available'
+            delete: '- (Default 5 minutes) Used for destroying volumes'
+            encrypted: '- (Optional) If true, the disk will be encrypted.'
+            id: '- The volume ID (e.g., vol-59fcb34e).'
+            iops: '- (Optional) The amount of IOPS to provision for the disk. Only valid for type of io1, io2 or gp3.'
+            kms_key_id: '- (Optional) The ARN for the KMS encryption key. When specifying kms_key_id, encrypted needs to be set to true. Note: Terraform must be running with credentials which have the GenerateDataKeyWithoutPlaintext permission on the specified KMS key as required by the EBS KMS CMK volume provisioning process to prevent a volume from being created and almost immediately deleted.'
+            multi_attach_enabled: '- (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on io1 and io2 volumes.'
+            outpost_arn: '- (Optional) The Amazon Resource Name (ARN) of the Outpost.'
+            size: '- (Optional) The size of the drive in GiBs.'
+            snapshot_id: (Optional) A snapshot to base the EBS volume off of.
+            tags: '- (Optional) A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.'
+            tags_all: '- A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block.'
+            throughput: '- (Optional) The throughput that the volume supports, in MiB/s. Only valid for type of gp3.'
+            type: '- (Optional) The type of EBS volume. Can be standard, gp2, gp3, io1, io2, sc1 or st1 (Default: gp2).'
+            update: '- (Default 5 minutes) Used for size, type, or iops volume changes'
+        importStatements: []
+    aws_s3_bucket_acl:
+        subCategory: S3 (Simple Storage)
+        description: Provides an S3 bucket ACL resource.
+        name: aws_s3_bucket_acl
+        title: aws_s3_bucket_acl
+        examples:
+            - name: example_bucket_acl
+              manifest: |-
+                {
+                  "acl": "private",
+                  "bucket": "${aws_s3_bucket.example.id}"
+                }
+              references:
+                bucket: aws_s3_bucket.example.id
+              dependencies:
+                aws_s3_bucket.example: |-
+                    {
+                      "bucket": "my-tf-example-bucket"
+                    }
+            - name: example
+              manifest: |-
+                {
+                  "access_control_policy": [
+                    {
+                      "grant": [
+                        {
+                          "grantee": [
+                            {
+                              "id": "${data.aws_canonical_user_id.current.id}",
+                              "type": "CanonicalUser"
+                            }
+                          ],
+                          "permission": "READ"
+                        },
+                        {
+                          "grantee": [
+                            {
+                              "type": "Group",
+                              "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                            }
+                          ],
+                          "permission": "READ_ACP"
+                        }
+                      ],
+                      "owner": [
+                        {
+                          "id": "${data.aws_canonical_user_id.current.id}"
+                        }
+                      ]
+                    }
+                  ],
+                  "bucket": "${aws_s3_bucket.example.id}"
+                }
+              references:
+                access_control_policy.grant.grantee.id: data.aws_canonical_user_id.current.id
+                access_control_policy.owner.id: data.aws_canonical_user_id.current.id
+                bucket: aws_s3_bucket.example.id
+              dependencies:
+                aws_s3_bucket.example: |-
+                    {
+                      "bucket": "my-tf-example-bucket"
+                    }
+        argumentDocs:
+            access_control_policy: '- (Optional, Conflicts with acl) A configuration block that sets the ACL permissions for an object per grantee documented below.'
+            access_control_policy.grant: '- (Required) Set of grant configuration blocks documented below.'
+            access_control_policy.grant.grantee: '- (Required) Configuration block for the person being granted permissions documented below.'
+            access_control_policy.grant.permission: '- (Required) Logging permissions assigned to the grantee for the bucket.'
+            access_control_policy.owner: '- (Required) Configuration block of the bucket owner''s display name and ID documented below.'
+            acl: '- (Optional, Conflicts with access_control_policy) The canned ACL to apply to the bucket.'
+            bucket: '- (Required, Forces new resource) The name of the bucket.'
+            expected_bucket_owner: '- (Optional, Forces new resource) The account ID of the expected bucket owner.'
+            grantee.email_address: '- (Optional) Email address of the grantee. See Regions and Endpoints for supported AWS regions where this argument can be specified.'
+            grantee.type: '- (Required) Type of grantee. Valid values: CanonicalUser, AmazonCustomerByEmail, Group.'
+            grantee.uri: '- (Optional) URI of the grantee group.'
+            owner.display_name: '- (Optional) The display name of the owner.'
+            owner.id: '- (Required) The ID of the owner.'
+        importStatements: []

--- a/pkg/registry/testdata/azure/pm.yaml
+++ b/pkg/registry/testdata/azure/pm.yaml
@@ -8,32 +8,30 @@ resources:
         examples:
             - name: example
               manifest: |-
-                  {
-                    "country_code": "US",
-                    "data_residency_location": "United States",
-                    "display_name": "example-b2c-tenant",
-                    "domain_name": "exampleb2ctenant.onmicrosoft.com",
-                    "resource_group_name": "example-rg",
-                    "sku_name": "PremiumP1"
-                  }
-              references: {}
-              dependencies: {}
+                {
+                  "country_code": "US",
+                  "data_residency_location": "United States",
+                  "display_name": "example-b2c-tenant",
+                  "domain_name": "exampleb2ctenant.onmicrosoft.com",
+                  "resource_group_name": "example-rg",
+                  "sku_name": "PremiumP1"
+                }
         argumentDocs:
-            billing_type: ' - The type of billing for the AAD B2C tenant. Possible values include: MAU or Auths.'
-            country_code: ' - (Optional) Country code of the B2C tenant. The country_code should be valid for the specified data_residency_location. See official docs for valid country codes. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.'
-            create: ' - (Defaults to 30 minutes) Used when creating the AAD B2C Directory.'
-            data_residency_location: ' - (Required) Location in which the B2C tenant is hosted and data resides. The data_residency_location should be valid for the specified country_code. See official docs for more information. Changing this forces a new AAD B2C Directory to be created.'
-            delete: ' - (Defaults to 30 minutes) Used when deleting the AAD B2C Directory.'
-            display_name: ' - (Optional) The initial display name of the B2C tenant. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.'
-            domain_name: ' - (Required) Domain name of the B2C tenant, including the .onmicrosoft.com suffix. Changing this forces a new AAD B2C Directory to be created.'
-            effective_start_date: ' - The date from which the billing type took effect. May not be populated until after the first billing cycle.'
-            id: ' - The ID of the AAD B2C Directory.'
-            read: ' - (Defaults to 5 minutes) Used when retrieving the AAD B2C Directory.'
-            resource_group_name: ' - (Required) The name of the Resource Group where the AAD B2C Directory should exist. Changing this forces a new AAD B2C Directory to be created.'
-            sku_name: ' - (Required) Billing SKU for the B2C tenant. Must be one of: PremiumP1 or PremiumP2 (Standard is not supported). See official docs for more information.'
-            tags: ' - (Optional) A mapping of tags which should be assigned to the AAD B2C Directory.'
-            tenant_id: ' - The Tenant ID for the AAD B2C tenant.'
-            update: ' - (Defaults to 30 minutes) Used when updating the AAD B2C Directory.'
+            billing_type: '- The type of billing for the AAD B2C tenant. Possible values include: MAU or Auths.'
+            country_code: '- (Optional) Country code of the B2C tenant. The country_code should be valid for the specified data_residency_location. See official docs for valid country codes. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.'
+            create: '- (Defaults to 30 minutes) Used when creating the AAD B2C Directory.'
+            data_residency_location: '- (Required) Location in which the B2C tenant is hosted and data resides. The data_residency_location should be valid for the specified country_code. See official docs for more information. Changing this forces a new AAD B2C Directory to be created.'
+            delete: '- (Defaults to 30 minutes) Used when deleting the AAD B2C Directory.'
+            display_name: '- (Optional) The initial display name of the B2C tenant. Required when creating a new resource. Changing this forces a new AAD B2C Directory to be created.'
+            domain_name: '- (Required) Domain name of the B2C tenant, including the .onmicrosoft.com suffix. Changing this forces a new AAD B2C Directory to be created.'
+            effective_start_date: '- The date from which the billing type took effect. May not be populated until after the first billing cycle.'
+            id: '- The ID of the AAD B2C Directory.'
+            read: '- (Defaults to 5 minutes) Used when retrieving the AAD B2C Directory.'
+            resource_group_name: '- (Required) The name of the Resource Group where the AAD B2C Directory should exist. Changing this forces a new AAD B2C Directory to be created.'
+            sku_name: '- (Required) Billing SKU for the B2C tenant. Must be one of: PremiumP1 or PremiumP2 (Standard is not supported). See official docs for more information.'
+            tags: '- (Optional) A mapping of tags which should be assigned to the AAD B2C Directory.'
+            tenant_id: '- The Tenant ID for the AAD B2C tenant.'
+            update: '- (Defaults to 30 minutes) Used when updating the AAD B2C Directory.'
         importStatements:
             - terraform import azurerm_aadb2c_directory.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.AzureActiveDirectory/b2cDirectories/directory-name
     azurerm_attestation_provider:
@@ -44,34 +42,34 @@ resources:
         examples:
             - name: example
               manifest: |-
-                  {
-                    "location": "${azurerm_resource_group.example.location}",
-                    "name": "example-attestationprovider",
-                    "policy_signing_certificate_data": "${file(\"./example/cert.pem\")}",
-                    "resource_group_name": "${azurerm_resource_group.example.name}"
-                  }
+                {
+                  "location": "${azurerm_resource_group.example.location}",
+                  "name": "example-attestationprovider",
+                  "policy_signing_certificate_data": "${file(\"./example/cert.pem\")}",
+                  "resource_group_name": "${azurerm_resource_group.example.name}"
+                }
               references:
-                  location: azurerm_resource_group.example.location
-                  resource_group_name: azurerm_resource_group.example.name
+                location: azurerm_resource_group.example.location
+                resource_group_name: azurerm_resource_group.example.name
               dependencies:
-                  azurerm_resource_group.example: |-
-                      {
-                        "location": "West Europe",
-                        "name": "example-resources"
-                      }
+                azurerm_resource_group.example: |-
+                    {
+                      "location": "West Europe",
+                      "name": "example-resources"
+                    }
         argumentDocs:
-            attestation_uri: ' - The URI of the Attestation Service.'
-            create: ' - (Defaults to 30 minutes) Used when creating the Attestation Provider.'
-            delete: ' - (Defaults to 30 minutes) Used when deleting the Attestation Provider.'
-            id: ' - The ID of the Attestation Provider.'
-            location: ' - (Required) The Azure Region where the Attestation Provider should exist. Changing this forces a new resource to be created.'
-            name: ' - (Required) The name which should be used for this Attestation Provider. Changing this forces a new resource to be created.'
-            policy_signing_certificate_data: ' - (Optional) A valid X.509 certificate (Section 4 of RFC4648). Changing this forces a new resource to be created.'
-            read: ' - (Defaults to 5 minutes) Used when retrieving the Attestation Provider.'
-            resource_group_name: ' - (Required) The name of the Resource Group where the attestation provider should exist. Changing this forces a new resource to be created.'
-            tags: ' - (Optional) A mapping of tags which should be assigned to the Attestation Provider.'
-            trust_model: ' - Trust model used for the Attestation Service.'
-            update: ' - (Defaults to 30 minutes) Used when updating the Attestation Provider.'
+            attestation_uri: '- The URI of the Attestation Service.'
+            create: '- (Defaults to 30 minutes) Used when creating the Attestation Provider.'
+            delete: '- (Defaults to 30 minutes) Used when deleting the Attestation Provider.'
+            id: '- The ID of the Attestation Provider.'
+            location: '- (Required) The Azure Region where the Attestation Provider should exist. Changing this forces a new resource to be created.'
+            name: '- (Required) The name which should be used for this Attestation Provider. Changing this forces a new resource to be created.'
+            policy_signing_certificate_data: '- (Optional) A valid X.509 certificate (Section 4 of RFC4648). Changing this forces a new resource to be created.'
+            read: '- (Defaults to 5 minutes) Used when retrieving the Attestation Provider.'
+            resource_group_name: '- (Required) The name of the Resource Group where the attestation provider should exist. Changing this forces a new resource to be created.'
+            tags: '- (Optional) A mapping of tags which should be assigned to the Attestation Provider.'
+            trust_model: '- Trust model used for the Attestation Service.'
+            update: '- (Defaults to 30 minutes) Used when updating the Attestation Provider.'
         importStatements:
             - terraform import azurerm_attestation_provider.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Attestation/attestationProviders/provider1
     azurerm_kubernetes_cluster:
@@ -82,224 +80,247 @@ resources:
         examples:
             - name: example
               manifest: |-
-                  {
-                    "default_node_pool": [
-                      {
-                        "name": "default",
-                        "node_count": 1,
-                        "vm_size": "Standard_D2_v2"
-                      }
-                    ],
-                    "dns_prefix": "exampleaks1",
-                    "identity": [
-                      {
-                        "type": "SystemAssigned"
-                      }
-                    ],
-                    "location": "${azurerm_resource_group.example.location}",
-                    "name": "example-aks1",
-                    "resource_group_name": "${azurerm_resource_group.example.name}",
-                    "tags": {
-                      "Environment": "Production"
+                {
+                  "default_node_pool": [
+                    {
+                      "name": "default",
+                      "node_count": 1,
+                      "vm_size": "Standard_D2_v2"
                     }
+                  ],
+                  "dns_prefix": "exampleaks1",
+                  "identity": [
+                    {
+                      "type": "SystemAssigned"
+                    }
+                  ],
+                  "location": "${azurerm_resource_group.example.location}",
+                  "name": "example-aks1",
+                  "resource_group_name": "${azurerm_resource_group.example.name}",
+                  "tags": {
+                    "Environment": "Production"
                   }
+                }
               references:
-                  location: azurerm_resource_group.example.location
-                  resource_group_name: azurerm_resource_group.example.name
+                location: azurerm_resource_group.example.location
+                resource_group_name: azurerm_resource_group.example.name
               dependencies:
-                  azurerm_resource_group.example: |-
-                      {
-                        "location": "West Europe",
-                        "name": "example-resources"
-                      }
+                azurerm_resource_group.example: |-
+                    {
+                      "location": "West Europe",
+                      "name": "example-resources"
+                    }
         argumentDocs:
-            aci_connector_linux: ' - (Optional) A aci_connector_linux block as defined below. For more details, please visit Create and configure an AKS cluster to use virtual nodes.'
-            admin_group_object_ids: ' - (Optional) A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster.'
-            admin_password: ' - (Required) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.'
-            allowed: ' - (Optional) One or more allowed block as defined below.'
-            allowed_unsafe_sysctls: ' - (Optional) Specifies the allow list of unsafe sysctls command or patterns (ending in *). Changing this forces a new resource to be created.'
-            api_server_authorized_ip_ranges: ' - (Optional) The IP ranges to allow for incoming traffic to the server nodes.'
-            auto_scaler_profile: ' - (Optional) A auto_scaler_profile block as defined below.'
-            automatic_channel_upgrade: ' - (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are patch, rapid, node-image and stable. Omitting this field sets this value to none.'
-            azure_active_directory_role_based_access_control: ' - (Optional) - A azure_active_directory_role_based_access_control block as defined below.'
-            azure_policy_enabled: ' - (Optional) Should the Azure Policy Add-On be enabled? For more details please visit Understand Azure Policy for Azure Kubernetes Service'
-            azure_rbac_enabled: ' - (Optional) Is Role Based Access Control based on Azure AD enabled?'
-            balance_similar_node_groups: ' - Detect similar node groups and balance the number of nodes between them. Defaults to false.'
-            client_app_id: ' - (Required) The Client ID of an Azure Active Directory Application.'
-            client_certificate: ' - Base64 encoded public certificate used by clients to authenticate to the Kubernetes cluster.'
-            client_key: ' - Base64 encoded private key used by clients to authenticate to the Kubernetes cluster.'
-            client_secret: ' - (Required) The Client Secret for the Service Principal.'
-            cluster_ca_certificate: ' - Base64 encoded public CA certificate used as the root of trust for the Kubernetes cluster.'
-            container_log_max_line: ' - (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.'
-            container_log_max_size_mb: ' - (Optional) Specifies the maximum size (e.g. 10MB) of container log file before it is rotated. Changing this forces a new resource to be created.'
-            cpu_cfs_quota_enabled: ' - (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.'
-            cpu_cfs_quota_period: ' - (Optional) Specifies the CPU CFS quota period value. Changing this forces a new resource to be created.'
-            cpu_manager_policy: ' - (Optional) Specifies the CPU Manager policy to use. Possible values are none and static, Changing this forces a new resource to be created.'
-            create: ' - (Defaults to 90 minutes) Used when creating the Kubernetes Cluster.'
-            day: ' - (Required) A day in a week. Possible values are Sunday, Monday, Tuesday, Wednesday, Thursday, Friday and Saturday.'
-            default_node_pool: ' - (Required) A default_node_pool block as defined below.'
-            delete: ' - (Defaults to 90 minutes) Used when deleting the Kubernetes Cluster.'
-            disk_encryption_set_id: ' - (Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. More information can be found in the documentation.'
-            dns_prefix: ' - (Optional) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created.'
-            dns_prefix_private_cluster: ' - (Optional) Specifies the DNS prefix to use with private clusters. Changing this forces a new resource to be created.'
-            dns_service_ip: ' - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created.'
-            docker_bridge_cidr: ' - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.'
-            effective_gateway_id: ' - The ID of the Application Gateway associated with the ingress controller deployed to this Kubernetes Cluster.'
-            empty_bulk_delete_max: ' - Maximum number of empty nodes that can be deleted at the same time. Defaults to 10.'
-            enable_auto_scaling: ' - (Optional) Should the Kubernetes Auto Scaler be enabled for this Node Pool? Defaults to false.'
-            enable_host_encryption: ' - (Optional) Should the nodes in the Default Node Pool have host encryption enabled? Defaults to false.'
-            enable_node_public_ip: ' - (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to false. Changing this forces a new resource to be created.'
-            end: ' - (Required) The end of a time span, formatted as an RFC3339 string.'
-            expander: ' - Expander to use. Possible values are least-waste, priority, most-pods and random. Defaults to random.'
-            fips_enabled: ' - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.'
-            fqdn: ' - The FQDN of the Azure Kubernetes Managed Cluster.'
-            fs_aio_max_nr: ' - (Optional) The sysctl setting fs.aio-max-nr. Must be between 65536 and 6553500. Changing this forces a new resource to be created.'
-            fs_file_max: ' - (Optional) The sysctl setting fs.file-max. Must be between 8192 and 12000500. Changing this forces a new resource to be created.'
-            fs_inotify_max_user_watches: ' - (Optional) The sysctl setting fs.inotify.max_user_watches. Must be between 781250 and 2097152. Changing this forces a new resource to be created.'
-            fs_nr_open: ' - (Optional) The sysctl setting fs.nr_open. Must be between 8192 and 20000500. Changing this forces a new resource to be created.'
-            gateway_id: ' - (Optional) The ID of the Application Gateway to integrate with the ingress controller of this Kubernetes Cluster. See this page for further details.'
-            gateway_name: ' - (Optional) The name of the Application Gateway to be used or created in the Nodepool Resource Group, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
-            host: ' - The Kubernetes cluster server host.'
-            hours: ' - (Required) An array of hour slots in a day. For example, specifying 1 will allow maintenance from 1:00am to 2:00am. Specifying 1, 2 will allow maintenance from 1:00am to 3:00m. Possible values are between 0 and 23.'
-            http_application_routing_enabled: ' - (Optional) Should HTTP Application Routing be enabled?'
-            http_application_routing_zone_name: ' - The Zone Name of the HTTP Application Routing.'
-            http_proxy: ' - (Optional) The proxy address to be used when communicating over HTTP.'
-            http_proxy_config: ' - (Optional) A http_proxy_config block as defined below.'
-            https_proxy: ' - (Optional) The proxy address to be used when communicating over HTTPS.'
-            id: ' - The Kubernetes Managed Cluster ID.'
-            identity: ' - (Optional) An identity block as defined below. One of either identity or service_principal must be specified.'
-            identity_ids: ' - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.'
-            image_gc_high_threshold: ' - (Optional) Specifies the percent of disk usage above which image garbage collection is always run. Must be between 0 and 100. Changing this forces a new resource to be created.'
-            image_gc_low_threshold: ' - (Optional) Specifies the percent of disk usage lower than which image garbage collection is never run. Must be between 0 and 100. Changing this forces a new resource to be created.'
-            ingress_application_gateway: ' - (Optional) A ingress_application_gateway block as defined below.'
-            ingress_application_gateway_identity: ' - An ingress_application_gateway_identity block is exported. The exported attributes are defined below.'
-            ip_versions: ' - (Optional) Specifies a list of IP versions the Kubernetes Cluster will use to assign IP addresses to its nodes and pods. Possible values are IPv4 and/or IPv6. IPv4 must always be specified. Changing this forces a new resource to be created.'
-            kernel_threads_max: ' - (Optional) The sysctl setting kernel.threads-max. Must be between 20 and 513785. Changing this forces a new resource to be created.'
-            key_data: ' - (Required) The Public SSH Key used to access the cluster. Changing this forces a new resource to be created.'
-            key_vault_secrets_provider: ' - (Optional) A key_vault_secrets_provider block as defined below. For more details, please visit Azure Keyvault Secrets Provider for AKS.'
-            kube_admin_config: ' - A kube_admin_config block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts enabled.'
-            kube_admin_config_raw: ' - Raw Kubernetes config for the admin account to be used by kubectl and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts enabled.'
-            kube_config: ' - A kube_config block as defined below.'
-            kube_config_raw: ' - Raw Kubernetes config to be used by kubectl and other compatible tools.'
-            kubelet_config: ' - (Optional) A kubelet_config block as defined below.'
-            kubelet_disk_type: ' - (Optional) The type of disk used by kubelet. Possible values are OS and Temporary.'
-            kubelet_identity: ' - A kubelet_identity block as defined below. Changing this forces a new resource to be created.'
-            kubernetes_version: ' - (Optional) Version of Kubernetes specified when creating the AKS managed cluster. If not specified, the latest recommended version will be used at provisioning time (but won''t auto-upgrade).'
-            license: ' - (Optional) Specifies the type of on-premise license which should be used for Node Pool Windows Virtual Machine. At this time the only possible value is Windows_Server.'
-            linux_os_config: ' - (Optional) A linux_os_config block as defined below.'
-            linux_profile: ' - (Optional) A linux_profile block as defined below.'
-            load_balancer_profile: ' - (Optional) A load_balancer_profile block. This can only be specified when load_balancer_sku is set to standard.'
-            load_balancer_sku: ' - (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are basic and standard. Defaults to standard.'
-            local_account_disabled: ' - (Optional) - If true local accounts will be disabled. Defaults to false. See the documentation for more information.'
-            location: ' - (Required) The location where the Managed Kubernetes Cluster should be created. Changing this forces a new resource to be created.'
-            maintenance_window: ' - (Optional) A maintenance_window block as defined below.'
-            managed: ' - (Optional) Is the Azure Active Directory integration Managed, meaning that Azure will create/manage the Service Principal used for integration.'
-            max_count: ' - (Required) The maximum number of nodes which should exist in this Node Pool. If specified this must be between 1 and 1000.'
-            max_graceful_termination_sec: ' - Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to 600.'
-            max_node_provisioning_time: ' - Maximum time the autoscaler waits for a node to be provisioned. Defaults to 15m.'
-            max_pods: ' - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.'
-            max_surge: ' - (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.'
-            max_unready_nodes: ' - Maximum Number of allowed unready nodes. Defaults to 3.'
-            max_unready_percentage: ' - Maximum percentage of unready nodes the cluster autoscaler will stop if the percentage is exceeded. Defaults to 45.'
-            microsoft_defender: ' - (Optional) A microsoft_defender block as defined below.'
-            min_count: ' - (Required) The minimum number of nodes which should exist in this Node Pool. If specified this must be between 1 and 1000.'
-            nat_gateway_profile: ' - (Optional) A nat_gateway_profile block. This can only be specified when load_balancer_sku is set to standard and outbound_type is set to managedNATGateway or userAssignedNATGateway.'
-            net_core_netdev_max_backlog: ' - (Optional) The sysctl setting net.core.netdev_max_backlog. Must be between 1000 and 3240000. Changing this forces a new resource to be created.'
-            net_core_optmem_max: ' - (Optional) The sysctl setting net.core.optmem_max. Must be between 20480 and 4194304. Changing this forces a new resource to be created.'
-            net_core_rmem_default: ' - (Optional) The sysctl setting net.core.rmem_default. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
-            net_core_rmem_max: ' - (Optional) The sysctl setting net.core.rmem_max. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
-            net_core_somaxconn: ' - (Optional) The sysctl setting net.core.somaxconn. Must be between 4096 and 3240000. Changing this forces a new resource to be created.'
-            net_core_wmem_default: ' - (Optional) The sysctl setting net.core.wmem_default. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
-            net_core_wmem_max: ' - (Optional) The sysctl setting net.core.wmem_max. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
-            net_ipv4_ip_local_port_range_max: ' - (Optional) The sysctl setting net.ipv4.ip_local_port_range max value. Must be between 1024 and 60999. Changing this forces a new resource to be created.'
-            net_ipv4_ip_local_port_range_min: ' - (Optional) The sysctl setting net.ipv4.ip_local_port_range min value. Must be between 1024 and 60999. Changing this forces a new resource to be created.'
-            net_ipv4_neigh_default_gc_thresh1: ' - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh1. Must be between 128 and 80000. Changing this forces a new resource to be created.'
-            net_ipv4_neigh_default_gc_thresh2: ' - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh2. Must be between 512 and 90000. Changing this forces a new resource to be created.'
-            net_ipv4_neigh_default_gc_thresh3: ' - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh3. Must be between 1024 and 100000. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_fin_timeout: ' - (Optional) The sysctl setting net.ipv4.tcp_fin_timeout. Must be between 5 and 120. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_keepalive_intvl: ' - (Optional) The sysctl setting net.ipv4.tcp_keepalive_intvl. Must be between 10 and 75. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_keepalive_probes: ' - (Optional) The sysctl setting net.ipv4.tcp_keepalive_probes. Must be between 1 and 15. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_keepalive_time: ' - (Optional) The sysctl setting net.ipv4.tcp_keepalive_time. Must be between 30 and 432000. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_max_syn_backlog: ' - (Optional) The sysctl setting net.ipv4.tcp_max_syn_backlog. Must be between 128 and 3240000. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_max_tw_buckets: ' - (Optional) The sysctl setting net.ipv4.tcp_max_tw_buckets. Must be between 8000 and 1440000. Changing this forces a new resource to be created.'
-            net_ipv4_tcp_tw_reuse: ' - (Optional) The sysctl setting net.ipv4.tcp_tw_reuse. Changing this forces a new resource to be created.'
-            net_netfilter_nf_conntrack_buckets: ' - (Optional) The sysctl setting net.netfilter.nf_conntrack_buckets. Must be between 65536 and 147456. Changing this forces a new resource to be created.'
-            net_netfilter_nf_conntrack_max: ' - (Optional) The sysctl setting net.netfilter.nf_conntrack_max. Must be between 131072 and 1048576. Changing this forces a new resource to be created.'
-            network_mode: ' - (Optional) Network mode to be used with Azure CNI. Possible values are bridge and transparent. Changing this forces a new resource to be created.'
-            network_plugin: ' - (Required) Network plugin to use for networking. Currently supported values are azure, kubenet and none. Changing this forces a new resource to be created.'
-            network_policy: ' - (Optional) Sets up network policy to be used with Azure CNI. Network policy allows us to control the traffic flow between pods. Currently supported values are calico and azure. Changing this forces a new resource to be created.'
-            network_profile: ' - (Optional) A network_profile block as defined below.'
-            new_pod_scale_up_delay: ' - For scenarios like burst/batch scale where you don''t want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they''re a certain age. Defaults to 10s.'
-            no_proxy: ' - (Optional) The list of domains that will not use the proxy for communication.'
-            node_labels: ' - (Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool.'
-            node_public_ip_prefix_id: ' - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. enable_node_public_ip should be true. Changing this forces a new resource to be created.'
-            not_allowed: ' - (Optional) One or more not_allowed block as defined below.'
-            oidc_issuer_enabled: ' - (Required) Enable or Disable the OIDC issuer URL'
-            oidc_issuer_url: ' - The OIDC issuer URL that is associated with the cluster.'
-            oms_agent: ' - (Optional) A oms_agent block as defined below.'
-            oms_agent_identity: ' - An oms_agent_identity block is exported. The exported attributes are defined below.'
-            only_critical_addons_enabled: ' - (Optional) Enabling this option will taint default node pool with CriticalAddonsOnly=true:NoSchedule taint. Changing this forces a new resource to be created.'
-            open_service_mesh_enabled: ' - (Optional) Is Open Service Mesh enabled? For more details, please visit Open Service Mesh for AKS.'
-            orchestrator_version: ' - (Optional) Version of Kubernetes used for the Agents. If not specified, the default node pool will be created with the version specified by kubernetes_version. If both are unspecified, the latest recommended version will be used at provisioning time (but won''t auto-upgrade)'
-            os_disk_size_gb: ' - (Optional) The size of the OS Disk which should be used for each agent in the Node Pool. Changing this forces a new resource to be created.'
-            os_disk_type: ' - (Optional) The type of disk which should be used for the Operating System. Possible values are Ephemeral and Managed. Defaults to Managed. Changing this forces a new resource to be created.'
-            os_sku: ' - (Optional) OsSKU to be used to specify Linux OSType. Not applicable to Windows OSType. Possible values include: Ubuntu, CBLMariner. Defaults to Ubuntu. Changing this forces a new resource to be created.'
-            outbound_ip_address_ids: ' - (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.'
-            outbound_ip_prefix_ids: ' - (Optional) The ID of the outbound Public IP Address Prefixes which should be used for the cluster load balancer.'
-            outbound_ports_allocated: ' - (Optional) Number of desired SNAT port for each VM in the clusters load balancer. Must be between 0 and 64000 inclusive. Defaults to 0.'
-            outbound_type: ' - (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are loadBalancer, userDefinedRouting, managedNATGateway and userAssignedNATGateway. Defaults to loadBalancer.'
-            password: ' - A password or token used to authenticate to the Kubernetes cluster.'
-            pod_cidr: ' - (Optional) The CIDR to use for pod IP addresses. This field can only be set when network_plugin is set to kubenet. Changing this forces a new resource to be created.'
-            pod_max_pid: ' - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.'
-            pod_subnet_id: ' - (Optional) The ID of the Subnet where the pods in the default Node Pool should exist. Changing this forces a new resource to be created.'
-            portal_fqdn: ' - The FQDN for the Azure Portal resources when private link has been enabled, which is only resolvable inside the Virtual Network used by the Kubernetes Cluster.'
-            principal_id: ' - The Principal ID associated with this Managed Service Identity.'
-            private_cluster_enabled: ' - (Optional) Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to false. Changing this forces a new resource to be created.'
-            private_cluster_public_fqdn_enabled: ' - (Optional) Specifies whether a Public FQDN for this Private Cluster should be added. Defaults to false.'
-            private_dns_zone_id: ' - (Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, System to have AKS manage this or None. In case of None you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created.'
-            private_fqdn: ' - The FQDN for the Kubernetes Cluster when private link has been enabled, which is only resolvable inside the Virtual Network used by the Kubernetes Cluster.'
-            read: ' - (Defaults to 5 minutes) Used when retrieving the Kubernetes Cluster.'
-            resource_group_name: ' - (Required) Specifies the Resource Group where the Managed Kubernetes Cluster should exist. Changing this forces a new resource to be created.'
-            role_based_access_control_enabled: ' (Optional) - Whether Role Based Access Control for the Kubernetes Cluster should be enabled. Defaults to true. Changing this forces a new resource to be created.'
-            run_command_enabled: ' - (Optional) Whether to enable run command for the cluster or not. Defaults to true.'
-            scale_down_delay_after_add: ' - How long after the scale up of AKS nodes the scale down evaluation resumes. Defaults to 10m.'
-            scale_down_delay_after_delete: ' - How long after node deletion that scale down evaluation resumes. Defaults to the value used for scan_interval.'
-            scale_down_delay_after_failure: ' - How long after scale down failure that scale down evaluation resumes. Defaults to 3m.'
-            scale_down_unneeded: ' - How long a node should be unneeded before it is eligible for scale down. Defaults to 10m.'
-            scale_down_unready: ' - How long an unready node should be unneeded before it is eligible for scale down. Defaults to 20m.'
-            scale_down_utilization_threshold: ' - Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to 0.5.'
-            scan_interval: ' - How often the AKS Cluster should be re-evaluated for scale up/down. Defaults to 10s.'
-            secret_identity: ' - An secret_identity block is exported. The exported attributes are defined below.'
-            secret_rotation_enabled: ' - (Required) Is secret rotation enabled?'
-            secret_rotation_interval: ' - (Required) The interval to poll for secret rotation. This attribute is only set when secret_rotation is true and defaults to 2m.'
-            server_app_id: ' - (Required) The Server ID of an Azure Active Directory Application.'
-            server_app_secret: ' - (Required) The Server Secret of an Azure Active Directory Application.'
-            service_cidr: ' - (Optional) The Network Range used by the Kubernetes service. Changing this forces a new resource to be created.'
-            service_principal: ' - (Optional) A service_principal block as documented below. One of either identity or service_principal must be specified.'
-            skip_nodes_with_local_storage: ' - If true cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to true.'
-            skip_nodes_with_system_pods: ' - If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). Defaults to true.'
-            sku_tier: ' - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free.'
-            ssh_key: ' - (Required) An ssh_key block. Only one is currently allowed. Changing this forces a new resource to be created.'
-            start: ' - (Required) The start of a time span, formatted as an RFC3339 string.'
-            subnet_cidr: ' - (Optional) The subnet CIDR to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
-            subnet_id: ' - (Optional) The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
-            subnet_name: ' - (Required) The subnet name for the virtual nodes to run.'
-            swap_file_size_mb: ' - (Optional) Specifies the size of swap file on each node in MB. Changing this forces a new resource to be created.'
-            sysctl_config: ' - (Optional) A sysctl_config block as defined below. Changing this forces a new resource to be created.'
-            topology_manager_policy: ' - (Optional) Specifies the Topology Manager policy to use. Possible values are none, best-effort, restricted or single-numa-node. Changing this forces a new resource to be created.'
-            transparent_huge_page_defrag: ' - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are always, defer, defer+madvise, madvise and never. Changing this forces a new resource to be created.'
-            transparent_huge_page_enabled: ' - (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are always, madvise and never. Changing this forces a new resource to be created.'
-            trusted_ca: ' - (Optional) The base64 encoded alternative CA certificate content in PEM format.'
-            ultra_ssd_enabled: ' - (Optional) Used to specify whether the UltraSSD is enabled in the Default Node Pool. Defaults to false. See the documentation for more information.'
-            update: ' - (Defaults to 90 minutes) Used when updating the Kubernetes Cluster.'
-            upgrade_settings: ' - (Optional) A upgrade_settings block as documented below.'
-            username: ' - A username used to authenticate to the Kubernetes cluster.'
-            vm_max_map_count: ' - (Optional) The sysctl setting vm.max_map_count. Must be between 65530 and 262144. Changing this forces a new resource to be created.'
-            vm_size: ' - (Required) The size of the Virtual Machine, such as Standard_DS2_v2. Changing this forces a new resource to be created.'
-            vm_swappiness: ' - (Optional) The sysctl setting vm.swappiness. Must be between 0 and 100. Changing this forces a new resource to be created.'
-            vm_vfs_cache_pressure: ' - (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between 0 and 100. Changing this forces a new resource to be created.'
-            vnet_subnet_id: ' - (Optional) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created.'
-            windows_profile: ' - (Optional) A windows_profile block as defined below.'
-            zones: ' - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. Changing this forces a new Kubernetes Cluster to be created.'
+            aci_connector_linux: '- (Optional) A aci_connector_linux block as defined below. For more details, please visit Create and configure an AKS cluster to use virtual nodes.'
+            aci_connector_linux.subnet_name: '- (Required) The subnet name for the virtual nodes to run.'
+            api_server_authorized_ip_ranges: '- (Optional) The IP ranges to allow for incoming traffic to the server nodes.'
+            auto_scaler_profile: '- (Optional) A auto_scaler_profile block as defined below.'
+            auto_scaler_profile.balance_similar_node_groups: '- Detect similar node groups and balance the number of nodes between them. Defaults to false.'
+            auto_scaler_profile.empty_bulk_delete_max: '- Maximum number of empty nodes that can be deleted at the same time. Defaults to 10.'
+            auto_scaler_profile.expander: '- Expander to use. Possible values are least-waste, priority, most-pods and random. Defaults to random.'
+            auto_scaler_profile.max_graceful_termination_sec: '- Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to 600.'
+            auto_scaler_profile.max_node_provisioning_time: '- Maximum time the autoscaler waits for a node to be provisioned. Defaults to 15m.'
+            auto_scaler_profile.max_unready_nodes: '- Maximum Number of allowed unready nodes. Defaults to 3.'
+            auto_scaler_profile.max_unready_percentage: '- Maximum percentage of unready nodes the cluster autoscaler will stop if the percentage is exceeded. Defaults to 45.'
+            auto_scaler_profile.new_pod_scale_up_delay: '- For scenarios like burst/batch scale where you don''t want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they''re a certain age. Defaults to 10s.'
+            auto_scaler_profile.scale_down_delay_after_add: '- How long after the scale up of AKS nodes the scale down evaluation resumes. Defaults to 10m.'
+            auto_scaler_profile.scale_down_delay_after_delete: '- How long after node deletion that scale down evaluation resumes. Defaults to the value used for scan_interval.'
+            auto_scaler_profile.scale_down_delay_after_failure: '- How long after scale down failure that scale down evaluation resumes. Defaults to 3m.'
+            auto_scaler_profile.scale_down_unneeded: '- How long a node should be unneeded before it is eligible for scale down. Defaults to 10m.'
+            auto_scaler_profile.scale_down_unready: '- How long an unready node should be unneeded before it is eligible for scale down. Defaults to 20m.'
+            auto_scaler_profile.scale_down_utilization_threshold: '- Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to 0.5.'
+            auto_scaler_profile.scan_interval: '- How often the AKS Cluster should be re-evaluated for scale up/down. Defaults to 10s.'
+            auto_scaler_profile.skip_nodes_with_local_storage: '- If true cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to true.'
+            auto_scaler_profile.skip_nodes_with_system_pods: '- If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). Defaults to true.'
+            automatic_channel_upgrade: '- (Optional) The upgrade channel for this Kubernetes Cluster. Possible values are patch, rapid, node-image and stable. Omitting this field sets this value to none.'
+            azure_active_directory_role_based_access_control: '- (Optional) - A azure_active_directory_role_based_access_control block as defined below.'
+            azure_active_directory_role_based_access_control.admin_group_object_ids: '- (Optional) A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster.'
+            azure_active_directory_role_based_access_control.azure_rbac_enabled: '- (Optional) Is Role Based Access Control based on Azure AD enabled?'
+            azure_active_directory_role_based_access_control.client_app_id: '- (Required) The Client ID of an Azure Active Directory Application.'
+            azure_active_directory_role_based_access_control.managed: '- (Optional) Is the Azure Active Directory integration Managed, meaning that Azure will create/manage the Service Principal used for integration.'
+            azure_active_directory_role_based_access_control.server_app_id: '- (Required) The Server ID of an Azure Active Directory Application.'
+            azure_active_directory_role_based_access_control.server_app_secret: '- (Required) The Server Secret of an Azure Active Directory Application.'
+            azure_active_directory_role_based_access_control.tenant_id: '- (Optional) The Tenant ID used for Azure Active Directory Application. If this isn''t specified the Tenant ID of the current Subscription is used.'
+            azure_policy_enabled: '- (Optional) Should the Azure Policy Add-On be enabled? For more details please visit Understand Azure Policy for Azure Kubernetes Service'
+            default_node_pool: '- (Required) A default_node_pool block as defined below.'
+            default_node_pool.enable_auto_scaling: '- (Optional) Should the Kubernetes Auto Scaler be enabled for this Node Pool? Defaults to false.'
+            default_node_pool.enable_host_encryption: '- (Optional) Should the nodes in the Default Node Pool have host encryption enabled? Defaults to false.'
+            default_node_pool.enable_node_public_ip: '- (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to false. Changing this forces a new resource to be created.'
+            default_node_pool.fips_enabled: '- (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.'
+            default_node_pool.kubelet_config: '- (Optional) A kubelet_config block as defined below.'
+            default_node_pool.kubelet_disk_type: '- (Optional) The type of disk used by kubelet. Possible values are OS and Temporary.'
+            default_node_pool.linux_os_config: '- (Optional) A linux_os_config block as defined below.'
+            default_node_pool.max_count: '- (Required) The maximum number of nodes which should exist in this Node Pool. If specified this must be between 1 and 1000.'
+            default_node_pool.max_pods: '- (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.'
+            default_node_pool.min_count: '- (Required) The minimum number of nodes which should exist in this Node Pool. If specified this must be between 1 and 1000.'
+            default_node_pool.name: '- (Required) The name which should be used for the default Kubernetes Node Pool. Changing this forces a new resource to be created.'
+            default_node_pool.node_labels: '- (Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool.'
+            default_node_pool.node_public_ip_prefix_id: '- (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. enable_node_public_ip should be true. Changing this forces a new resource to be created.'
+            default_node_pool.only_critical_addons_enabled: '- (Optional) Enabling this option will taint default node pool with CriticalAddonsOnly=true:NoSchedule taint. Changing this forces a new resource to be created.'
+            default_node_pool.orchestrator_version: '- (Optional) Version of Kubernetes used for the Agents. If not specified, the default node pool will be created with the version specified by kubernetes_version. If both are unspecified, the latest recommended version will be used at provisioning time (but won''t auto-upgrade)'
+            default_node_pool.os_disk_size_gb: '- (Optional) The size of the OS Disk which should be used for each agent in the Node Pool. Changing this forces a new resource to be created.'
+            default_node_pool.os_disk_type: '- (Optional) The type of disk which should be used for the Operating System. Possible values are Ephemeral and Managed. Defaults to Managed. Changing this forces a new resource to be created.'
+            default_node_pool.os_sku: '- (Optional) OsSKU to be used to specify Linux OSType. Not applicable to Windows OSType. Possible values include: Ubuntu, CBLMariner. Defaults to Ubuntu. Changing this forces a new resource to be created.'
+            default_node_pool.pod_subnet_id: '- (Optional) The ID of the Subnet where the pods in the default Node Pool should exist. Changing this forces a new resource to be created.'
+            default_node_pool.tags: '- (Optional) A mapping of tags to assign to the Node Pool.'
+            default_node_pool.type: '- (Optional) The type of Node Pool which should be created. Possible values are AvailabilitySet and VirtualMachineScaleSets. Defaults to VirtualMachineScaleSets.'
+            default_node_pool.ultra_ssd_enabled: '- (Optional) Used to specify whether the UltraSSD is enabled in the Default Node Pool. Defaults to false. See the documentation for more information.'
+            default_node_pool.upgrade_settings: '- (Optional) A upgrade_settings block as documented below.'
+            default_node_pool.vm_size: '- (Required) The size of the Virtual Machine, such as Standard_DS2_v2. Changing this forces a new resource to be created.'
+            default_node_pool.vnet_subnet_id: '- (Optional) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created.'
+            default_node_pool.zones: '- (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. Changing this forces a new Kubernetes Cluster to be created.'
+            disk_encryption_set_id: '- (Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. More information can be found in the documentation.'
+            dns_prefix: '- (Optional) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created.'
+            dns_prefix_private_cluster: '- (Optional) Specifies the DNS prefix to use with private clusters. Changing this forces a new resource to be created.'
+            http_application_routing_enabled: '- (Optional) Should HTTP Application Routing be enabled?'
+            http_proxy_config: '- (Optional) A http_proxy_config block as defined below.'
+            http_proxy_config.http_proxy: '- (Optional) The proxy address to be used when communicating over HTTP.'
+            http_proxy_config.https_proxy: '- (Optional) The proxy address to be used when communicating over HTTPS.'
+            http_proxy_config.no_proxy: '- (Optional) The list of domains that will not use the proxy for communication.'
+            http_proxy_config.trusted_ca: '- (Optional) The base64 encoded alternative CA certificate content in PEM format.'
+            identity: '- (Optional) An identity block as defined below. One of either identity or service_principal must be specified.'
+            identity.identity_ids: '- (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.'
+            identity.type: '- (Required) Specifies the type of Managed Service Identity that should be configured on this Kubernetes Cluster. Possible values are SystemAssigned, UserAssigned, SystemAssigned, UserAssigned (to enable both).'
+            ingress_application_gateway: '- (Optional) A ingress_application_gateway block as defined below.'
+            ingress_application_gateway.gateway_id: '- (Optional) The ID of the Application Gateway to integrate with the ingress controller of this Kubernetes Cluster. See this page for further details.'
+            ingress_application_gateway.gateway_name: '- (Optional) The name of the Application Gateway to be used or created in the Nodepool Resource Group, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
+            ingress_application_gateway.subnet_cidr: '- (Optional) The subnet CIDR to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
+            ingress_application_gateway.subnet_id: '- (Optional) The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See this page for further details.'
+            key_vault_secrets_provider: '- (Optional) A key_vault_secrets_provider block as defined below. For more details, please visit Azure Keyvault Secrets Provider for AKS.'
+            key_vault_secrets_provider.secret_rotation_enabled: '- (Required) Is secret rotation enabled?'
+            key_vault_secrets_provider.secret_rotation_interval: '- (Required) The interval to poll for secret rotation. This attribute is only set when secret_rotation is true and defaults to 2m.'
+            kubelet_config.allowed_unsafe_sysctls: '- (Optional) Specifies the allow list of unsafe sysctls command or patterns (ending in *). Changing this forces a new resource to be created.'
+            kubelet_config.container_log_max_line: '- (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.'
+            kubelet_config.container_log_max_size_mb: '- (Optional) Specifies the maximum size (e.g. 10MB) of container log file before it is rotated. Changing this forces a new resource to be created.'
+            kubelet_config.cpu_cfs_quota_enabled: '- (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.'
+            kubelet_config.cpu_cfs_quota_period: '- (Optional) Specifies the CPU CFS quota period value. Changing this forces a new resource to be created.'
+            kubelet_config.cpu_manager_policy: '- (Optional) Specifies the CPU Manager policy to use. Possible values are none and static, Changing this forces a new resource to be created.'
+            kubelet_config.image_gc_high_threshold: '- (Optional) Specifies the percent of disk usage above which image garbage collection is always run. Must be between 0 and 100. Changing this forces a new resource to be created.'
+            kubelet_config.image_gc_low_threshold: '- (Optional) Specifies the percent of disk usage lower than which image garbage collection is never run. Must be between 0 and 100. Changing this forces a new resource to be created.'
+            kubelet_config.pod_max_pid: '- (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.'
+            kubelet_config.topology_manager_policy: '- (Optional) Specifies the Topology Manager policy to use. Possible values are none, best-effort, restricted or single-numa-node. Changing this forces a new resource to be created.'
+            kubelet_identity: '- A kubelet_identity block as defined below. Changing this forces a new resource to be created.'
+            kubelet_identity.client_id: '- (Required) The Client ID of the user-defined Managed Identity to be assigned to the Kubelets. If not specified a Managed Identity is created automatically.'
+            kubelet_identity.object_id: '- (Required) The Object ID of the user-defined Managed Identity assigned to the Kubelets.If not specified a Managed Identity is created automatically.'
+            kubelet_identity.user_assigned_identity_id: '- (Required) The ID of the User Assigned Identity assigned to the Kubelets. If not specified a Managed Identity is created automatically.'
+            kubernetes_version: '- (Optional) Version of Kubernetes specified when creating the AKS managed cluster. If not specified, the latest recommended version will be used at provisioning time (but won''t auto-upgrade).'
+            linux_os_config.swap_file_size_mb: '- (Optional) Specifies the size of swap file on each node in MB. Changing this forces a new resource to be created.'
+            linux_os_config.sysctl_config: '- (Optional) A sysctl_config block as defined below. Changing this forces a new resource to be created.'
+            linux_os_config.transparent_huge_page_defrag: '- (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are always, defer, defer+madvise, madvise and never. Changing this forces a new resource to be created.'
+            linux_os_config.transparent_huge_page_enabled: '- (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are always, madvise and never. Changing this forces a new resource to be created.'
+            linux_profile: '- (Optional) A linux_profile block as defined below.'
+            linux_profile.admin_username: '- (Required) The Admin Username for the Cluster. Changing this forces a new resource to be created.'
+            linux_profile.ssh_key: '- (Required) An ssh_key block. Only one is currently allowed. Changing this forces a new resource to be created.'
+            load_balancer_profile.idle_timeout_in_minutes: '- (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between 4 and 120 inclusive. Defaults to 30.'
+            load_balancer_profile.managed_outbound_ip_count: '- (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be between 1 and 100 inclusive.'
+            load_balancer_profile.outbound_ip_address_ids: '- (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.'
+            load_balancer_profile.outbound_ip_prefix_ids: '- (Optional) The ID of the outbound Public IP Address Prefixes which should be used for the cluster load balancer.'
+            load_balancer_profile.outbound_ports_allocated: '- (Optional) Number of desired SNAT port for each VM in the clusters load balancer. Must be between 0 and 64000 inclusive. Defaults to 0.'
+            local_account_disabled: '- (Optional) - If true local accounts will be disabled. Defaults to false. See the documentation for more information.'
+            location: '- (Required) The location where the Managed Kubernetes Cluster should be created. Changing this forces a new resource to be created.'
+            maintenance_window: '- (Optional) A maintenance_window block as defined below.'
+            maintenance_window.allowed: '- (Optional) One or more allowed block as defined below.'
+            maintenance_window.day: '- (Required) A day in a week. Possible values are Sunday, Monday, Tuesday, Wednesday, Thursday, Friday and Saturday.'
+            maintenance_window.end: '- (Required) The end of a time span, formatted as an RFC3339 string.'
+            maintenance_window.hours: '- (Required) An array of hour slots in a day. For example, specifying 1 will allow maintenance from 1:00am to 2:00am. Specifying 1, 2 will allow maintenance from 1:00am to 3:00m. Possible values are between 0 and 23.'
+            maintenance_window.not_allowed: '- (Optional) One or more not_allowed block as defined below.'
+            maintenance_window.start: '- (Required) The start of a time span, formatted as an RFC3339 string.'
+            microsoft_defender: '- (Optional) A microsoft_defender block as defined below.'
+            microsoft_defender.log_analytics_workspace_id: '- (Required) Specifies the ID of the Log Analytics Workspace where the audit logs collected by Microsoft Defender should be sent to.'
+            name: '- (Required) The name of the Managed Kubernetes Cluster to create. Changing this forces a new resource to be created.'
+            nat_gateway_profile.idle_timeout_in_minutes: '- (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between 4 and 120 inclusive. Defaults to 4.'
+            nat_gateway_profile.managed_outbound_ip_count: '- (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be between 1 and 100 inclusive.'
+            network_profile: '- (Optional) A network_profile block as defined below.'
+            network_profile.dns_service_ip: '- (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created.'
+            network_profile.docker_bridge_cidr: '- (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.'
+            network_profile.ip_versions: '- (Optional) Specifies a list of IP versions the Kubernetes Cluster will use to assign IP addresses to its nodes and pods. Possible values are IPv4 and/or IPv6. IPv4 must always be specified. Changing this forces a new resource to be created.'
+            network_profile.load_balancer_profile: '- (Optional) A load_balancer_profile block. This can only be specified when load_balancer_sku is set to standard.'
+            network_profile.load_balancer_sku: '- (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are basic and standard. Defaults to standard.'
+            network_profile.nat_gateway_profile: '- (Optional) A nat_gateway_profile block. This can only be specified when load_balancer_sku is set to standard and outbound_type is set to managedNATGateway or userAssignedNATGateway.'
+            network_profile.network_mode: '- (Optional) Network mode to be used with Azure CNI. Possible values are bridge and transparent. Changing this forces a new resource to be created.'
+            network_profile.network_plugin: '- (Required) Network plugin to use for networking. Currently supported values are azure, kubenet and none. Changing this forces a new resource to be created.'
+            network_profile.network_policy: '- (Optional) Sets up network policy to be used with Azure CNI. Network policy allows us to control the traffic flow between pods. Currently supported values are calico and azure. Changing this forces a new resource to be created.'
+            network_profile.outbound_type: '- (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are loadBalancer, userDefinedRouting, managedNATGateway and userAssignedNATGateway. Defaults to loadBalancer.'
+            network_profile.pod_cidr: '- (Optional) The CIDR to use for pod IP addresses. This field can only be set when network_plugin is set to kubenet. Changing this forces a new resource to be created.'
+            network_profile.service_cidr: '- (Optional) The Network Range used by the Kubernetes service. Changing this forces a new resource to be created.'
+            node_resource_group: '- (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.'
+            oidc_issuer_enabled: '- (Required) Enable or Disable the OIDC issuer URL'
+            oms_agent: '- (Optional) A oms_agent block as defined below.'
+            oms_agent.log_analytics_workspace_id: '- (Required) The ID of the Log Analytics Workspace which the OMS Agent should send data to.'
+            open_service_mesh_enabled: '- (Optional) Is Open Service Mesh enabled? For more details, please visit Open Service Mesh for AKS.'
+            private_cluster_enabled: '- (Optional) Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to false. Changing this forces a new resource to be created.'
+            private_cluster_public_fqdn_enabled: '- (Optional) Specifies whether a Public FQDN for this Private Cluster should be added. Defaults to false.'
+            private_dns_zone_id: '- (Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, System to have AKS manage this or None. In case of None you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created.'
+            resource_group_name: '- (Required) Specifies the Resource Group where the Managed Kubernetes Cluster should exist. Changing this forces a new resource to be created.'
+            role_based_access_control_enabled: (Optional) - Whether Role Based Access Control for the Kubernetes Cluster should be enabled. Defaults to true. Changing this forces a new resource to be created.
+            run_command_enabled: '- (Optional) Whether to enable run command for the cluster or not. Defaults to true.'
+            service_principal: '- (Optional) A service_principal block as documented below. One of either identity or service_principal must be specified.'
+            service_principal.client_id: '- (Required) The Client ID for the Service Principal.'
+            service_principal.client_secret: '- (Required) The Client Secret for the Service Principal.'
+            sku_tier: '- (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free.'
+            ssh_key.key_data: '- (Required) The Public SSH Key used to access the cluster. Changing this forces a new resource to be created.'
+            sysctl_config.fs_aio_max_nr: '- (Optional) The sysctl setting fs.aio-max-nr. Must be between 65536 and 6553500. Changing this forces a new resource to be created.'
+            sysctl_config.fs_file_max: '- (Optional) The sysctl setting fs.file-max. Must be between 8192 and 12000500. Changing this forces a new resource to be created.'
+            sysctl_config.fs_inotify_max_user_watches: '- (Optional) The sysctl setting fs.inotify.max_user_watches. Must be between 781250 and 2097152. Changing this forces a new resource to be created.'
+            sysctl_config.fs_nr_open: '- (Optional) The sysctl setting fs.nr_open. Must be between 8192 and 20000500. Changing this forces a new resource to be created.'
+            sysctl_config.kernel_threads_max: '- (Optional) The sysctl setting kernel.threads-max. Must be between 20 and 513785. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_netdev_max_backlog: '- (Optional) The sysctl setting net.core.netdev_max_backlog. Must be between 1000 and 3240000. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_optmem_max: '- (Optional) The sysctl setting net.core.optmem_max. Must be between 20480 and 4194304. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_rmem_default: '- (Optional) The sysctl setting net.core.rmem_default. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_rmem_max: '- (Optional) The sysctl setting net.core.rmem_max. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_somaxconn: '- (Optional) The sysctl setting net.core.somaxconn. Must be between 4096 and 3240000. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_wmem_default: '- (Optional) The sysctl setting net.core.wmem_default. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
+            sysctl_config.net_core_wmem_max: '- (Optional) The sysctl setting net.core.wmem_max. Must be between 212992 and 134217728. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_ip_local_port_range_max: '- (Optional) The sysctl setting net.ipv4.ip_local_port_range max value. Must be between 1024 and 60999. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_ip_local_port_range_min: '- (Optional) The sysctl setting net.ipv4.ip_local_port_range min value. Must be between 1024 and 60999. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_neigh_default_gc_thresh1: '- (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh1. Must be between 128 and 80000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_neigh_default_gc_thresh2: '- (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh2. Must be between 512 and 90000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_neigh_default_gc_thresh3: '- (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh3. Must be between 1024 and 100000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_fin_timeout: '- (Optional) The sysctl setting net.ipv4.tcp_fin_timeout. Must be between 5 and 120. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_keepalive_intvl: '- (Optional) The sysctl setting net.ipv4.tcp_keepalive_intvl. Must be between 10 and 75. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_keepalive_probes: '- (Optional) The sysctl setting net.ipv4.tcp_keepalive_probes. Must be between 1 and 15. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_keepalive_time: '- (Optional) The sysctl setting net.ipv4.tcp_keepalive_time. Must be between 30 and 432000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_max_syn_backlog: '- (Optional) The sysctl setting net.ipv4.tcp_max_syn_backlog. Must be between 128 and 3240000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_max_tw_buckets: '- (Optional) The sysctl setting net.ipv4.tcp_max_tw_buckets. Must be between 8000 and 1440000. Changing this forces a new resource to be created.'
+            sysctl_config.net_ipv4_tcp_tw_reuse: '- (Optional) The sysctl setting net.ipv4.tcp_tw_reuse. Changing this forces a new resource to be created.'
+            sysctl_config.net_netfilter_nf_conntrack_buckets: '- (Optional) The sysctl setting net.netfilter.nf_conntrack_buckets. Must be between 65536 and 147456. Changing this forces a new resource to be created.'
+            sysctl_config.net_netfilter_nf_conntrack_max: '- (Optional) The sysctl setting net.netfilter.nf_conntrack_max. Must be between 131072 and 1048576. Changing this forces a new resource to be created.'
+            sysctl_config.vm_max_map_count: '- (Optional) The sysctl setting vm.max_map_count. Must be between 65530 and 262144. Changing this forces a new resource to be created.'
+            sysctl_config.vm_swappiness: '- (Optional) The sysctl setting vm.swappiness. Must be between 0 and 100. Changing this forces a new resource to be created.'
+            sysctl_config.vm_vfs_cache_pressure: '- (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between 0 and 100. Changing this forces a new resource to be created.'
+            tags: '- (Optional) A mapping of tags to assign to the resource.'
+            upgrade_settings.client_certificate: '- Base64 encoded public certificate used by clients to authenticate to the Kubernetes cluster.'
+            upgrade_settings.client_key: '- Base64 encoded private key used by clients to authenticate to the Kubernetes cluster.'
+            upgrade_settings.cluster_ca_certificate: '- Base64 encoded public CA certificate used as the root of trust for the Kubernetes cluster.'
+            upgrade_settings.create: '- (Defaults to 90 minutes) Used when creating the Kubernetes Cluster.'
+            upgrade_settings.delete: '- (Defaults to 90 minutes) Used when deleting the Kubernetes Cluster.'
+            upgrade_settings.effective_gateway_id: '- The ID of the Application Gateway associated with the ingress controller deployed to this Kubernetes Cluster.'
+            upgrade_settings.effective_outbound_ips: '- The outcome (resource IDs) of the specified arguments.'
+            upgrade_settings.fqdn: '- The FQDN of the Azure Kubernetes Managed Cluster.'
+            upgrade_settings.host: '- The Kubernetes cluster server host.'
+            upgrade_settings.http_application_routing_zone_name: '- The Zone Name of the HTTP Application Routing.'
+            upgrade_settings.id: '- The Kubernetes Managed Cluster ID.'
+            upgrade_settings.ingress_application_gateway_identity: '- An ingress_application_gateway_identity block is exported. The exported attributes are defined below.'
+            upgrade_settings.kube_admin_config: '- A kube_admin_config block as defined below. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts enabled.'
+            upgrade_settings.kube_admin_config_raw: '- Raw Kubernetes config for the admin account to be used by kubectl and other compatible tools. This is only available when Role Based Access Control with Azure Active Directory is enabled and local accounts enabled.'
+            upgrade_settings.kube_config: '- A kube_config block as defined below.'
+            upgrade_settings.kube_config_raw: '- Raw Kubernetes config to be used by kubectl and other compatible tools.'
+            upgrade_settings.max_surge: '- (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.'
+            upgrade_settings.node_resource_group: '- The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster.'
+            upgrade_settings.oidc_issuer_url: '- The OIDC issuer URL that is associated with the cluster.'
+            upgrade_settings.oms_agent_identity: '- An oms_agent_identity block is exported. The exported attributes are defined below.'
+            upgrade_settings.password: '- A password or token used to authenticate to the Kubernetes cluster.'
+            upgrade_settings.portal_fqdn: '- The FQDN for the Azure Portal resources when private link has been enabled, which is only resolvable inside the Virtual Network used by the Kubernetes Cluster.'
+            upgrade_settings.principal_id: '- The Principal ID associated with this Managed Service Identity.'
+            upgrade_settings.private_fqdn: '- The FQDN for the Kubernetes Cluster when private link has been enabled, which is only resolvable inside the Virtual Network used by the Kubernetes Cluster.'
+            upgrade_settings.read: '- (Defaults to 5 minutes) Used when retrieving the Kubernetes Cluster.'
+            upgrade_settings.secret_identity: '- An secret_identity block is exported. The exported attributes are defined below.'
+            upgrade_settings.tenant_id: '- The Tenant ID associated with this Managed Service Identity.'
+            upgrade_settings.update: '- (Defaults to 90 minutes) Used when updating the Kubernetes Cluster.'
+            upgrade_settings.username: '- A username used to authenticate to the Kubernetes cluster.'
+            windows_profile: '- (Optional) A windows_profile block as defined below.'
+            windows_profile.admin_password: '- (Required) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.'
+            windows_profile.admin_username: '- (Required) The Admin Username for Windows VMs.'
+            windows_profile.license: '- (Optional) Specifies the type of on-premise license which should be used for Node Pool Windows Virtual Machine. At this time the only possible value is Windows_Server.'
         importStatements:
             - terraform import azurerm_kubernetes_cluster.cluster1 /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1

--- a/pkg/registry/testdata/gcp/pm.yaml
+++ b/pkg/registry/testdata/gcp/pm.yaml
@@ -1,912 +1,980 @@
 name: test-provider
 resources:
-  google_access_context_manager_access_level:
-    subCategory: Access Context Manager (VPC Service Controls)
-    description: An AccessLevel is a label that can be applied to requests to GCP services, along with a list of requirements necessary for the label to be applied.
-    name: google_access_context_manager_access_level
-    title: google_access_context_manager_access_level
-    examples:
-      - name: access-level
-        manifest: |-
-          {
-            "basic": [
-              {
-                "conditions": [
-                  {
-                    "device_policy": [
-                      {
-                        "os_constraints": [
-                          {
-                            "os_type": "DESKTOP_CHROME_OS"
-                          }
-                        ],
-                        "require_screen_lock": true
-                      }
-                    ],
-                    "regions": [
-                      "CH",
-                      "IT",
-                      "US"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "name": "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/chromeos_no_lock",
-            "parent": "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}",
-            "title": "chromeos_no_lock"
-          }
-        references: {}
-        dependencies:
-          google_access_context_manager_access_policy.access-policy: |-
-            {
-              "parent": "organizations/123456789",
-              "title": "my policy"
-            }
-    argumentDocs:
-      allowed_device_management_levels: |4-
-           -
-          (Optional)
-          A list of allowed device management levels.
-          An empty list allows all management levels.
-          Each value may be one of MANAGEMENT_UNSPECIFIED, NONE, BASIC, and COMPLETE.
-      allowed_encryption_statuses: |4-
-           -
-          (Optional)
-          A list of allowed encryptions statuses.
-          An empty list allows all statuses.
-          Each value may be one of ENCRYPTION_UNSPECIFIED, ENCRYPTION_UNSUPPORTED, UNENCRYPTED, and ENCRYPTED.
-      basic: |4-
-           -
-          (Optional)
-          A set of predefined conditions for the access level and a combining function.
-          Structure is documented below.
-      combining_function: |4-
-           -
-          (Optional)
-          How the conditions list should be combined to determine if a request
-          is granted this AccessLevel. If AND is used, each Condition in
-          conditions must be satisfied for the AccessLevel to be applied. If
-          OR is used, at least one Condition in conditions must be satisfied
-          for the AccessLevel to be applied.
-          Default value is AND.
-          Possible values are AND and OR.
-      conditions: |4-
-           -
-          (Required)
-          A set of requirements for the AccessLevel to be granted.
-          Structure is documented below.
-      create: ' - Default is 20 minutes.'
-      custom: |4-
-           -
-          (Optional)
-          Custom access level conditions are set using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request.
-          See CEL spec at: https://github.com/google/cel-spec.
-          Structure is documented below.
-      delete: ' - Default is 20 minutes.'
-      device_policy: |4-
-           -
-          (Optional)
-          Device specific restrictions, all restrictions must hold for
-          the Condition to be true. If not specified, all devices are
-          allowed.
-          Structure is documented below.
-      expr: |4-
-           -
-          (Required)
-          Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language.
-          This page details the objects and attributes that are used to the build the CEL expressions for
-          custom access levels - https://cloud.google.com/access-context-manager/docs/custom-access-level-spec.
-          Structure is documented below.
-      expression: |4-
-           -
-          (Required)
-          Textual representation of an expression in Common Expression Language syntax.
-      id: ' - an identifier for the resource with format {{name}}'
-      ip_subnetworks: |4-
-           -
-          (Optional)
-          A list of CIDR block IP subnetwork specification. May be IPv4
-          or IPv6.
-          Note that for a CIDR IP address block, the specified IP address
-          portion must be properly truncated (i.e. all the host bits must
-          be zero) or the input is considered malformed. For example,
-          "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly,
-          for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32"
-          is not. The originating IP of a request must be in one of the
-          listed subnets in order for this Condition to be true.
-          If empty, all IP addresses are allowed.
-      location: |4-
-           -
-          (Optional)
-          String indicating the location of the expression for error reporting, e.g. a file name and a position in the file
-      members: |4-
-           -
-          (Optional)
-          An allowed list of members (users, service accounts).
-          Using groups is not supported yet.
-          The signed-in user originating the request must be a part of one
-          of the provided members. If not specified, a request may come
-          from any user (logged in/not logged in, not present in any
-          groups, etc.).
-          Formats: user:{emailid}, serviceAccount:{emailid}
-      minimum_version: |4-
-           -
-          (Optional)
-          The minimum allowed OS version. If not set, any version
-          of this OS satisfies the constraint.
-          Format: "major.minor.patch" such as "10.5.301", "9.2.1".
-      name: |4-
-           -
-          (Required)
-          Resource name for the Access Level. The short_name component must begin
-          with a letter and only include alphanumeric and '_'.
-          Format: accessPolicies/{policy_id}/accessLevels/{short_name}
-      negate: |4-
-           -
-          (Optional)
-          Whether to negate the Condition. If true, the Condition becomes
-          a NAND over its non-empty fields, each field must be false for
-          the Condition overall to be satisfied. Defaults to false.
-      os_constraints: |4-
-           -
-          (Optional)
-          A list of allowed OS versions.
-          An empty list allows all types and all versions.
-          Structure is documented below.
-      os_type: |4-
-           -
-          (Required)
-          The operating system type of the device.
-          Possible values are OS_UNSPECIFIED, DESKTOP_MAC, DESKTOP_WINDOWS, DESKTOP_LINUX, DESKTOP_CHROME_OS, ANDROID, and IOS.
-      parent: |4-
-           -
-          (Required)
-          The AccessPolicy this AccessLevel lives in.
-          Format: accessPolicies/{policy_id}
-      regions: |4-
-           -
-          (Optional)
-          The request must originate from one of the provided
-          countries/regions.
-          Format: A valid ISO 3166-1 alpha-2 code.
-      require_admin_approval: |4-
-           -
-          (Optional)
-          Whether the device needs to be approved by the customer admin.
-      require_corp_owned: |4-
-           -
-          (Optional)
-          Whether the device needs to be corp owned.
-      require_screen_lock: |4-
-           -
-          (Optional)
-          Whether or not screenlock is required for the DevicePolicy
-          to be true. Defaults to false.
-      require_verified_chrome_os: |4-
-           -
-          (Optional)
-          If you specify DESKTOP_CHROME_OS for osType, you can optionally include requireVerifiedChromeOs to require Chrome Verified Access.
-      required_access_levels: |4-
-           -
-          (Optional)
-          A list of other access levels defined in the same Policy,
-          referenced by resource name. Referencing an AccessLevel which
-          does not exist is an error. All access levels listed must be
-          granted for the Condition to be true.
-          Format: accessPolicies/{policy_id}/accessLevels/{short_name}
-      update: ' - Default is 20 minutes.'
-  google_container_cluster:
-    subCategory: Kubernetes (Container) Engine
-    description: Creates a Google Kubernetes Engine (GKE) cluster.
-    name: google_container_cluster
-    title: google_container_cluster
-    examples:
-      - name: primary
-        manifest: |-
-          {
-            "initial_node_count": 1,
-            "location": "us-central1",
-            "name": "my-gke-cluster",
-            "remove_default_node_pool": true
-          }
-        references: {}
-        dependencies:
-          google_container_node_pool.primary_preemptible_nodes: |-
-            {
-              "cluster": "${google_container_cluster.primary.name}",
-              "location": "us-central1",
-              "name": "my-node-pool",
-              "node_config": [
+    google_access_context_manager_access_level:
+        subCategory: Access Context Manager (VPC Service Controls)
+        description: An AccessLevel is a label that can be applied to requests to GCP services, along with a list of requirements necessary for the label to be applied.
+        name: google_access_context_manager_access_level
+        title: google_access_context_manager_access_level
+        examples:
+            - name: access-level
+              manifest: |-
                 {
-                  "machine_type": "e2-medium",
-                  "oauth_scopes": [
-                    "https://www.googleapis.com/auth/cloud-platform"
+                  "basic": [
+                    {
+                      "conditions": [
+                        {
+                          "device_policy": [
+                            {
+                              "os_constraints": [
+                                {
+                                  "os_type": "DESKTOP_CHROME_OS"
+                                }
+                              ],
+                              "require_screen_lock": true
+                            }
+                          ],
+                          "regions": [
+                            "CH",
+                            "IT",
+                            "US"
+                          ]
+                        }
+                      ]
+                    }
                   ],
-                  "preemptible": true,
-                  "service_account": "${google_service_account.default.email}"
+                  "name": "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/chromeos_no_lock",
+                  "parent": "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}",
+                  "title": "chromeos_no_lock"
                 }
-              ],
-              "node_count": 1
-            }
-          google_service_account.default: |-
-            {
-              "account_id": "service-account-id",
-              "display_name": "Service Account"
-            }
-      - name: primary
-        manifest: |-
-          {
-            "initial_node_count": 3,
-            "location": "us-central1-a",
-            "name": "marcellus-wallace",
-            "node_config": [
-              {
-                "labels": {
-                  "foo": "bar"
-                },
-                "oauth_scopes": [
-                  "https://www.googleapis.com/auth/cloud-platform"
-                ],
-                "service_account": "${google_service_account.default.email}",
-                "tags": [
-                  "foo",
-                  "bar"
-                ]
-              }
-            ],
-            "timeouts": [
-              {
-                "create": "30m",
-                "update": "40m"
-              }
-            ]
-          }
-        references:
-          node_config.service_account: google_service_account.default.email
-        dependencies:
-          google_service_account.default: |-
-            {
-              "account_id": "service-account-id",
-              "display_name": "Service Account"
-            }
-    argumentDocs:
-      '"gvisor"': ': Pods run within a gVisor sandbox.'
-      addons_config: |4-
-           - (Optional) The configuration for addons supported by GKE.
-          Structure is documented below.
-      auth: ' - (Optional) The authentication type between services in Istio. Available options include AUTH_MUTUAL_TLS.'
-      authenticator_groups_config: |4-
-           - (Optional) Configuration for the
-          Google Groups for GKE feature.
-          Structure is documented below.
-      auto_provisioning_defaults: |4-
-           - (Optional) Contains defaults for a node pool created by NAP.
-          Structure is documented below.
-      autoscaling_profile: |4-
-           - (Optional, Beta) Configuration
-          options for the Autoscaling profile
-          feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability
-          when deciding to remove nodes from a cluster. Can be BALANCED or OPTIMIZE_UTILIZATION. Defaults to BALANCED.
-      bigquery_destination: ' (Required) - Parameters for using BigQuery as the destination of resource usage export.'
-      bigquery_destination.dataset_id: ' (Required) - The ID of a BigQuery Dataset. For Example:'
-      boot_disk_kms_key: ' - (Optional) The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool. This should be of the form projects/[KEY_PROJECT_ID]/locations/[LOCATION]/keyRings/[RING_NAME]/cryptoKeys/[KEY_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption'
-      channel: |4+
-           - (Required) The selected release channel.
-          Accepted values are:
-      
-
-      cidr_block: |4-
-           - (Optional) External network that can access Kubernetes master through HTTPS.
-          Must be specified in CIDR notation.
-      cidr_blocks: |4-
-           - (Optional) External networks that can access the
-          Kubernetes cluster master through HTTPS.
-      client_certificate_config: ' - (Required) Whether client certificate authorization is enabled for this cluster.  For example:'
-      cloudrun_config: ' - (Optional). Structure is documented below.'
-      cluster_autoscaling: |4-
-           - (Optional)
-          Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
-          automatically adjust the size of the cluster and create/delete node pools based
-          on the current needs of the cluster's workload. See the
-          guide to using Node Auto-Provisioning
-          for more details. Structure is documented below.
-      cluster_dns: ' - (Optional) Which in-cluster DNS provider should be used. PROVIDER_UNSPECIFIED (default) or PLATFORM_DEFAULT or CLOUD_DNS.'
-      cluster_dns_domain: ' - (Optional) The suffix used for all cluster service records.'
-      cluster_dns_scope: ' - (Optional) The scope of access to cluster DNS records. DNS_SCOPE_UNSPECIFIED (default) or CLUSTER_SCOPE or VPC_SCOPE.'
-      cluster_ipv4_cidr: |4-
-           - (Optional) The IP address range of the Kubernetes pods
-          in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one
-          automatically chosen or specify a /14 block in 10.0.0.0/8. This field will
-          only work for routes-based clusters, where ip_allocation_policy is not defined.
-      cluster_ipv4_cidr_block: |4-
-           - (Optional) The IP address range for the cluster pod IPs.
-          Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
-          to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
-          from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
-          pick a specific range to use.
-      cluster_secondary_range_name: |4-
-           - (Optional) The name of the existing secondary
-          range in the cluster's subnetwork to use for pod IP addresses. Alternatively,
-          cluster_ipv4_cidr_block can be used to automatically create a GKE-managed one.
-      cluster_telemetry: |4-
-           - (Optional, Beta) Configuration for
-          ClusterTelemetry feature,
-          Structure is documented below.
-      confidential_nodes: ' - Configuration for Confidential Nodes feature. Structure is documented below documented below.'
-      config_connector_config: |4-
-           -  (Optional, Beta).
-          The status of the ConfigConnector addon. It is disabled by default; Set enabled = true to enable.
-      count: ' (Required) - The number of the guest accelerator cards exposed to this instance.'
-      cpu_cfs_quota: |4-
-           - (Optional) If true, enables CPU CFS quota enforcement for
-          containers that specify CPU limits.
-      cpu_cfs_quota_period: |4-
-           - (Optional) The CPU CFS quota period value. Specified
-          as a sequence of decimal numbers, each with optional fraction and a unit suffix,
-          such as "300ms". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
-          "h". The value must be a positive duration.
-      cpu_manager_policy: |4-
-           - (Required) The CPU management policy on the node. See
-          K8S CPU Management Policies.
-          One of "none" or "static". Defaults to none when kubelet_config is unset.
-      create: ' - Default is 40 minutes.'
-      create_pod_range: ' - (Optional, Beta) Whether to create a new range for pod IPs in this node pool. Defaults are provided for pod_range and pod_ipv4_cidr_block if they are not specified.'
-      database_encryption: |4-
-           - (Optional)
-          Structure is documented below.
-      datapath_provider: |4-
-           - (Optional)
-          The desired datapath provider for this cluster. By default, uses the IPTables-based kube-proxy implementation.
-      default_max_pods_per_node: |4-
-           - (Optional) The default maximum number of pods
-          per node in this cluster. This doesn't work on "routes-based" clusters, clusters
-          that don't have IP Aliasing enabled. See the official documentation
-          for more information.
-      default_snat_status: |4-
-           - (Optional)
-          GKE SNAT DefaultSnatStatus contains the desired state of whether default sNAT should be disabled on the cluster, API doc. Structure is documented below
-      delete: ' - Default is 40 minutes.'
-      description: ' - (Optional) Description of the cluster.'
-      disk_size_gb: |4-
-           - (Optional) Size of the disk attached to each node, specified
-          in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
-      disk_type: |4-
-           - (Optional) Type of the disk attached to each node
-          (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'
-      display_name: ' - (Optional) Field for users to identify CIDR blocks.'
-      dns_cache_config: |4-
-           - (Optional, Beta).
-          The status of the NodeLocal DNSCache addon. It is disabled by default.
-          Set enabled = true to enable.
-      dns_config: |4-
-           - (Optional)
-          Configuration for Using Cloud DNS for GKE. Structure is documented below.
-      effect: ' (Required) Effect for taint. Accepted values are NO_SCHEDULE, PREFER_NO_SCHEDULE, and NO_EXECUTE.'
-      enable_autopilot: |4-
-           - (Optional) Enable Autopilot for this cluster. Defaults to false.
-          Note that when this option is enabled, certain features of Standard GKE are not available.
-          See the official documentation
-          for available features.
-      enable_binary_authorization: |4-
-           - (Optional) Enable Binary Authorization for this cluster.
-          If enabled, all container images will be validated by Google Binary Authorization.
-      enable_integrity_monitoring: ' (Optional) - Defines if the instance has integrity monitoring enabled.'
-      enable_intranode_visibility: |4-
-           - (Optional)
-          Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.
-      enable_kubernetes_alpha: |4-
-           - (Optional) Whether to enable Kubernetes Alpha features for
-          this cluster. Note that when this option is enabled, the cluster cannot be upgraded
-          and will be automatically deleted after 30 days.
-      enable_l4_ilb_subsetting: |4-
-           - (Optional, Beta)
-          Whether L4ILB Subsetting is enabled for this cluster.
-      enable_legacy_abac: |4-
-           - (Optional) Whether the ABAC authorizer is enabled for this cluster.
-          When enabled, identities in the system, including service accounts, nodes, and controllers,
-          will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
-          Defaults to false
-      enable_network_egress_metering: |4-
-           (Optional) - Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created
-          in the cluster to meter network egress traffic.
-      enable_private_endpoint: |4-
-           (Optional) - When true, the cluster's private
-          endpoint is used as the cluster endpoint and access through the public endpoint
-          is disabled. When false, either endpoint can be used. This field only applies
-          to private clusters, when enable_private_nodes is true.
-      enable_private_nodes: |4-
-           (Optional) - Enables the private cluster feature,
-          creating a private endpoint on the cluster. In a private cluster, nodes only
-          have RFC 1918 private addresses and communicate with the master's private
-          endpoint via private networking.
-      enable_resource_consumption_metering: |4-
-           (Optional) - Whether to enable resource
-          consumption metering on this cluster. When enabled, a table will be created in
-          the resource export BigQuery dataset to store resource consumption data. The
-          resulting table can be joined with the resource usage table or with BigQuery
-          billing export. Defaults to true.
-      enable_secure_boot: ' (Optional) - Defines if the instance has Secure Boot enabled.'
-      enable_shielded_nodes: ' - (Optional) Enable Shielded Nodes features on all nodes in this cluster.  Defaults to true.'
-      enable_tpu: |4-
-           - (Optional) Whether to enable Cloud TPU resources in this cluster.
-          See the official documentation.
-      endpoint: ' - The IP address of this cluster''s Kubernetes master.'
-      ephemeral_storage_config: ' - (Optional, [Beta]) Parameters for the ephemeral storage filesystem. If unspecified, ephemeral storage is backed by the boot disk. Structure is documented below.'
-      exclusion_options: ' - (Optional) MaintenanceExclusionOptions provides maintenance exclusion related options.'
-      gce_persistent_disk_csi_driver_config: |4-
-           - (Optional, Beta).
-          Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set enabled = true to enable.
-      gcfs_config: |4-
-           - (Optional) Parameters for the Google Container Filesystem (GCFS).
-          If unspecified, GCFS will not be enabled on the node pool. When enabling this feature you must specify image_type = "COS_CONTAINERD" and node_version from GKE versions 1.19 or later to use it.
-          For GKE versions 1.19, 1.20, and 1.21, the recommended minimum node_version would be 1.19.15-gke.1300, 1.20.11-gke.1300, and 1.21.5-gke.1300 respectively.
-          A machine_type that has more than 16 GiB of memory is also recommended.
-          GCFS must be enabled in order to use image streaming.
-          Structure is documented below.
-      gcp_filestore_csi_driver_config: |4-
-           - (Optional) The status of the Filestore CSI driver addon,
-          which allows the usage of filestore instance as volumes.
-          It is disabled by default; set enabled = true to enable.
-      gke_backup_agent_config: |4-
-           -  (Optional, Beta).
-          The status of the Backup for GKE agent addon. It is disabled by default; Set enabled = true to enable.
-      gpu_partition_size: ' (Optional) - Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig user guide.'
-      guest_accelerator: |4-
-           - (Optional) List of the type and count of accelerator cards attached to the instance.
-          Structure documented below.
-          To support removal of guest_accelerators in Terraform 0.12 this field is an
-          Attribute as Block
-      gvnic: |4-
-           - (Optional) Google Virtual NIC (gVNIC) is a virtual network interface.
-          Installing the gVNIC driver allows for more efficient traffic transmission across the Google network infrastructure.
-          gVNIC is an alternative to the virtIO-based ethernet driver. GKE nodes must use a Container-Optimized OS node image.
-          GKE node version 1.15.11-gke.15 or later
-          Structure is documented below.
-      horizontal_pod_autoscaling: |4-
-           - (Optional) The status of the Horizontal Pod Autoscaling
-          addon, which increases or decreases the number of replica pods a replication controller
-          has based on the resource usage of the existing pods.
-          It is enabled by default;
-          set disabled = true to disable.
-      http_load_balancing: |4-
-           - (Optional) The status of the HTTP (L7) load balancing
-          controller addon, which makes it easy to set up HTTP load balancers for services in a
-          cluster. It is enabled by default; set disabled = true to disable.
-      id: ' - an identifier for the resource with format projects/{{project}}/locations/{{zone}}/clusters/{{name}}'
-      identity_service_config: ' - (Optional, Beta). Structure is documented below.'
-      initial_node_count: |4-
-           - (Optional) The number of nodes to create in this
-          cluster's default node pool. In regional or multi-zonal clusters, this is the
-          number of nodes per zone. Must be set if node_pool is not set. If you're using
-          google_container_node_pool objects with no default node pool, you'll need to
-          set this to a value of at least 1, alongside setting
-          remove_default_node_pool to true.
-      ip_allocation_policy: |4-
-           - (Optional) Configuration of cluster IP allocation for
-          VPC-native clusters. Adding this block enables IP aliasing,
-          making the cluster VPC-native instead of routes-based. Structure is documented
-          below.
-      istio_config: |4-
-           - (Optional, Beta).
-          Structure is documented below.
-      kalm_config: |4-
-           - (Optional, Beta).
-          Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set enabled = true to enable.
-      key: ' (Required) Key for taint.'
-      key_name: ' - (Required) the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.'
-      kubelet_config: |4-
-           - (Optional, Beta)
-          Kubelet configuration, currently supported attributes can be found here.
-          Structure is documented below.
-      label_fingerprint: ' - The fingerprint of the set of labels for this cluster.'
-      labels: |4-
-           - (Optional) The Kubernetes labels (key/value pairs) to be applied to each node. The kubernetes.io/ and k8s.io/ prefixes are
-          reserved by Kubernetes Core components and cannot be specified.
-      linux_node_config: |4-
-           - (Optional, Beta)
-          Linux node configuration, currently supported attributes can be found here.
-          Note that validations happen all server side. All attributes are optional.
-          Structure is documented below.
-      load_balancer_type: |4-
-           - (Optional) The load balancer type of CloudRun ingress service. It is external load balancer by default.
-          Set load_balancer_type=LOAD_BALANCER_TYPE_INTERNAL to configure it as internal load balancer.
-      location: |4-
-           - (Optional) The location (region or zone) in which the cluster
-          master will be created, as well as the default node location. If you specify a
-          zone (such as us-central1-a), the cluster will be a zonal cluster with a
-          single cluster master. If you specify a region (such as us-west1), the
-          cluster will be a regional cluster with multiple masters spread across zones in
-          the region, and with default node locations in those zones as well
-      logging_config: |4-
-           - (Optional) Logging configuration for the cluster.
-          Structure is documented below.
-      logging_service: |4-
-           - (Optional) The logging service that the cluster should
-          write logs to. Available options include logging.googleapis.com(Legacy Stackdriver),
-          logging.googleapis.com/kubernetes(Stackdriver Kubernetes Engine Logging), and none. Defaults to logging.googleapis.com/kubernetes
-      machine_type: |4-
-           - (Optional) The name of a Google Compute Engine machine type.
-          Defaults to e2-medium. To create a custom machine type, value should be set as specified
-          here.
-      maintenance_policy: |4-
-           - (Optional) The maintenance policy to use for the cluster. Structure is
-          documented below.
-      maintenance_policy.0.daily_maintenance_window.0.duration: |4-
-           - Duration of the time window, automatically chosen to be
-          smallest possible in the given scenario.
-          Duration will be in RFC3339 format "PTnHnMnS".
-      master_auth: |4-
-           - (Optional) The authentication information for accessing the
-          Kubernetes master. Some values in this block are only returned by the API if
-          your service account has permission to get credentials for your GKE cluster. If
-          you see an unexpected diff unsetting your client cert, ensure you have the
-          container.clusters.getCredentials permission.
-          Structure is documented below.
-      master_auth.0.client_certificate: |4-
-           - Base64 encoded public certificate
-          used by clients to authenticate to the cluster endpoint.
-      master_auth.0.client_key: |4-
-           - Base64 encoded private key used by clients
-          to authenticate to the cluster endpoint.
-      master_auth.0.cluster_ca_certificate: |4-
-           - Base64 encoded public certificate
-          that is the root certificate of the cluster.
-      master_authorized_networks_config: |4-
-           - (Optional) The desired
-          configuration options for master authorized networks. Omit the
-          nested cidr_blocks attribute to disallow external access (except
-          the cluster node IPs, which GKE automatically whitelists).
-          Structure is documented below.
-      master_global_access_config: |4-
-           (Optional) - Controls cluster master global
-          access settings. If unset, Terraform will no longer manage this field and will
-          not modify the previously-set value. Structure is documented below.
-      master_ipv4_cidr_block: |4-
-           (Optional) - The IP range in CIDR notation to use for
-          the hosted master network. This range will be used for assigning private IP
-          addresses to the cluster master(s) and the ILB VIP. This range must not overlap
-          with any other ranges in use within the cluster's network, and it must be a /28
-          subnet. See Private Cluster Limitations
-          for more details. This field only applies to private clusters, when
-          enable_private_nodes is true.
-      master_version: |4-
-           - The current version of the master in the cluster. This may
-          be different than the min_master_version set in the config if the master
-          has been updated by GKE.
-      maximum: ' - (Optional) Maximum amount of the resource in the cluster.'
-      metadata: |4-
-           - (Optional) The metadata key/value pairs assigned to instances in
-          the cluster. From GKE 1.12 onwards, disable-legacy-endpoints is set to
-          true by the API; if metadata is set but that default value is not
-          included, Terraform will attempt to unset the value. To avoid this, set the
-          value in your config.
-      min_master_version: |4-
-           - (Optional) The minimum version of the master. GKE
-          will auto-update the master to new versions, so this does not guarantee the
-          current master version--use the read-only master_version field to obtain that.
-          If unset, the cluster's version will be set by GKE to the version of the most recent
-          official release (which is not necessarily the latest version).  Most users will find
-          the google_container_engine_versions data source useful - it indicates which versions
-          are available, and can be use to approximate fuzzy versions in a
-          Terraform-compatible way. If you intend to specify versions manually,
-          the docs
-          describe the various acceptable formats for this field.
-      minimum: ' - (Optional) Minimum amount of the resource in the cluster.'
-      mode: |4+
-           (Required) How to expose the node metadata to the workload running on the node.
-          Accepted values are:
-      
-
-      monitoring_config: |4-
-           - (Optional) Monitoring configuration for the cluster.
-          Structure is documented below.
-      monitoring_service: |4-
-           - (Optional) The monitoring service that the cluster
-          should write metrics to.
-          Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API.
-          VM metrics will be collected by Google Compute Engine regardless of this setting
-          Available options include
-          monitoring.googleapis.com(Legacy Stackdriver), monitoring.googleapis.com/kubernetes(Stackdriver Kubernetes Engine Monitoring), and none.
-          Defaults to monitoring.googleapis.com/kubernetes
-      name: |4-
-           - (Required) The name of the cluster, unique within the project and
-          location.
-      network: |4-
-           - (Optional) The name or self_link of the Google Compute Engine
-          network to which the cluster is connected. For Shared VPC, set this to the self link of the
-          shared network.
-      network_config: |4-
-           -  (Optional, Beta) Configuration for
-          Adding Pod IP address ranges) to the node pool. Structure is documented below
-      network_policy: |4-
-           - (Optional) Configuration options for the
-          NetworkPolicy
-          feature. Structure is documented below.
-      network_policy_config: |4-
-           - (Optional) Whether we should enable the network policy addon
-          for the master.  This must be enabled in order to enable network policy for the nodes.
-          To enable this, you must also define a network_policy block,
-          otherwise nothing will happen.
-          It can only be disabled if the nodes already do not have network policies enabled.
-          Defaults to disabled; set disabled = false to enable.
-      networking_mode: |4-
-           - (Optional) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
-          Options are VPC_NATIVE or ROUTES. VPC_NATIVE enables IP aliasing,
-          and requires the ip_allocation_policy block to be defined. By default, when this field is unspecified and no ip_allocation_policy blocks are set, GKE will create a ROUTES-based cluster.
-      node_config: |4-
-           -  (Optional) Parameters used in creating the default node pool.
-          Generally, this field should not be used at the same time as a
-          google_container_node_pool or a node_pool block; this configuration
-          manages the default node pool, which isn't recommended to be used with
-          Terraform. Structure is documented below.
-      node_group: ' - (Optional) Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on sole tenant nodes.'
-      node_locations: |4-
-           - (Optional) The list of zones in which the cluster's nodes
-          are located. Nodes must be in the region of their regional cluster or in the
-          same region as their cluster's zone for zonal clusters. If this is specified for
-          a zonal cluster, omit the cluster's zone.
-      node_pool: |4-
-           - (Optional) List of node pools associated with this cluster.
-          See google_container_node_pool for schema.
-          Warning: node pools defined inside a cluster can't be changed (or added/removed) after
-          cluster creation without deleting and recreating the entire cluster. Unless you absolutely need the ability
-          to say "these are the only node pools associated with this cluster", use the
-          google_container_node_pool resource instead of this property.
-      node_version: |4-
-           - (Optional) The Kubernetes version on the nodes. Must either be unset
-          or set to the same value as min_master_version on create. Defaults to the default
-          version set by GKE which is not necessarily the latest version. This only affects
-          nodes in the default node pool. While a fuzzy version can be specified, it's
-          recommended that you specify explicit versions as Terraform will see spurious diffs
-          when fuzzy versions are used. See the google_container_engine_versions data source's
-          version_prefix field to approximate fuzzy versions in a Terraform-compatible way.
-          To update nodes in other node pools, use the version attribute on the node pool.
-      notification_config: ' - (Optional, Beta) Configuration for the cluster upgrade notifications feature. Structure is documented below.'
-      peering_name: ' - The name of the peering between this cluster and the Google owned VPC.'
-      pod_ipv4_cidr_block: ' - (Optional, Beta) The IP address range for pod IPs in this node pool. Only applicable if createPodRange is true. Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) to pick a specific range to use.'
-      pod_range: ' - (Optional, Beta) The ID of the secondary range for pod IPs. If create_pod_range is true, this ID is used for the new range. If create_pod_range is false, uses an existing secondary range with this ID.'
-      pod_security_policy_config: |4-
-           - (Optional, Beta) Configuration for the
-          PodSecurityPolicy feature.
-          Structure is documented below.
-      preemptible: |4-
-           - (Optional) A boolean that represents whether or not the underlying node VMs
-          are preemptible. See the official documentation
-          for more information. Defaults to false.
-      private_cluster_config: |4-
-           - (Optional) Configuration for private clusters,
-          clusters with private nodes. Structure is documented below.
-      private_endpoint: ' - The internal IP address of this cluster''s master endpoint.'
-      private_ipv6_google_access: |4-
-           - (Optional)
-          The desired state of IPv6 connectivity to Google Services. By default, no private IPv6 access to or from Google Services (all access will be via IPv4).
-      project: |4-
-           - (Optional) The ID of the project in which the resource belongs. If it
-          is not provided, the provider project is used.
-      provider: ' - (Optional) The selected network policy provider. Defaults to PROVIDER_UNSPECIFIED.'
-      public_endpoint: ' - The external IP address of this cluster''s master endpoint.'
-      pubsub: ' (Required) - The pubsub config for the cluster''s upgrade notifications.'
-      read: '   - Default is 40 minutes.'
-      release_channel: |4-
-           - (Optional)
-          Configuration options for the Release channel
-          feature, which provide more control over automatic upgrades of your GKE clusters.
-          When updating this field, GKE imposes specific version requirements. See
-          Selecting a new release channel
-          for more details; the google_container_engine_versions datasource can provide
-          the default version for a channel. Note that removing the release_channel
-          field from your config will cause Terraform to stop managing your cluster's
-          release channel, but will not unenroll it. Instead, use the "UNSPECIFIED"
-          channel. Structure is documented below.
-      remove_default_node_pool: |4-
-           - (Optional) If true, deletes the default node
-          pool upon cluster creation. If you're using google_container_node_pool
-          resources with no default node pool, this should be set to true, alongside
-          setting initial_node_count to at least 1.
-      resource_labels: ' - (Optional) The GCE resource labels (a map of key/value pairs) to be applied to the cluster.'
-      resource_limits: |4-
-           - (Optional) Global constraints for machine resources in the
-          cluster. Configuring the cpu and memory types is required if node
-          auto-provisioning is enabled. These limits will apply to node pool autoscaling
-          in addition to node auto-provisioning. Structure is documented below.
-      resource_type: |4-
-           - (Required) The type of the resource. For example, cpu and
-          memory.  See the guide to using Node Auto-Provisioning
-          for a list of types.
-      resource_usage_export_config: |4-
-           - (Optional) Configuration for the
-          ResourceUsageExportConfig feature.
-          Structure is documented below.
-      sandbox_config: |4-
-           - (Optional, Beta) GKE Sandbox configuration. When enabling this feature you must specify image_type = "COS_CONTAINERD" and node_version = "1.12.7-gke.17" or later to use it.
-          Structure is documented below.
-      sandbox_type: |4-
-           (Required) Which sandbox to use for pods in the node pool.
-          Accepted values are:
-      scope: ' - (Required) The scope of automatic upgrades to restrict in the exclusion window. One of: NO_UPGRADES | NO_MINOR_UPGRADES | NO_MINOR_OR_NODE_UPGRADES'
-      security_group: ' - (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com.'
-      self_link: ' - The server-defined URL for the resource.'
-      services_ipv4_cidr: |4-
-           - The IP address range of the Kubernetes services in this
-          cluster, in CIDR
-          notation (e.g. 1.2.3.4/29). Service addresses are typically put in the last
-          /16 from the container CIDR.
-      services_ipv4_cidr_block: |4-
-           - (Optional) The IP address range of the services IPs in this cluster.
-          Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
-          to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
-          from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
-          pick a specific range to use.
-      services_secondary_range_name: |4-
-           - (Optional) The name of the existing
-          secondary range in the cluster's subnetwork to use for service ClusterIPs.
-          Alternatively, services_ipv4_cidr_block can be used to automatically create a
-          GKE-managed one.
-      shielded_instance_config: ' - (Optional) Shielded Instance options. Structure is documented below.'
-      spot: |4-
-           - (Optional, Beta) A boolean
-          that represents whether the underlying node VMs are spot. See the official documentation
-          for more information. Defaults to false.
-      state: ' - (Required) ENCRYPTED or DECRYPTED'
-      subnetwork: |4-
-           - (Optional) The name or self_link of the Google Compute Engine
-          subnetwork in which the cluster's instances are launched.
-      sysctls: |4-
-           - (Required)  The Linux kernel parameters to be applied to the nodes
-          and all pods running on the nodes. Specified as a map from the key, such as
-          net.core.wmem_max, to a string value.
-      tags: |4-
-           - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
-          valid sources or targets for network firewalls.
-      taint: |4-
-           - (Optional) A list of Kubernetes taints
-          to apply to nodes. GKE's API can only set this field on cluster creation.
-          However, GKE will add taints to your nodes if you enable certain features such
-          as GPUs. If this field is set, any diffs on this field will cause Terraform to
-          recreate the underlying resource. Taint values can be updated safely in
-          Kubernetes (eg. through kubectl), and it's recommended that you do not use
-          this field to manage taints. If you do, lifecycle.ignore_changes is
-          recommended. Structure is documented below.
-      topic: ' (Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: projects/{project}/topics/{topic}.'
-      tpu_ipv4_cidr_block: |4-
-           - The IP address range of the Cloud TPUs in this cluster, in
-          CIDR
-          notation (e.g. 1.2.3.4/29).
-      update: ' - Default is 60 minutes.'
-      value: ' (Required) Value for taint.'
-      vertical_pod_autoscaling: |4-
-           - (Optional, Beta)
-          Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it.
-          Structure is documented below.
-      workload_identity_config: |4-
-           - (Optional)
-          Workload Identity allows Kubernetes service accounts to act as a user-managed
-          Google IAM Service Account.
-          Structure is documented below.
-      workload_metadata_config: |4-
-           - (Optional) Metadata configuration to expose to workloads on the node pool.
-          Structure is documented below.
-      workload_pool: ' (Optional) - The workload pool to attach all Kubernetes service accounts to.'
-  google_storage_bucket:
-    subCategory: Cloud Storage
-    description: Creates a new bucket in Google Cloud Storage.
-    name: google_storage_bucket
-    title: google_storage_bucket
-    examples:
-      - name: static-site
-        manifest: |-
-          {
-            "cors": [
-              {
-                "max_age_seconds": 3600,
-                "method": [
-                  "GET",
-                  "HEAD",
-                  "PUT",
-                  "POST",
-                  "DELETE"
-                ],
-                "origin": [
-                  "http://image-store.com"
-                ],
-                "response_header": [
-                  "*"
-                ]
-              }
-            ],
-            "force_destroy": true,
-            "location": "EU",
-            "name": "image-store.com",
-            "uniform_bucket_level_access": true,
-            "website": [
-              {
-                "main_page_suffix": "index.html",
-                "not_found_page": "404.html"
-              }
-            ]
-          }
-        references: {}
-        dependencies: {}
-      - name: auto-expire
-        manifest: |-
-          {
-            "force_destroy": true,
-            "lifecycle_rule": [
-              {
-                "action": [
-                  {
-                    "type": "Delete"
-                  }
-                ],
-                "condition": [
-                  {
-                    "age": 3
-                  }
-                ]
-              }
-            ],
-            "location": "US",
-            "name": "auto-expiring-bucket"
-          }
-        references: {}
-        dependencies: {}
-    argumentDocs:
-      action: ' - (Required) The Lifecycle Rule''s action configuration. A single block of this type is supported. Structure is documented below.'
-      age: ' - (Optional) Minimum age of an object in days to satisfy this condition.'
-      condition: ' - (Required) The Lifecycle Rule''s condition configuration. A single block of this type is supported. Structure is documented below.'
-      cors: ' - (Optional) The bucket''s Cross-Origin Resource Sharing (CORS) configuration. Multiple blocks of this type are permitted. Structure is documented below.'
-      create: ' - Default is 4 minutes.'
-      created_before: ' - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when an object is created before midnight of the specified date in UTC.'
-      custom_time_before: ' - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.'
-      days_since_custom_time: " - (Optional)\tDays since the date set in the customTime metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the customTime."
-      days_since_noncurrent_time: ' - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.'
-      default_event_based_hold: ' - (Optional) Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.'
-      default_kms_key_name: |-
-        : The id of a Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no encryption method is specified.
-        You must pay attention to whether the crypto key is available in the location that this bucket is created in.
-        See the docs for more details.
-      enabled: ' - (Required) While set to true, versioning is fully enabled for this bucket.'
-      encryption: ' - (Optional) The bucket''s encryption configuration. Structure is documented below.'
-      force_destroy: |4-
-           - (Optional, Default: false) When deleting a bucket, this
-          boolean option will delete all contained objects. If you try to delete a
-          bucket that contains objects, Terraform will fail that run.
-      is_locked: ' - (Optional) If set to true, the bucket will be locked and permanently restrict edits to the bucket''s retention policy.  Caution: Locking a bucket is an irreversible action.'
-      labels: ' - (Optional) A map of key/value label pairs to assign to the bucket.'
-      lifecycle_rule: ' - (Optional) The bucket''s Lifecycle Rules configuration. Multiple blocks of this type are permitted. Structure is documented below.'
-      location: ' - (Required) The GCS location'
-      log_bucket: ' - (Required) The bucket that will receive log objects.'
-      log_object_prefix: |4-
-           - (Optional, Computed) The object prefix for log objects. If it's not provided,
-          by default GCS sets this to this bucket's name.
-      logging: ' - (Optional) The bucket''s Access & Storage Logs configuration. Structure is documented below.'
-      main_page_suffix: |4-
-           - (Optional) Behaves as the bucket's directory index where
-          missing objects are treated as potential directories.
-      matches_storage_class: ' - (Optional) Storage Class of objects to satisfy this condition. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE, DURABLE_REDUCED_AVAILABILITY.'
-      max_age_seconds: ' - (Optional) The value, in seconds, to return in the Access-Control-Max-Age header used in preflight responses.'
-      method: ' - (Optional) The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list of methods, and means "any method".'
-      name: ' - (Required) The name of the bucket.'
-      noncurrent_time_before: ' - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.'
-      not_found_page: |4-
-           - (Optional) The custom object to return when a requested
-          resource is not found.
-      num_newer_versions: ' - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.'
-      origin: ' - (Optional) The list of Origins eligible to receive CORS response headers. Note: "*" is permitted in the list of origins, and means "any Origin".'
-      project: |4-
-           - (Optional) The ID of the project in which the resource belongs. If it
-          is not provided, the provider project is used.
-      read: ' - Default is 4 minutes.'
-      requester_pays: ' - (Optional, Default: false) Enables Requester Pays on a storage bucket.'
-      response_header: ' - (Optional) The list of HTTP headers other than the simple response headers to give permission for the user-agent to share across domains.'
-      retention_period: ' - (Required) The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 2,147,483,647 seconds.'
-      retention_policy: ' - (Optional) Configuration of the bucket''s data retention policy for how long objects in the bucket should be retained. Structure is documented below.'
-      self_link: ' - The URI of the created resource.'
-      type: ' - The type of the action of this Lifecycle Rule. Supported values include: Delete and SetStorageClass.'
-      uniform_bucket_level_access: ' - (Optional, Default: false) Enables Uniform bucket-level access access to a bucket.'
-      update: ' - Default is 4 minutes.'
-      url: ' - The base URL of the bucket, in the format gs://<bucket-name>.'
-      versioning: ' - (Optional) The bucket''s Versioning configuration.  Structure is documented below.'
-      website: ' - (Optional) Configuration if the bucket acts as a website. Structure is documented below.'
-      with_state: ' - (Optional) Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: "LIVE", "ARCHIVED", "ANY".'
+              dependencies:
+                google_access_context_manager_access_policy.access-policy: |-
+                    {
+                      "parent": "organizations/123456789",
+                      "title": "my policy"
+                    }
+        argumentDocs:
+            basic: |-
+                -
+                (Optional)
+                A set of predefined conditions for the access level and a combining function.
+                Structure is documented below.
+            basic.combining_function: |-
+                -
+                (Optional)
+                How the conditions list should be combined to determine if a request
+                is granted this AccessLevel. If AND is used, each Condition in
+                conditions must be satisfied for the AccessLevel to be applied. If
+                OR is used, at least one Condition in conditions must be satisfied
+                for the AccessLevel to be applied.
+                Default value is AND.
+                Possible values are AND and OR.
+            basic.conditions: |-
+                -
+                (Required)
+                A set of requirements for the AccessLevel to be granted.
+                Structure is documented below.
+            conditions.device_policy: |-
+                -
+                (Optional)
+                Device specific restrictions, all restrictions must hold for
+                the Condition to be true. If not specified, all devices are
+                allowed.
+                Structure is documented below.
+            conditions.ip_subnetworks: |-
+                -
+                (Optional)
+                A list of CIDR block IP subnetwork specification. May be IPv4
+                or IPv6.
+                Note that for a CIDR IP address block, the specified IP address
+                portion must be properly truncated (i.e. all the host bits must
+                be zero) or the input is considered malformed. For example,
+                "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly,
+                for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32"
+                is not. The originating IP of a request must be in one of the
+                listed subnets in order for this Condition to be true.
+                If empty, all IP addresses are allowed.
+            conditions.members: |-
+                -
+                (Optional)
+                An allowed list of members (users, service accounts).
+                Using groups is not supported yet.
+                The signed-in user originating the request must be a part of one
+                of the provided members. If not specified, a request may come
+                from any user (logged in/not logged in, not present in any
+                groups, etc.).
+                Formats: user:{emailid}, serviceAccount:{emailid}
+            conditions.negate: |-
+                -
+                (Optional)
+                Whether to negate the Condition. If true, the Condition becomes
+                a NAND over its non-empty fields, each field must be false for
+                the Condition overall to be satisfied. Defaults to false.
+            conditions.regions: |-
+                -
+                (Optional)
+                The request must originate from one of the provided
+                countries/regions.
+                Format: A valid ISO 3166-1 alpha-2 code.
+            conditions.required_access_levels: |-
+                -
+                (Optional)
+                A list of other access levels defined in the same Policy,
+                referenced by resource name. Referencing an AccessLevel which
+                does not exist is an error. All access levels listed must be
+                granted for the Condition to be true.
+                Format: accessPolicies/{policy_id}/accessLevels/{short_name}
+            custom: |-
+                -
+                (Optional)
+                Custom access level conditions are set using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request.
+                See CEL spec at: https://github.com/google/cel-spec.
+                Structure is documented below.
+            custom.expr: |-
+                -
+                (Required)
+                Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language.
+                This page details the objects and attributes that are used to the build the CEL expressions for
+                custom access levels - https://cloud.google.com/access-context-manager/docs/custom-access-level-spec.
+                Structure is documented below.
+            custom.expr.create: '- Default is 20 minutes.'
+            custom.expr.delete: '- Default is 20 minutes.'
+            custom.expr.description: |-
+                -
+                (Optional)
+                Description of the expression
+            custom.expr.expression: |-
+                -
+                (Required)
+                Textual representation of an expression in Common Expression Language syntax.
+            custom.expr.id: '- an identifier for the resource with format {{name}}'
+            custom.expr.location: |-
+                -
+                (Optional)
+                String indicating the location of the expression for error reporting, e.g. a file name and a position in the file
+            custom.expr.title: |-
+                -
+                (Optional)
+                Title for the expression, i.e. a short string describing its purpose.
+            custom.expr.update: '- Default is 20 minutes.'
+            description: |-
+                -
+                (Optional)
+                Description of the AccessLevel and its use. Does not affect behavior.
+            device_policy.allowed_device_management_levels: |-
+                -
+                (Optional)
+                A list of allowed device management levels.
+                An empty list allows all management levels.
+                Each value may be one of MANAGEMENT_UNSPECIFIED, NONE, BASIC, and COMPLETE.
+            device_policy.allowed_encryption_statuses: |-
+                -
+                (Optional)
+                A list of allowed encryptions statuses.
+                An empty list allows all statuses.
+                Each value may be one of ENCRYPTION_UNSPECIFIED, ENCRYPTION_UNSUPPORTED, UNENCRYPTED, and ENCRYPTED.
+            device_policy.os_constraints: |-
+                -
+                (Optional)
+                A list of allowed OS versions.
+                An empty list allows all types and all versions.
+                Structure is documented below.
+            device_policy.require_admin_approval: |-
+                -
+                (Optional)
+                Whether the device needs to be approved by the customer admin.
+            device_policy.require_corp_owned: |-
+                -
+                (Optional)
+                Whether the device needs to be corp owned.
+            device_policy.require_screen_lock: |-
+                -
+                (Optional)
+                Whether or not screenlock is required for the DevicePolicy
+                to be true. Defaults to false.
+            name: |-
+                -
+                (Required)
+                Resource name for the Access Level. The short_name component must begin
+                with a letter and only include alphanumeric and '_'.
+                Format: accessPolicies/{policy_id}/accessLevels/{short_name}
+            os_constraints.minimum_version: |-
+                -
+                (Optional)
+                The minimum allowed OS version. If not set, any version
+                of this OS satisfies the constraint.
+                Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+            os_constraints.os_type: |-
+                -
+                (Required)
+                The operating system type of the device.
+                Possible values are OS_UNSPECIFIED, DESKTOP_MAC, DESKTOP_WINDOWS, DESKTOP_LINUX, DESKTOP_CHROME_OS, ANDROID, and IOS.
+            os_constraints.require_verified_chrome_os: |-
+                -
+                (Optional)
+                If you specify DESKTOP_CHROME_OS for osType, you can optionally include requireVerifiedChromeOs to require Chrome Verified Access.
+            parent: |-
+                -
+                (Required)
+                The AccessPolicy this AccessLevel lives in.
+                Format: accessPolicies/{policy_id}
+            title: |-
+                -
+                (Required)
+                Human readable title. Must be unique within the Policy.
+        importStatements: []
+    google_container_cluster:
+        subCategory: Kubernetes (Container) Engine
+        description: Creates a Google Kubernetes Engine (GKE) cluster.
+        name: google_container_cluster
+        title: google_container_cluster
+        examples:
+            - name: primary
+              manifest: |-
+                {
+                  "initial_node_count": 1,
+                  "location": "us-central1",
+                  "name": "my-gke-cluster",
+                  "remove_default_node_pool": true
+                }
+              dependencies:
+                google_container_node_pool.primary_preemptible_nodes: |-
+                    {
+                      "cluster": "${google_container_cluster.primary.name}",
+                      "location": "us-central1",
+                      "name": "my-node-pool",
+                      "node_config": [
+                        {
+                          "machine_type": "e2-medium",
+                          "oauth_scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "preemptible": true,
+                          "service_account": "${google_service_account.default.email}"
+                        }
+                      ],
+                      "node_count": 1
+                    }
+                google_service_account.default: |-
+                    {
+                      "account_id": "service-account-id",
+                      "display_name": "Service Account"
+                    }
+            - name: primary
+              manifest: |-
+                {
+                  "initial_node_count": 3,
+                  "location": "us-central1-a",
+                  "name": "marcellus-wallace",
+                  "node_config": [
+                    {
+                      "labels": {
+                        "foo": "bar"
+                      },
+                      "oauth_scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "service_account": "${google_service_account.default.email}",
+                      "tags": [
+                        "foo",
+                        "bar"
+                      ]
+                    }
+                  ],
+                  "timeouts": [
+                    {
+                      "create": "30m",
+                      "update": "40m"
+                    }
+                  ]
+                }
+              references:
+                node_config.service_account: google_service_account.default.email
+              dependencies:
+                google_service_account.default: |-
+                    {
+                      "account_id": "service-account-id",
+                      "display_name": "Service Account"
+                    }
+        argumentDocs:
+            '"gvisor"': ': Pods run within a gVisor sandbox.'
+            addons_config: |-
+                - (Optional) The configuration for addons supported by GKE.
+                Structure is documented below.
+            addons_config.cloudrun_config: '- (Optional). Structure is documented below.'
+            addons_config.config_connector_config: |-
+                -  (Optional, Beta).
+                The status of the ConfigConnector addon. It is disabled by default; Set enabled = true to enable.
+            addons_config.dns_cache_config: |-
+                - (Optional, Beta).
+                The status of the NodeLocal DNSCache addon. It is disabled by default.
+                Set enabled = true to enable.
+            addons_config.gce_persistent_disk_csi_driver_config: |-
+                - (Optional, Beta).
+                Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set enabled = true to enable.
+            addons_config.gcp_filestore_csi_driver_config: |-
+                - (Optional) The status of the Filestore CSI driver addon,
+                which allows the usage of filestore instance as volumes.
+                It is disabled by default; set enabled = true to enable.
+            addons_config.gke_backup_agent_config: |-
+                -  (Optional, Beta).
+                The status of the Backup for GKE agent addon. It is disabled by default; Set enabled = true to enable.
+            addons_config.horizontal_pod_autoscaling: |-
+                - (Optional) The status of the Horizontal Pod Autoscaling
+                addon, which increases or decreases the number of replica pods a replication controller
+                has based on the resource usage of the existing pods.
+                It is enabled by default;
+                set disabled = true to disable.
+            addons_config.http_load_balancing: |-
+                - (Optional) The status of the HTTP (L7) load balancing
+                controller addon, which makes it easy to set up HTTP load balancers for services in a
+                cluster. It is enabled by default; set disabled = true to disable.
+            addons_config.identity_service_config: '- (Optional, Beta). Structure is documented below.'
+            addons_config.istio_config: |-
+                - (Optional, Beta).
+                Structure is documented below.
+            addons_config.kalm_config: |-
+                - (Optional, Beta).
+                Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set enabled = true to enable.
+            addons_config.network_policy_config: |-
+                - (Optional) Whether we should enable the network policy addon
+                for the master.  This must be enabled in order to enable network policy for the nodes.
+                To enable this, you must also define a network_policy block,
+                otherwise nothing will happen.
+                It can only be disabled if the nodes already do not have network policies enabled.
+                Defaults to disabled; set disabled = false to enable.
+            authenticator_groups_config: |-
+                - (Optional) Configuration for the
+                Google Groups for GKE feature.
+                Structure is documented below.
+            authenticator_groups_config.security_group: '- (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com.'
+            auto_provisioning_defaults.image_type: '- (Optional) The default image type used by NAP once a new node pool is being created. Please note that according to the official documentation the value must be one of the [COS_CONTAINERD, COS, UBUNTU_CONTAINERD, UBUNTU]. NOTE : COS AND UBUNTU are deprecated as of GKE 1.24'
+            auto_provisioning_defaults.min_cpu_platform: |-
+                - (Optional, Beta)
+                Minimum CPU platform to be used for NAP created node pools. The instance may be scheduled on the
+                specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such
+                as "Intel Haswell" or "Intel Sandy Bridge".
+            auto_provisioning_defaults.oauth_scopes: '- (Optional) Scopes that are used by NAP when creating node pools. Use the "https://www.googleapis.com/auth/cloud-platform" scope to grant access to all APIs. It is recommended that you set service_account to a non-default service account and grant IAM roles to that service account for only the resources that it needs.'
+            auto_provisioning_defaults.service_account: '- (Optional) The Google Cloud Platform Service Account to be used by the node VMs.'
+            cloudrun_config.disabled: '- (Optional) The status of the CloudRun addon. It is disabled by default. Set disabled=false to enable.'
+            cloudrun_config.load_balancer_type: |-
+                - (Optional) The load balancer type of CloudRun ingress service. It is external load balancer by default.
+                Set load_balancer_type=LOAD_BALANCER_TYPE_INTERNAL to configure it as internal load balancer.
+            cluster_autoscaling: |-
+                - (Optional)
+                Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
+                automatically adjust the size of the cluster and create/delete node pools based
+                on the current needs of the cluster's workload. See the
+                guide to using Node Auto-Provisioning
+                for more details. Structure is documented below.
+            cluster_autoscaling.auto_provisioning_defaults: |-
+                - (Optional) Contains defaults for a node pool created by NAP.
+                Structure is documented below.
+            cluster_autoscaling.autoscaling_profile: |-
+                - (Optional, Beta) Configuration
+                options for the Autoscaling profile
+                feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability
+                when deciding to remove nodes from a cluster. Can be BALANCED or OPTIMIZE_UTILIZATION. Defaults to BALANCED.
+            cluster_autoscaling.enabled: |-
+                - (Required) Whether node auto-provisioning is enabled. Resource
+                limits for cpu and memory must be defined to enable node auto-provisioning.
+            cluster_autoscaling.resource_limits: |-
+                - (Optional) Global constraints for machine resources in the
+                cluster. Configuring the cpu and memory types is required if node
+                auto-provisioning is enabled. These limits will apply to node pool autoscaling
+                in addition to node auto-provisioning. Structure is documented below.
+            cluster_ipv4_cidr: |-
+                - (Optional) The IP address range of the Kubernetes pods
+                in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one
+                automatically chosen or specify a /14 block in 10.0.0.0/8. This field will
+                only work for routes-based clusters, where ip_allocation_policy is not defined.
+            cluster_telemetry: |-
+                - (Optional, Beta) Configuration for
+                ClusterTelemetry feature,
+                Structure is documented below.
+            cluster_telemetry.type: |-
+                - Telemetry integration for the cluster. Supported values (ENABLED, DISABLED, SYSTEM_ONLY);
+                SYSTEM_ONLY (Only system components are monitored and logged) is only available in GKE versions 1.15 and later.
+            confidential_nodes: '- Configuration for Confidential Nodes feature. Structure is documented below documented below.'
+            confidential_nodes.enabled: (Required) - Enable Confidential Nodes for this cluster.
+            database_encryption: |-
+                - (Optional)
+                Structure is documented below.
+            database_encryption.key_name: '- (Required) the key to use to encrypt/decrypt secrets.  See the DatabaseEncryption definition for more information.'
+            database_encryption.state: '- (Required) ENCRYPTED or DECRYPTED'
+            datapath_provider: |-
+                - (Optional)
+                The desired datapath provider for this cluster. By default, uses the IPTables-based kube-proxy implementation.
+            default_max_pods_per_node: |-
+                - (Optional) The default maximum number of pods
+                per node in this cluster. This doesn't work on "routes-based" clusters, clusters
+                that don't have IP Aliasing enabled. See the official documentation
+                for more information.
+            default_snat_status: |-
+                - (Optional)
+                GKE SNAT DefaultSnatStatus contains the desired state of whether default sNAT should be disabled on the cluster, API doc. Structure is documented below
+            default_snat_status.disabled: '- (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic'
+            description: '- (Optional) Description of the cluster.'
+            dns_config: |-
+                - (Optional)
+                Configuration for Using Cloud DNS for GKE. Structure is documented below.
+            dns_config.cluster_dns: '- (Optional) Which in-cluster DNS provider should be used. PROVIDER_UNSPECIFIED (default) or PLATFORM_DEFAULT or CLOUD_DNS.'
+            dns_config.cluster_dns_domain: '- (Optional) The suffix used for all cluster service records.'
+            dns_config.cluster_dns_scope: '- (Optional) The scope of access to cluster DNS records. DNS_SCOPE_UNSPECIFIED (default) or CLUSTER_SCOPE or VPC_SCOPE.'
+            dns_config.create: '- Default is 40 minutes.'
+            dns_config.delete: '- Default is 40 minutes.'
+            dns_config.endpoint: '- The IP address of this cluster''s Kubernetes master.'
+            dns_config.id: '- an identifier for the resource with format projects/{{project}}/locations/{{zone}}/clusters/{{name}}'
+            dns_config.label_fingerprint: '- The fingerprint of the set of labels for this cluster.'
+            dns_config.maintenance_policy.0.daily_maintenance_window.0.duration: |-
+                - Duration of the time window, automatically chosen to be
+                smallest possible in the given scenario.
+                Duration will be in RFC3339 format "PTnHnMnS".
+            dns_config.master_auth.0.client_certificate: |-
+                - Base64 encoded public certificate
+                used by clients to authenticate to the cluster endpoint.
+            dns_config.master_auth.0.client_key: |-
+                - Base64 encoded private key used by clients
+                to authenticate to the cluster endpoint.
+            dns_config.master_auth.0.cluster_ca_certificate: |-
+                - Base64 encoded public certificate
+                that is the root certificate of the cluster.
+            dns_config.master_version: |-
+                - The current version of the master in the cluster. This may
+                be different than the min_master_version set in the config if the master
+                has been updated by GKE.
+            dns_config.read: '- Default is 40 minutes.'
+            dns_config.self_link: '- The server-defined URL for the resource.'
+            dns_config.services_ipv4_cidr: |-
+                - The IP address range of the Kubernetes services in this
+                cluster, in CIDR
+                notation (e.g. 1.2.3.4/29). Service addresses are typically put in the last
+                /16 from the container CIDR.
+            dns_config.tpu_ipv4_cidr_block: |-
+                - The IP address range of the Cloud TPUs in this cluster, in
+                CIDR
+                notation (e.g. 1.2.3.4/29).
+            dns_config.update: '- Default is 60 minutes.'
+            enable_autopilot: |-
+                - (Optional) Enable Autopilot for this cluster. Defaults to false.
+                Note that when this option is enabled, certain features of Standard GKE are not available.
+                See the official documentation
+                for available features.
+            enable_binary_authorization: |-
+                - (Optional) Enable Binary Authorization for this cluster.
+                If enabled, all container images will be validated by Google Binary Authorization.
+            enable_intranode_visibility: |-
+                - (Optional)
+                Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.
+            enable_kubernetes_alpha: |-
+                - (Optional) Whether to enable Kubernetes Alpha features for
+                this cluster. Note that when this option is enabled, the cluster cannot be upgraded
+                and will be automatically deleted after 30 days.
+            enable_l4_ilb_subsetting: |-
+                - (Optional, Beta)
+                Whether L4ILB Subsetting is enabled for this cluster.
+            enable_legacy_abac: |-
+                - (Optional) Whether the ABAC authorizer is enabled for this cluster.
+                When enabled, identities in the system, including service accounts, nodes, and controllers,
+                will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
+                Defaults to false
+            enable_shielded_nodes: '- (Optional) Enable Shielded Nodes features on all nodes in this cluster.  Defaults to true.'
+            enable_tpu: |-
+                - (Optional) Whether to enable Cloud TPU resources in this cluster.
+                See the official documentation.
+            ephemeral_storage_config.local_ssd_count: (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.
+            gcfs_config.enabled: (Required) - Whether or not the Google Container Filesystem (GCFS) is enabled
+            guest_accelerator.count: (Required) - The number of the guest accelerator cards exposed to this instance.
+            guest_accelerator.gpu_partition_size: (Optional) - Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig user guide.
+            guest_accelerator.type: (Required) - The accelerator type resource to expose to this instance. E.g. nvidia-tesla-k80.
+            gvnic.enabled: (Required) - Whether or not the Google Virtual NIC (gVNIC) is enabled
+            identity_service_config.enabled: '- (Optional) Whether to enable the Identity Service component. It is disabled by default. Set enabled=true to enable.'
+            initial_node_count: |-
+                - (Optional) The number of nodes to create in this
+                cluster's default node pool. In regional or multi-zonal clusters, this is the
+                number of nodes per zone. Must be set if node_pool is not set. If you're using
+                google_container_node_pool objects with no default node pool, you'll need to
+                set this to a value of at least 1, alongside setting
+                remove_default_node_pool to true.
+            ip_allocation_policy: |-
+                - (Optional) Configuration of cluster IP allocation for
+                VPC-native clusters. Adding this block enables IP aliasing,
+                making the cluster VPC-native instead of routes-based. Structure is documented
+                below.
+            ip_allocation_policy.cluster_ipv4_cidr_block: |-
+                - (Optional) The IP address range for the cluster pod IPs.
+                Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
+                to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
+                from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
+                pick a specific range to use.
+            ip_allocation_policy.cluster_secondary_range_name: |-
+                - (Optional) The name of the existing secondary
+                range in the cluster's subnetwork to use for pod IP addresses. Alternatively,
+                cluster_ipv4_cidr_block can be used to automatically create a GKE-managed one.
+            ip_allocation_policy.services_ipv4_cidr_block: |-
+                - (Optional) The IP address range of the services IPs in this cluster.
+                Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
+                to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
+                from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
+                pick a specific range to use.
+            ip_allocation_policy.services_secondary_range_name: |-
+                - (Optional) The name of the existing
+                secondary range in the cluster's subnetwork to use for service ClusterIPs.
+                Alternatively, services_ipv4_cidr_block can be used to automatically create a
+                GKE-managed one.
+            istio_config.auth: '- (Optional) The authentication type between services in Istio. Available options include AUTH_MUTUAL_TLS.'
+            istio_config.disabled: |-
+                - (Optional) The status of the Istio addon, which makes it easy to set up Istio for services in a
+                cluster. It is disabled by default. Set disabled = false to enable.
+            kubelet_config.cpu_cfs_quota: |-
+                - (Optional) If true, enables CPU CFS quota enforcement for
+                containers that specify CPU limits.
+            kubelet_config.cpu_cfs_quota_period: |-
+                - (Optional) The CPU CFS quota period value. Specified
+                as a sequence of decimal numbers, each with optional fraction and a unit suffix,
+                such as "300ms". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                "h". The value must be a positive duration.
+            kubelet_config.cpu_manager_policy: |-
+                - (Required) The CPU management policy on the node. See
+                K8S CPU Management Policies.
+                One of "none" or "static". Defaults to none when kubelet_config is unset.
+            linux_node_config.sysctls: |-
+                - (Required)  The Linux kernel parameters to be applied to the nodes
+                and all pods running on the nodes. Specified as a map from the key, such as
+                net.core.wmem_max, to a string value.
+            location: |-
+                - (Optional) The location (region or zone) in which the cluster
+                master will be created, as well as the default node location. If you specify a
+                zone (such as us-central1-a), the cluster will be a zonal cluster with a
+                single cluster master. If you specify a region (such as us-west1), the
+                cluster will be a regional cluster with multiple masters spread across zones in
+                the region, and with default node locations in those zones as well
+            logging_config: |-
+                - (Optional) Logging configuration for the cluster.
+                Structure is documented below.
+            logging_config.enable_components: |-
+                - (Required) The GKE components exposing logs. Supported values include:
+                SYSTEM_COMPONENTS and WORKLOADS.
+            logging_service: |-
+                - (Optional) The logging service that the cluster should
+                write logs to. Available options include logging.googleapis.com(Legacy Stackdriver),
+                logging.googleapis.com/kubernetes(Stackdriver Kubernetes Engine Logging), and none. Defaults to logging.googleapis.com/kubernetes
+            maintenance_policy: |-
+                - (Optional) The maintenance policy to use for the cluster. Structure is
+                documented below.
+            maintenance_policy.maintenance_exclusion.exclusion_options: '- (Optional) MaintenanceExclusionOptions provides maintenance exclusion related options.'
+            maintenance_policy.maintenance_exclusion.exclusion_options.scope: '- (Required) The scope of automatic upgrades to restrict in the exclusion window. One of: NO_UPGRADES | NO_MINOR_UPGRADES | NO_MINOR_OR_NODE_UPGRADES'
+            master_auth: |-
+                - (Optional) The authentication information for accessing the
+                Kubernetes master. Some values in this block are only returned by the API if
+                your service account has permission to get credentials for your GKE cluster. If
+                you see an unexpected diff unsetting your client cert, ensure you have the
+                container.clusters.getCredentials permission.
+                Structure is documented below.
+            master_auth.client_certificate_config: '- (Required) Whether client certificate authorization is enabled for this cluster.  For example:'
+            master_authorized_networks_config: |-
+                - (Optional) The desired
+                configuration options for master authorized networks. Omit the
+                nested cidr_blocks attribute to disallow external access (except
+                the cluster node IPs, which GKE automatically whitelists).
+                Structure is documented below.
+            master_authorized_networks_config.cidr_blocks: |-
+                - (Optional) External networks that can access the
+                Kubernetes cluster master through HTTPS.
+            master_authorized_networks_config.cidr_blocks.cidr_block: |-
+                - (Optional) External network that can access Kubernetes master through HTTPS.
+                Must be specified in CIDR notation.
+            master_authorized_networks_config.cidr_blocks.display_name: '- (Optional) Field for users to identify CIDR blocks.'
+            min_master_version: |-
+                - (Optional) The minimum version of the master. GKE
+                will auto-update the master to new versions, so this does not guarantee the
+                current master version--use the read-only master_version field to obtain that.
+                If unset, the cluster's version will be set by GKE to the version of the most recent
+                official release (which is not necessarily the latest version).  Most users will find
+                the google_container_engine_versions data source useful - it indicates which versions
+                are available, and can be use to approximate fuzzy versions in a
+                Terraform-compatible way. If you intend to specify versions manually,
+                the docs
+                describe the various acceptable formats for this field.
+            monitoring_config: |-
+                - (Optional) Monitoring configuration for the cluster.
+                Structure is documented below.
+            monitoring_config.enable_components: '- (Required) The GKE components exposing logs. SYSTEM_COMPONENTS and in beta provider, both SYSTEM_COMPONENTS and WORKLOADS are supported.'
+            monitoring_service: |-
+                - (Optional) The monitoring service that the cluster
+                should write metrics to.
+                Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API.
+                VM metrics will be collected by Google Compute Engine regardless of this setting
+                Available options include
+                monitoring.googleapis.com(Legacy Stackdriver), monitoring.googleapis.com/kubernetes(Stackdriver Kubernetes Engine Monitoring), and none.
+                Defaults to monitoring.googleapis.com/kubernetes
+            name: |-
+                - (Required) The name of the cluster, unique within the project and
+                location.
+            network: |-
+                - (Optional) The name or self_link of the Google Compute Engine
+                network to which the cluster is connected. For Shared VPC, set this to the self link of the
+                shared network.
+            network_config: |-
+                -  (Optional, Beta) Configuration for
+                Adding Pod IP address ranges) to the node pool. Structure is documented below
+            network_config.create_pod_range: '- (Optional, Beta) Whether to create a new range for pod IPs in this node pool. Defaults are provided for pod_range and pod_ipv4_cidr_block if they are not specified.'
+            network_config.pod_ipv4_cidr_block: '- (Optional, Beta) The IP address range for pod IPs in this node pool. Only applicable if createPodRange is true. Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) to pick a specific range to use.'
+            network_config.pod_range: '- (Optional, Beta) The ID of the secondary range for pod IPs. If create_pod_range is true, this ID is used for the new range. If create_pod_range is false, uses an existing secondary range with this ID.'
+            network_policy: |-
+                - (Optional) Configuration options for the
+                NetworkPolicy
+                feature. Structure is documented below.
+            network_policy.enabled: '- (Required) Whether network policy is enabled on the cluster.'
+            network_policy.provider: '- (Optional) The selected network policy provider. Defaults to PROVIDER_UNSPECIFIED.'
+            networking_mode: |-
+                - (Optional) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
+                Options are VPC_NATIVE or ROUTES. VPC_NATIVE enables IP aliasing,
+                and requires the ip_allocation_policy block to be defined. By default, when this field is unspecified and no ip_allocation_policy blocks are set, GKE will create a ROUTES-based cluster.
+            node_config: |-
+                -  (Optional) Parameters used in creating the default node pool.
+                Generally, this field should not be used at the same time as a
+                google_container_node_pool or a node_pool block; this configuration
+                manages the default node pool, which isn't recommended to be used with
+                Terraform. Structure is documented below.
+            node_config.boot_disk_kms_key: '- (Optional) The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool. This should be of the form projects/[KEY_PROJECT_ID]/locations/[LOCATION]/keyRings/[RING_NAME]/cryptoKeys/[KEY_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption'
+            node_config.disk_size_gb: |-
+                - (Optional) Size of the disk attached to each node, specified
+                in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
+            node_config.disk_type: |-
+                - (Optional) Type of the disk attached to each node
+                (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'
+            node_config.ephemeral_storage_config: '- (Optional, [Beta]) Parameters for the ephemeral storage filesystem. If unspecified, ephemeral storage is backed by the boot disk. Structure is documented below.'
+            node_config.gcfs_config: |-
+                - (Optional) Parameters for the Google Container Filesystem (GCFS).
+                If unspecified, GCFS will not be enabled on the node pool. When enabling this feature you must specify image_type = "COS_CONTAINERD" and node_version from GKE versions 1.19 or later to use it.
+                For GKE versions 1.19, 1.20, and 1.21, the recommended minimum node_version would be 1.19.15-gke.1300, 1.20.11-gke.1300, and 1.21.5-gke.1300 respectively.
+                A machine_type that has more than 16 GiB of memory is also recommended.
+                GCFS must be enabled in order to use image streaming.
+                Structure is documented below.
+            node_config.guest_accelerator: |-
+                - (Optional) List of the type and count of accelerator cards attached to the instance.
+                Structure documented below.
+                To support removal of guest_accelerators in Terraform 0.12 this field is an
+                Attribute as Block
+            node_config.gvnic: |-
+                - (Optional) Google Virtual NIC (gVNIC) is a virtual network interface.
+                Installing the gVNIC driver allows for more efficient traffic transmission across the Google network infrastructure.
+                gVNIC is an alternative to the virtIO-based ethernet driver. GKE nodes must use a Container-Optimized OS node image.
+                GKE node version 1.15.11-gke.15 or later
+                Structure is documented below.
+            node_config.image_type: |-
+                - (Optional) The image type to use for this node. Note that changing the image type
+                will delete and recreate all nodes in the node pool.
+            node_config.kubelet_config: |-
+                - (Optional, Beta)
+                Kubelet configuration, currently supported attributes can be found here.
+                Structure is documented below.
+            node_config.labels: |-
+                - (Optional) The Kubernetes labels (key/value pairs) to be applied to each node. The kubernetes.io/ and k8s.io/ prefixes are
+                reserved by Kubernetes Core components and cannot be specified.
+            node_config.linux_node_config: |-
+                - (Optional, Beta)
+                Linux node configuration, currently supported attributes can be found here.
+                Note that validations happen all server side. All attributes are optional.
+                Structure is documented below.
+            node_config.local_ssd_count: |-
+                - (Optional) The amount of local SSD disks that will be
+                attached to each cluster node. Defaults to 0.
+            node_config.machine_type: |-
+                - (Optional) The name of a Google Compute Engine machine type.
+                Defaults to e2-medium. To create a custom machine type, value should be set as specified
+                here.
+            node_config.metadata: |-
+                - (Optional) The metadata key/value pairs assigned to instances in
+                the cluster. From GKE 1.12 onwards, disable-legacy-endpoints is set to
+                true by the API; if metadata is set but that default value is not
+                included, Terraform will attempt to unset the value. To avoid this, set the
+                value in your config.
+            node_config.min_cpu_platform: |-
+                - (Optional) Minimum CPU platform to be used by this instance.
+                The instance may be scheduled on the specified or newer CPU platform. Applicable
+                values are the friendly names of CPU platforms, such as Intel Haswell. See the
+                official documentation
+                for more information.
+            node_config.node_group: '- (Optional) Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on sole tenant nodes.'
+            node_config.oauth_scopes: |-
+                - (Optional) The set of Google API scopes to be made available
+                on all of the node VMs under the "default" service account.
+                Use the "https://www.googleapis.com/auth/cloud-platform" scope to grant access to all APIs. It is recommended that you set service_account to a non-default service account and grant IAM roles to that service account for only the resources that it needs.
+            node_config.preemptible: |-
+                - (Optional) A boolean that represents whether or not the underlying node VMs
+                are preemptible. See the official documentation
+                for more information. Defaults to false.
+            node_config.sandbox_config: |-
+                - (Optional, Beta) GKE Sandbox configuration. When enabling this feature you must specify image_type = "COS_CONTAINERD" and node_version = "1.12.7-gke.17" or later to use it.
+                Structure is documented below.
+            node_config.service_account: |-
+                - (Optional) The service account to be used by the Node VMs.
+                If not specified, the "default" service account is used.
+            node_config.shielded_instance_config: '- (Optional) Shielded Instance options. Structure is documented below.'
+            node_config.spot: |-
+                - (Optional, Beta) A boolean
+                that represents whether the underlying node VMs are spot. See the official documentation
+                for more information. Defaults to false.
+            node_config.tags: |-
+                - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
+                valid sources or targets for network firewalls.
+            node_config.taint: |-
+                - (Optional) A list of Kubernetes taints
+                to apply to nodes. GKE's API can only set this field on cluster creation.
+                However, GKE will add taints to your nodes if you enable certain features such
+                as GPUs. If this field is set, any diffs on this field will cause Terraform to
+                recreate the underlying resource. Taint values can be updated safely in
+                Kubernetes (eg. through kubectl), and it's recommended that you do not use
+                this field to manage taints. If you do, lifecycle.ignore_changes is
+                recommended. Structure is documented below.
+            node_config.workload_metadata_config: |-
+                - (Optional) Metadata configuration to expose to workloads on the node pool.
+                Structure is documented below.
+            node_locations: |-
+                - (Optional) The list of zones in which the cluster's nodes
+                are located. Nodes must be in the region of their regional cluster or in the
+                same region as their cluster's zone for zonal clusters. If this is specified for
+                a zonal cluster, omit the cluster's zone.
+            node_pool: |-
+                - (Optional) List of node pools associated with this cluster.
+                See google_container_node_pool for schema.
+                Warning: node pools defined inside a cluster can't be changed (or added/removed) after
+                cluster creation without deleting and recreating the entire cluster. Unless you absolutely need the ability
+                to say "these are the only node pools associated with this cluster", use the
+                google_container_node_pool resource instead of this property.
+            node_version: |-
+                - (Optional) The Kubernetes version on the nodes. Must either be unset
+                or set to the same value as min_master_version on create. Defaults to the default
+                version set by GKE which is not necessarily the latest version. This only affects
+                nodes in the default node pool. While a fuzzy version can be specified, it's
+                recommended that you specify explicit versions as Terraform will see spurious diffs
+                when fuzzy versions are used. See the google_container_engine_versions data source's
+                version_prefix field to approximate fuzzy versions in a Terraform-compatible way.
+                To update nodes in other node pools, use the version attribute on the node pool.
+            notification_config: '- (Optional, Beta) Configuration for the cluster upgrade notifications feature. Structure is documented below.'
+            notification_config.pubsub: (Required) - The pubsub config for the cluster's upgrade notifications.
+            notification_config.pubsub.enabled: (Required) - Whether or not the notification config is enabled
+            notification_config.pubsub.topic: '(Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: projects/{project}/topics/{topic}.'
+            pod_security_policy_config: |-
+                - (Optional, Beta) Configuration for the
+                PodSecurityPolicy feature.
+                Structure is documented below.
+            pod_security_policy_config.enabled: |-
+                (Required) - Enable the PodSecurityPolicy controller for this cluster.
+                If enabled, pods must be valid under a PodSecurityPolicy to be created.
+            private_cluster_config: |-
+                - (Optional) Configuration for private clusters,
+                clusters with private nodes. Structure is documented below.
+            private_cluster_config.enable_private_endpoint: |-
+                (Optional) - When true, the cluster's private
+                endpoint is used as the cluster endpoint and access through the public endpoint
+                is disabled. When false, either endpoint can be used. This field only applies
+                to private clusters, when enable_private_nodes is true.
+            private_cluster_config.enable_private_nodes: |-
+                (Optional) - Enables the private cluster feature,
+                creating a private endpoint on the cluster. In a private cluster, nodes only
+                have RFC 1918 private addresses and communicate with the master's private
+                endpoint via private networking.
+            private_cluster_config.master_global_access_config: |-
+                (Optional) - Controls cluster master global
+                access settings. If unset, Terraform will no longer manage this field and will
+                not modify the previously-set value. Structure is documented below.
+            private_cluster_config.master_global_access_config.enabled: |-
+                (Optional) - Whether the cluster master is accessible globally or
+                not.
+            private_cluster_config.master_ipv4_cidr_block: |-
+                (Optional) - The IP range in CIDR notation to use for
+                the hosted master network. This range will be used for assigning private IP
+                addresses to the cluster master(s) and the ILB VIP. This range must not overlap
+                with any other ranges in use within the cluster's network, and it must be a /28
+                subnet. See Private Cluster Limitations
+                for more details. This field only applies to private clusters, when
+                enable_private_nodes is true.
+            private_cluster_config.peering_name: '- The name of the peering between this cluster and the Google owned VPC.'
+            private_cluster_config.private_endpoint: '- The internal IP address of this cluster''s master endpoint.'
+            private_cluster_config.public_endpoint: '- The external IP address of this cluster''s master endpoint.'
+            private_ipv6_google_access: |-
+                - (Optional)
+                The desired state of IPv6 connectivity to Google Services. By default, no private IPv6 access to or from Google Services (all access will be via IPv4).
+            project: |-
+                - (Optional) The ID of the project in which the resource belongs. If it
+                is not provided, the provider project is used.
+            release_channel: |-
+                - (Optional)
+                Configuration options for the Release channel
+                feature, which provide more control over automatic upgrades of your GKE clusters.
+                When updating this field, GKE imposes specific version requirements. See
+                Selecting a new release channel
+                for more details; the google_container_engine_versions datasource can provide
+                the default version for a channel. Note that removing the release_channel
+                field from your config will cause Terraform to stop managing your cluster's
+                release channel, but will not unenroll it. Instead, use the "UNSPECIFIED"
+                channel. Structure is documented below.
+            release_channel.channel: |-
+                - (Required) The selected release channel.
+                Accepted values are:
+            remove_default_node_pool: |-
+                - (Optional) If true, deletes the default node
+                pool upon cluster creation. If you're using google_container_node_pool
+                resources with no default node pool, this should be set to true, alongside
+                setting initial_node_count to at least 1.
+            resource_labels: '- (Optional) The GCE resource labels (a map of key/value pairs) to be applied to the cluster.'
+            resource_limits.maximum: '- (Optional) Maximum amount of the resource in the cluster.'
+            resource_limits.minimum: '- (Optional) Minimum amount of the resource in the cluster.'
+            resource_limits.resource_type: |-
+                - (Required) The type of the resource. For example, cpu and
+                memory.  See the guide to using Node Auto-Provisioning
+                for a list of types.
+            resource_usage_export_config: |-
+                - (Optional) Configuration for the
+                ResourceUsageExportConfig feature.
+                Structure is documented below.
+            resource_usage_export_config.bigquery_destination: (Required) - Parameters for using BigQuery as the destination of resource usage export.
+            resource_usage_export_config.bigquery_destination.dataset_id: '(Required) - The ID of a BigQuery Dataset. For Example:'
+            resource_usage_export_config.enable_network_egress_metering: |-
+                (Optional) - Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created
+                in the cluster to meter network egress traffic.
+            resource_usage_export_config.enable_resource_consumption_metering: |-
+                (Optional) - Whether to enable resource
+                consumption metering on this cluster. When enabled, a table will be created in
+                the resource export BigQuery dataset to store resource consumption data. The
+                resulting table can be joined with the resource usage table or with BigQuery
+                billing export. Defaults to true.
+            sandbox_config.sandbox_type: |-
+                (Required) Which sandbox to use for pods in the node pool.
+                Accepted values are:
+            shielded_instance_config.enable_integrity_monitoring: (Optional) - Defines if the instance has integrity monitoring enabled.
+            shielded_instance_config.enable_secure_boot: (Optional) - Defines if the instance has Secure Boot enabled.
+            subnetwork: |-
+                - (Optional) The name or self_link of the Google Compute Engine
+                subnetwork in which the cluster's instances are launched.
+            taint.effect: (Required) Effect for taint. Accepted values are NO_SCHEDULE, PREFER_NO_SCHEDULE, and NO_EXECUTE.
+            taint.key: (Required) Key for taint.
+            taint.value: (Required) Value for taint.
+            vertical_pod_autoscaling: |-
+                - (Optional, Beta)
+                Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it.
+                Structure is documented below.
+            vertical_pod_autoscaling.enabled: (Required) - Enables vertical pod autoscaling
+            workload_identity_config: |-
+                - (Optional)
+                Workload Identity allows Kubernetes service accounts to act as a user-managed
+                Google IAM Service Account.
+                Structure is documented below.
+            workload_identity_config.workload_pool: (Optional) - The workload pool to attach all Kubernetes service accounts to.
+            workload_metadata_config.mode: |-
+                (Required) How to expose the node metadata to the workload running on the node.
+                Accepted values are:
+        importStatements: []
+    google_storage_bucket:
+        subCategory: Cloud Storage
+        description: Creates a new bucket in Google Cloud Storage.
+        name: google_storage_bucket
+        title: google_storage_bucket
+        examples:
+            - name: static-site
+              manifest: |-
+                {
+                  "cors": [
+                    {
+                      "max_age_seconds": 3600,
+                      "method": [
+                        "GET",
+                        "HEAD",
+                        "PUT",
+                        "POST",
+                        "DELETE"
+                      ],
+                      "origin": [
+                        "http://image-store.com"
+                      ],
+                      "response_header": [
+                        "*"
+                      ]
+                    }
+                  ],
+                  "force_destroy": true,
+                  "location": "EU",
+                  "name": "image-store.com",
+                  "uniform_bucket_level_access": true,
+                  "website": [
+                    {
+                      "main_page_suffix": "index.html",
+                      "not_found_page": "404.html"
+                    }
+                  ]
+                }
+            - name: auto-expire
+              manifest: |-
+                {
+                  "force_destroy": true,
+                  "lifecycle_rule": [
+                    {
+                      "action": [
+                        {
+                          "type": "Delete"
+                        }
+                      ],
+                      "condition": [
+                        {
+                          "age": 3
+                        }
+                      ]
+                    }
+                  ],
+                  "location": "US",
+                  "name": "auto-expiring-bucket"
+                }
+        argumentDocs:
+            action.storage_class: '- (Required if action type is SetStorageClass) The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.'
+            action.type: '- The type of the action of this Lifecycle Rule. Supported values include: Delete and SetStorageClass.'
+            condition.age: '- (Optional) Minimum age of an object in days to satisfy this condition.'
+            condition.created_before: '- (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when an object is created before midnight of the specified date in UTC.'
+            condition.custom_time_before: '- (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.'
+            condition.days_since_custom_time: "- (Optional)\tDays since the date set in the customTime metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the customTime."
+            condition.days_since_noncurrent_time: '- (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object.'
+            condition.matches_storage_class: '- (Optional) Storage Class of objects to satisfy this condition. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE, DURABLE_REDUCED_AVAILABILITY.'
+            condition.noncurrent_time_before: '- (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. 2017-06-13) when the object became nonconcurrent.'
+            condition.num_newer_versions: '- (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.'
+            condition.with_state: '- (Optional) Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: "LIVE", "ARCHIVED", "ANY".'
+            cors: '- (Optional) The bucket''s Cross-Origin Resource Sharing (CORS) configuration. Multiple blocks of this type are permitted. Structure is documented below.'
+            cors.max_age_seconds: '- (Optional) The value, in seconds, to return in the Access-Control-Max-Age header used in preflight responses.'
+            cors.method: '- (Optional) The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list of methods, and means "any method".'
+            cors.origin: '- (Optional) The list of Origins eligible to receive CORS response headers. Note: "*" is permitted in the list of origins, and means "any Origin".'
+            cors.response_header: '- (Optional) The list of HTTP headers other than the simple response headers to give permission for the user-agent to share across domains.'
+            default_event_based_hold: '- (Optional) Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.'
+            encryption: '- (Optional) The bucket''s encryption configuration. Structure is documented below.'
+            encryption.create: '- Default is 4 minutes.'
+            encryption.default_kms_key_name: |-
+                : The id of a Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no encryption method is specified.
+                You must pay attention to whether the crypto key is available in the location that this bucket is created in.
+                See the docs for more details.
+            encryption.read: '- Default is 4 minutes.'
+            encryption.self_link: '- The URI of the created resource.'
+            encryption.update: '- Default is 4 minutes.'
+            encryption.url: '- The base URL of the bucket, in the format gs://<bucket-name>.'
+            force_destroy: |-
+                - (Optional, Default: false) When deleting a bucket, this
+                boolean option will delete all contained objects. If you try to delete a
+                bucket that contains objects, Terraform will fail that run.
+            labels: '- (Optional) A map of key/value label pairs to assign to the bucket.'
+            lifecycle_rule: '- (Optional) The bucket''s Lifecycle Rules configuration. Multiple blocks of this type are permitted. Structure is documented below.'
+            lifecycle_rule.action: '- (Required) The Lifecycle Rule''s action configuration. A single block of this type is supported. Structure is documented below.'
+            lifecycle_rule.condition: '- (Required) The Lifecycle Rule''s condition configuration. A single block of this type is supported. Structure is documented below.'
+            location: '- (Required) The GCS location'
+            logging: '- (Optional) The bucket''s Access & Storage Logs configuration. Structure is documented below.'
+            logging.log_bucket: '- (Required) The bucket that will receive log objects.'
+            logging.log_object_prefix: |-
+                - (Optional, Computed) The object prefix for log objects. If it's not provided,
+                by default GCS sets this to this bucket's name.
+            name: '- (Required) The name of the bucket.'
+            project: |-
+                - (Optional) The ID of the project in which the resource belongs. If it
+                is not provided, the provider project is used.
+            requester_pays: '- (Optional, Default: false) Enables Requester Pays on a storage bucket.'
+            retention_policy: '- (Optional) Configuration of the bucket''s data retention policy for how long objects in the bucket should be retained. Structure is documented below.'
+            retention_policy.is_locked: '- (Optional) If set to true, the bucket will be locked and permanently restrict edits to the bucket''s retention policy.  Caution: Locking a bucket is an irreversible action.'
+            retention_policy.retention_period: '- (Required) The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 2,147,483,647 seconds.'
+            storage_class: '- (Optional, Default: ''STANDARD'') The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.'
+            uniform_bucket_level_access: '- (Optional, Default: false) Enables Uniform bucket-level access access to a bucket.'
+            versioning: '- (Optional) The bucket''s Versioning configuration.  Structure is documented below.'
+            versioning.enabled: '- (Required) While set to true, versioning is fully enabled for this bucket.'
+            website: '- (Optional) Configuration if the bucket acts as a website. Structure is documented below.'
+            website.main_page_suffix: |-
+                - (Optional) Behaves as the bucket's directory index where
+                missing objects are treated as potential directories.
+            website.not_found_page: |-
+                - (Optional) The custom object to return when a requested
+                resource is not found.
+        importStatements: []


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/official-providers/issues/536

This PR proposes new heuristics in the Terraform provider metadata scraper so that the field (Terraform argument & attribute) names under the `argumentDocs` node will be hierarchical. For example, in the context of https://registry.terraform.io/providers/hashicorp/aws/4.15.1/docs/resources/s3_bucket, instead of generating the following section of the provider metadata file:
```yaml
argumentDocs:
            ...
            replication_configuration: |
                 A configuration of replication configuration. See Replication Configuration below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_replication_configuration instead.
            role: ' The ARN of the IAM role for Amazon S3 to assume when replicating the objects.'
            rules: ' Specifies the rules managing the replication .'
            delete_marker_replication_status: ' Whether delete markers are replicated. The only valid value is Enabled. To disable, omit this argument. This argument is only valid with V2 replication configurations .'
            destination: ' Specifies the destination for the rule .'
```
, which is ambiguous (e.g., there may be multiple `destination` arguments/attributes under different paths: `a.destination`, `b.destination`, etc.)
, we now generate:

```yaml
argumentDocs:
            ...
            replication_configuration: |
                 A configuration of replication configuration. See Replication Configuration below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_replication_configuration instead.
            replication_configuration.role: ' The ARN of the IAM role for Amazon S3 to assume when replicating the objects.'
            replication_configuration.rules: ' Specifies the rules managing the replication .'
            replication_configuration.rules.delete_marker_replication_status: ' Whether delete markers are replicated. The only valid value is Enabled. To disable, omit this argument. This argument is only valid with V2 replication configurations .'
            replication_configuration.rules.destination: ' Specifies the destination for the rule .'
            replication_configuration.rules.filter: ' Filter that identifies subset of objects to which the replication rule applies .'
            replication_configuration.rules.filter.prefix: ' Object keyname prefix that identifies subset of objects to which the rule applies. Must be less than or equal to 1024 characters in length.'
            replication_configuration.rules.filter.tags: |
                  A map of tags that identifies subset of objects to which the rule applies.
                The rule applies only to objects having all the tags in its tagset.
            replication_configuration.rules.id: ' Unique identifier for the rule. Must be less than or equal to 255 characters in length.'
            replication_configuration.rules.prefix: ' Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.'
            replication_configuration.rules.priority: ' The priority associated with the rule. Priority should only be set if filter is configured. If not provided, defaults to 0. Priority must be unique between multiple rules.'
            replication_configuration.rules.source_selection_criteria: ' Specifies special object selection criteria .'
            replication_configuration.rules.status: ' The status of the rule. Either Enabled or Disabled. The rule is ignored if status is not Enabled.
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested with the AWS S3 bucket as follows:

```yaml
name: hashicorp/terraform-provider-aws
resources:
    aws_s3_bucket:
        subCategory: S3 (Simple Storage)
        description: Provides a S3 bucket resource.
        name: aws_s3_bucket
        title: aws_s3_bucket
        examples:
            - name: b
              manifest: |-
                {
                  "bucket": "my-tf-test-bucket",
                  "tags": {
                    "Environment": "Dev",
                    "Name": "My bucket"
                  }
                }
              dependencies:
                aws_s3_bucket_acl.example: |-
                    {
                      "acl": "private",
                      "bucket": "${aws_s3_bucket.b.id}"
                    }
            - name: b
              manifest: |-
                {
                  "acl": "public-read",
                  "bucket": "s3-website-test.hashicorp.com",
                  "policy": "${file(\"policy.json\")}",
                  "website": [
                    {
                      "error_document": "error.html",
                      "index_document": "index.html",
                      "routing_rules": "[{\n    \"Condition\": {\n        \"KeyPrefixEquals\": \"docs/\"\n    },\n    \"Redirect\": {\n        \"ReplaceKeyPrefixWith\": \"documents/\"\n    }\n}]\n"
                    }
                  ]
                }
            - name: b
              manifest: |-
                {
                  "acl": "public-read",
                  "bucket": "s3-website-test.hashicorp.com",
                  "cors_rule": [
                    {
                      "allowed_headers": [
                        "*"
                      ],
                      "allowed_methods": [
                        "PUT",
                        "POST"
                      ],
                      "allowed_origins": [
                        "https://s3-website-test.hashicorp.com"
                      ],
                      "expose_headers": [
                        "ETag"
                      ],
                      "max_age_seconds": 3000
                    }
                  ]
                }
            - name: b
              manifest: |-
                {
                  "acl": "private",
                  "bucket": "my-tf-test-bucket",
                  "versioning": [
                    {
                      "enabled": true
                    }
                  ]
                }
            - name: log_bucket
              manifest: |-
                {
                  "acl": "log-delivery-write",
                  "bucket": "my-tf-log-bucket"
                }
            - name: b
              manifest: |-
                {
                  "acl": "private",
                  "bucket": "my-tf-test-bucket",
                  "logging": [
                    {
                      "target_bucket": "${aws_s3_bucket.log_bucket.id}",
                      "target_prefix": "log/"
                    }
                  ]
                }
              references:
                logging.target_bucket: aws_s3_bucket.log_bucket.id
            - name: bucket
              manifest: |-
                {
                  "acl": "private",
                  "bucket": "my-bucket",
                  "lifecycle_rule": [
                    {
                      "enabled": true,
                      "expiration": [
                        {
                          "days": 90
                        }
                      ],
                      "id": "log",
                      "prefix": "log/",
                      "tags": {
                        "autoclean": "true",
                        "rule": "log"
                      },
                      "transition": [
                        {
                          "days": 30,
                          "storage_class": "STANDARD_IA"
                        },
                        {
                          "days": 60,
                          "storage_class": "GLACIER"
                        }
                      ]
                    },
                    {
                      "enabled": true,
                      "expiration": [
                        {
                          "date": "2016-01-12"
                        }
                      ],
                      "id": "tmp",
                      "prefix": "tmp/"
                    }
                  ]
                }
            - name: versioning_bucket
              manifest: |-
                {
                  "acl": "private",
                  "bucket": "my-versioning-bucket",
                  "lifecycle_rule": [
                    {
                      "enabled": true,
                      "noncurrent_version_expiration": [
                        {
                          "days": 90
                        }
                      ],
                      "noncurrent_version_transition": [
                        {
                          "days": 30,
                          "storage_class": "STANDARD_IA"
                        },
                        {
                          "days": 60,
                          "storage_class": "GLACIER"
                        }
                      ],
                      "prefix": "config/"
                    }
                  ],
                  "versioning": [
                    {
                      "enabled": true
                    }
                  ]
                }
            - name: example
              manifest: |-
                {
                  "bucket": "my-tf-example-bucket",
                  "object_lock_configuration": [
                    {
                      "object_lock_enabled": "Enabled",
                      "rule": [
                        {
                          "default_retention": [
                            {
                              "days": 5,
                              "mode": "COMPLIANCE"
                            }
                          ]
                        }
                      ]
                    }
                  ]
                }
            - name: destination
              manifest: |-
                {
                  "bucket": "tf-test-bucket-destination-12345",
                  "versioning": [
                    {
                      "enabled": true
                    }
                  ]
                }
              dependencies:
                aws_iam_policy.replication: |-
                    {
                      "name": "tf-iam-role-policy-replication-12345",
                      "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"s3:GetReplicationConfiguration\",\n        \"s3:ListBucket\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"${aws_s3_bucket.source.arn}\"\n      ]\n    },\n    {\n      \"Action\": [\n        \"s3:GetObjectVersionForReplication\",\n        \"s3:GetObjectVersionAcl\",\n         \"s3:GetObjectVersionTagging\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"${aws_s3_bucket.source.arn}/*\"\n      ]\n    },\n    {\n      \"Action\": [\n        \"s3:ReplicateObject\",\n        \"s3:ReplicateDelete\",\n        \"s3:ReplicateTags\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"${aws_s3_bucket.destination.arn}/*\"\n    }\n  ]\n}\n"
                    }
                aws_iam_role.replication: |-
                    {
                      "assume_role_policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"s3.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n",
                      "name": "tf-iam-role-replication-12345"
                    }
                aws_iam_role_policy_attachment.replication: |-
                    {
                      "policy_arn": "${aws_iam_policy.replication.arn}",
                      "role": "${aws_iam_role.replication.name}"
                    }
            - name: source
              manifest: |-
                {
                  "acl": "private",
                  "bucket": "tf-test-bucket-source-12345",
                  "provider": "${aws.central}",
                  "replication_configuration": [
                    {
                      "role": "${aws_iam_role.replication.arn}",
                      "rules": [
                        {
                          "destination": [
                            {
                              "bucket": "${aws_s3_bucket.destination.arn}",
                              "metrics": [
                                {
                                  "minutes": 15,
                                  "status": "Enabled"
                                }
                              ],
                              "replication_time": [
                                {
                                  "minutes": 15,
                                  "status": "Enabled"
                                }
                              ],
                              "storage_class": "STANDARD"
                            }
                          ],
                          "filter": [
                            {
                              "tags": {}
                            }
                          ],
                          "id": "foobar",
                          "status": "Enabled"
                        }
                      ]
                    }
                  ],
                  "versioning": [
                    {
                      "enabled": true
                    }
                  ]
                }
              references:
                provider: aws.central
                replication_configuration.role: aws_iam_role.replication.arn
                replication_configuration.rules.destination.bucket: aws_s3_bucket.destination.arn
              dependencies:
                aws_iam_policy.replication: |-
                    {
                      "name": "tf-iam-role-policy-replication-12345",
                      "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"s3:GetReplicationConfiguration\",\n        \"s3:ListBucket\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"${aws_s3_bucket.source.arn}\"\n      ]\n    },\n    {\n      \"Action\": [\n        \"s3:GetObjectVersionForReplication\",\n        \"s3:GetObjectVersionAcl\",\n         \"s3:GetObjectVersionTagging\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"${aws_s3_bucket.source.arn}/*\"\n      ]\n    },\n    {\n      \"Action\": [\n        \"s3:ReplicateObject\",\n        \"s3:ReplicateDelete\",\n        \"s3:ReplicateTags\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"${aws_s3_bucket.destination.arn}/*\"\n    }\n  ]\n}\n"
                    }
                aws_iam_role.replication: |-
                    {
                      "assume_role_policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"s3.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n",
                      "name": "tf-iam-role-replication-12345"
                    }
                aws_iam_role_policy_attachment.replication: |-
                    {
                      "policy_arn": "${aws_iam_policy.replication.arn}",
                      "role": "${aws_iam_role.replication.name}"
                    }
            - name: mybucket
              manifest: |-
                {
                  "bucket": "mybucket",
                  "server_side_encryption_configuration": [
                    {
                      "rule": [
                        {
                          "apply_server_side_encryption_by_default": [
                            {
                              "kms_master_key_id": "${aws_kms_key.mykey.arn}",
                              "sse_algorithm": "aws:kms"
                            }
                          ]
                        }
                      ]
                    }
                  ]
                }
              references:
                server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id: aws_kms_key.mykey.arn
              dependencies:
                aws_kms_key.mykey: |-
                    {
                      "deletion_window_in_days": 10,
                      "description": "This key is used to encrypt bucket objects"
                    }
            - name: bucket
              manifest: |-
                {
                  "bucket": "mybucket",
                  "grant": [
                    {
                      "id": "${data.aws_canonical_user_id.current_user.id}",
                      "permissions": [
                        "FULL_CONTROL"
                      ],
                      "type": "CanonicalUser"
                    },
                    {
                      "permissions": [
                        "READ_ACP",
                        "WRITE"
                      ],
                      "type": "Group",
                      "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
                    }
                  ]
                }
              references:
                grant.id: data.aws_canonical_user_id.current_user.id
        argumentDocs:
            acceleration_status: |-
                Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. Cannot be used in cn-north-1 or us-gov-west-1. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_accelerate_configuration instead.
            acl: The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, and log-delivery-write. Defaults to private.  Conflicts with grant. Terraform will only perform drift detection if a configuration value is provided. Use the resource aws_s3_bucket_acl instead.
            bucket: The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules may be found here.
            bucket_prefix: Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules may be found here.
            cors_rule: A rule of Cross-Origin Resource Sharing. See CORS rule below for details. Terraform will only perform drift detection if a configuration value is provided. Use the resource aws_s3_bucket_cors_configuration instead.
            cors_rule.allowed_headers: List of headers allowed.
            cors_rule.allowed_methods: One or more HTTP methods that you allow the origin to execute. Can be GET, PUT, POST, DELETE or HEAD.
            cors_rule.allowed_origins: One or more origins you want customers to be able to access the bucket from.
            cors_rule.expose_headers: One or more headers in the response that you want customers to be able to access from their applications .
            cors_rule.max_age_seconds: Specifies time in seconds that browser can cache the response for a preflight request.
            destination.access_control_translation: Specifies the overrides to use for object owners on replication. Must be used in conjunction with account_id owner override configuration.
            destination.account_id: The Account ID to use for overriding the object owner on replication. Must be used in conjunction with access_control_translation override configuration.
            destination.bucket: The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
            destination.metrics: Enables replication metrics  .
            destination.replica_kms_key_id: |-
                Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
                sse_kms_encrypted_objects source selection criteria.
            destination.replication_time: Enables S3 Replication Time Control  .
            destination.replication_time.minutes: Threshold within which objects are to be replicated. The only valid value is 15.
            destination.replication_time.status: The status of RTC. Either Enabled or Disabled.
            destination.storage_class: The storage class used to store the object. By default, Amazon S3 uses the storage class of the source object to create the object replica.
            force_destroy: A boolean that indicates all objects  should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.
            grant: An ACL policy grant. See Grant below for details. Conflicts with acl. Terraform will only perform drift detection if a configuration value is provided. Use the resource aws_s3_bucket_acl instead.
            grant.id: Canonical user id to grant for. Used only when type is CanonicalUser.
            grant.permissions: List of permissions to apply for grantee. Valid values are READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL.
            grant.type: Type of grantee to apply for. Valid values are CanonicalUser and Group. AmazonCustomerByEmail is not supported.
            grant.uri: Uri address to grant for. Used only when type is Group.
            lifecycle_rule: |-
                A configuration of object lifecycle management. See Lifecycle Rule below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_lifecycle_configuration instead.
            lifecycle_rule.abort_incomplete_multipart_upload_days: Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
            lifecycle_rule.enabled: Specifies lifecycle rule status.
            lifecycle_rule.expiration: Specifies a period in the object's expire. See Expiration below for details.
            lifecycle_rule.expiration.date: Specifies the date after which you want the corresponding action to take effect.
            lifecycle_rule.expiration.days: Specifies the number of days after object creation when the specific rule action takes effect.
            lifecycle_rule.expiration.expired_object_delete_marker: On a versioned bucket , you can add this element in the lifecycle configuration to direct Amazon S3 to delete expired object delete markers. This cannot be specified with Days or Date in a Lifecycle Expiration Policy.
            lifecycle_rule.id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
            lifecycle_rule.noncurrent_version_expiration: Specifies when noncurrent object versions expire. See Noncurrent Version Expiration below for details.
            lifecycle_rule.noncurrent_version_transition: Specifies when noncurrent object versions transitions. See Noncurrent Version Transition below for details.
            lifecycle_rule.prefix: Object key prefix identifying one or more objects to which the rule applies.
            lifecycle_rule.tags: Specifies object tags key and value.
            lifecycle_rule.transition: Specifies a period in the object's transitions. See Transition below for details.
            logging: |-
                A configuration of S3 bucket logging parameters. See Logging below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_logging instead.
            logging.target_bucket: The name of the bucket that will receive the log objects.
            logging.target_prefix: To specify a key prefix for log objects.
            metrics.minutes: Threshold within which objects are to be replicated. The only valid value is 15.
            metrics.status: The status of replication metrics. Either Enabled or Disabled.
            noncurrent_version_expiration.storage_class: Specifies the Amazon S3 storage class to which you want the object to transition.
            object_lock_configuration: |-
                A configuration of S3 object locking. See Object Lock Configuration below for details.
                Terraform wil only perform drift detection if a configuration value is provided.
                Use the object_lock_enabled parameter and the resource aws_s3_bucket_object_lock_configuration instead.
            object_lock_configuration.object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid value is Enabled. Use the top-level argument object_lock_enabled instead.
            object_lock_configuration.rule: The Object Lock rule in place for this bucket .
            object_lock_configuration.rule.default_retention: The default retention period that you want to apply to new objects placed in this bucket .
            object_lock_configuration.rule.default_retention.days: The number of days that you want to specify for the default retention period.
            object_lock_configuration.rule.default_retention.mode: The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are GOVERNANCE and COMPLIANCE.
            object_lock_configuration.rule.default_retention.years: The number of years that you want to specify for the default retention period.
            object_lock_enabled: Indicates whether this bucket has an Object Lock configuration enabled. Valid values are true or false.
            policy: |-
                A valid bucket policy JSON document. Note that if the policy document is not specific enough , Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.
                Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_policy instead.
            replication_configuration: |-
                A configuration of replication configuration. See Replication Configuration below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_replication_configuration instead.
            replication_configuration.role: The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
            replication_configuration.rules: Specifies the rules managing the replication .
            replication_configuration.rules.delete_marker_replication_status: Whether delete markers are replicated. The only valid value is Enabled. To disable, omit this argument. This argument is only valid with V2 replication configurations .
            replication_configuration.rules.destination: Specifies the destination for the rule .
            replication_configuration.rules.filter: Filter that identifies subset of objects to which the replication rule applies .
            replication_configuration.rules.filter.prefix: Object keyname prefix that identifies subset of objects to which the rule applies. Must be less than or equal to 1024 characters in length.
            replication_configuration.rules.filter.tags: |-
                A map of tags that identifies subset of objects to which the rule applies.
                The rule applies only to objects having all the tags in its tagset.
            replication_configuration.rules.id: Unique identifier for the rule. Must be less than or equal to 255 characters in length.
            replication_configuration.rules.prefix: Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
            replication_configuration.rules.priority: The priority associated with the rule. Priority should only be set if filter is configured. If not provided, defaults to 0. Priority must be unique between multiple rules.
            replication_configuration.rules.source_selection_criteria: Specifies special object selection criteria .
            replication_configuration.rules.status: The status of the rule. Either Enabled or Disabled. The rule is ignored if status is not Enabled.
            request_payer: |-
                Specifies who should bear the cost of Amazon S3 data transfer.
                Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer.
                See Requester Pays Buckets developer guide for more information.
                Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_request_payment_configuration instead.
            server_side_encryption_configuration: |-
                A configuration of server-side encryption configuration. See Server Side Encryption Configuration below for details.
                Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_server_side_encryption_configuration instead.
            server_side_encryption_configuration.rule: A single object for server-side encryption by default configuration.
            server_side_encryption_configuration.rule.apply_server_side_encryption_by_default: A single object for setting server-side encryption by default.
            server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id: The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms.
            server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm: The server-side encryption algorithm to use. Valid values are AES256 and aws:kms
            server_side_encryption_configuration.rule.bucket_key_enabled: Whether or not to use Amazon S3 Bucket Keys for SSE-KMS.
            source_selection_criteria.sse_kms_encrypted_objects: |-
                Match SSE-KMS encrypted objects . If specified, replica_kms_key_id
                in destination must be specified as well.
            source_selection_criteria.sse_kms_encrypted_objects.enabled: Boolean which indicates if this criteria is enabled.
            tags: A map of tags to assign to the bucket. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
            transition.date: Specifies the date after which you want the corresponding action to take effect.
            transition.days: Specifies the number of days after object creation when the specific rule action takes effect.
            transition.storage_class: Specifies the Amazon S3 storage class to which you want the object to transition.
            versioning: A configuration of the S3 bucket versioning state. See Versioning below for details. Terraform will only perform drift detection if a configuration value is provided. Use the resource aws_s3_bucket_versioning instead.
            versioning.enabled: Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
            versioning.mfa_delete: Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
            website: |-
                A configuration of the S3 bucket website. See Website below for details. Terraform will only perform drift detection if a configuration value is provided.
                Use the resource aws_s3_bucket_website_configuration instead.
            website.arn: The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.
            website.bucket_domain_name: The bucket domain name. Will be of format bucketname.s3.amazonaws.com.
            website.bucket_regional_domain_name: 'The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.'
            website.error_document: An absolute path to the document to return in case of a 4XX error.
            website.hosted_zone_id: The Route 53 Hosted Zone ID for this bucket's region.
            website.id: The name of the bucket.
            website.index_document: Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders.
            website.redirect_all_requests_to: A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol  to use when redirecting requests. The default is the protocol that is used in the original request.
            website.region: The AWS region this bucket resides in.
            website.routing_rules: |-
                A json array containing routing rules
                describing redirect behavior and when redirects are applied.
            website.tags_all: A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block.
            website.website_domain: The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
            website.website_endpoint: The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
        importStatements: []
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
