### PR TITLE
terraform: do not fill the empty tfstate if the resource is being deleted

### DIFF
--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -135,7 +135,9 @@ func (fp *FileProducer) WriteMainTF() error {
 
 // EnsureTFState writes the Terraform state that should exist in the filesystem
 // to start any Terraform operation.
-func (fp *FileProducer) EnsureTFState(ctx context.Context) error {
+func (fp *FileProducer) EnsureTFState(ctx context.Context) error { //nolint:gocyclo
+	// TODO(muvaf): Reduce the cyclomatic complexity by separating the attributes
+	// generation into its own function/interface.
 	empty, err := fp.isStateEmpty()
 	if err != nil {
 		return errors.Wrap(err, errCheckIfStateEmpty)


### PR DESCRIPTION
### Description of your changes

Details are in https://github.com/upbound/upjet/issues/100 but the gist is that we should not fill the tfstate during deletion since that's how TF signals that the destroy operation succeeded.

Fixes https://github.com/upbound/upjet/issues/100

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

In my local, with GCP KMS KeyRing.
```
make uptest-local PROVIDER_NAME=provider-gcp EXAMPLE_LIST=$(find provider-gcp/examples/kms/*.yaml | tr '\n' ',')
```

All tests have passed in three cloud providers. See status checks of this commit https://github.com/upbound/official-providers/pull/779/commits/aac5fd7a349441d5d361467a4cf8c00961dce3cd

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
