### PR TITLE
Add server-side apply merge strategy markers

### DIFF
--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -152,7 +152,9 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 	f.FieldType = fieldType
 	f.InitType = initType
 
-	AddServerSideApplyMarkers(f)
+	if !sch.Sensitive {
+		AddServerSideApplyMarkers(f)
+	}
 
 	return f, nil
 }
@@ -173,7 +175,7 @@ func AddServerSideApplyMarkers(f *Field) {
 	case schema.TypeSet:
 		if es, ok := f.Schema.Elem.(*schema.Schema); ok {
 			switch es.Type { //nolint:exhaustive
-			// We assume scalar types can be granular maps.
+			// We assume scalar types can be granular sets.
 			case schema.TypeString, schema.TypeBool, schema.TypeInt, schema.TypeFloat:
 				f.Comment.ServerSideApplyOptions.ListType = ptr.To[markers.ListType](markers.ListTypeSet)
 			}

--- a/pkg/types/markers/options.go
+++ b/pkg/types/markers/options.go
@@ -9,11 +9,13 @@ type Options struct {
 	UpjetOptions
 	CrossplaneOptions
 	KubebuilderOptions
+	ServerSideApplyOptions
 }
 
 // String returns a string representation of this Options object.
 func (o Options) String() string {
 	return o.UpjetOptions.String() +
 		o.CrossplaneOptions.String() +
-		o.KubebuilderOptions.String()
+		o.KubebuilderOptions.String() +
+		o.ServerSideApplyOptions.String()
 }

--- a/pkg/types/markers/ssa.go
+++ b/pkg/types/markers/ssa.go
@@ -20,7 +20,7 @@ const (
 	// elements.
 	ListTypeSet ListType = "set"
 
-	// ListTypeSet can be granularly merged, and different managers can own
+	// ListTypeMap can be granularly merged, and different managers can own
 	// different elements in the list. The list can include only nested types
 	// (i.e. objects).
 	ListTypeMap ListType = "map"
@@ -68,19 +68,19 @@ func (o ServerSideApplyOptions) String() string {
 	m := ""
 
 	if o.ListType != nil {
-		m += fmt.Sprintf("+listType:%s\n", *o.ListType)
+		m += fmt.Sprintf("+listType=%s\n", *o.ListType)
 	}
 
 	for _, k := range o.ListMapKey {
-		m += fmt.Sprintf("+listMapKey:%s\n", k)
+		m += fmt.Sprintf("+listMapKey=%s\n", k)
 	}
 
 	if o.MapType != nil {
-		m += fmt.Sprintf("+mapType:%s\n", *o.MapType)
+		m += fmt.Sprintf("+mapType=%s\n", *o.MapType)
 	}
 
 	if o.StructType != nil {
-		m += fmt.Sprintf("+structType:%s\n", *o.StructType)
+		m += fmt.Sprintf("+structType=%s\n", *o.StructType)
 	}
 
 	return m

--- a/pkg/types/markers/ssa.go
+++ b/pkg/types/markers/ssa.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package markers
+
+import "fmt"
+
+// A ListType is a type of list.
+type ListType string
+
+// Types of lists.
+const (
+	// ListTypeAtomic means the entire list is replaced during merge. At any
+	// point in time, a single manager owns the list.
+	ListTypeAtomic ListType = "atomic"
+
+	// ListTypeSet can be granularly merged, and different managers can own
+	// different elements in the list. The list can include only scalar
+	// elements.
+	ListTypeSet ListType = "set"
+
+	// ListTypeSet can be granularly merged, and different managers can own
+	// different elements in the list. The list can include only nested types
+	// (i.e. objects).
+	ListTypeMap ListType = "map"
+)
+
+// A MapType is a type of map.
+type MapType string
+
+// Types of maps.
+const (
+	// MapTypeAtomic means that the map can only be entirely replaced by a
+	// single manager.
+	MapTypeAtomic MapType = "atomic"
+
+	// MapTypeGranular means that the map supports separate managers updating
+	// individual fields.
+	MapTypeGranular MapType = "granular"
+)
+
+// A StructType is a type of struct.
+type StructType string
+
+// Struct types.
+const (
+	// StructTypeAtomic means that the struct can only be entirely replaced by a
+	// single manager.
+	StructTypeAtomic StructType = "atomic"
+
+	// StructTypeGranular means that the struct supports separate managers
+	// updating individual fields.
+	StructTypeGranular StructType = "granular"
+)
+
+// ServerSideApplyOptions represents the server-side apply merge options that
+// upjet needs to control.
+// https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy
+type ServerSideApplyOptions struct {
+	ListType   *ListType
+	ListMapKey []string
+	MapType    *MapType
+	StructType *StructType
+}
+
+func (o ServerSideApplyOptions) String() string {
+	m := ""
+
+	if o.ListType != nil {
+		m += fmt.Sprintf("+listType:%s\n", *o.ListType)
+	}
+
+	for _, k := range o.ListMapKey {
+		m += fmt.Sprintf("+listMapKey:%s\n", k)
+	}
+
+	if o.MapType != nil {
+		m += fmt.Sprintf("+mapType:%s\n", *o.MapType)
+	}
+
+	if o.StructType != nil {
+		m += fmt.Sprintf("+structType:%s\n", *o.StructType)
+	}
+
+	return m
+}

--- a/pkg/types/markers/ssa_test.go
+++ b/pkg/types/markers/ssa_test.go
@@ -20,20 +20,20 @@ func TestServerSideApplyOptions(t *testing.T) {
 			o: ServerSideApplyOptions{
 				MapType: ptr.To[MapType](MapTypeAtomic),
 			},
-			want: "+mapType:atomic\n",
+			want: "+mapType=atomic\n",
 		},
 		"StructType": {
 			o: ServerSideApplyOptions{
 				StructType: ptr.To[StructType](StructTypeAtomic),
 			},
-			want: "+structType:atomic\n",
+			want: "+structType=atomic\n",
 		},
 		"ListType": {
 			o: ServerSideApplyOptions{
 				ListType:   ptr.To[ListType](ListTypeMap),
 				ListMapKey: []string{"name", "coolness"},
 			},
-			want: "+listType:map\n+listMapKey:name\n+listMapKey:coolness\n",
+			want: "+listType=map\n+listMapKey=name\n+listMapKey=coolness\n",
 		},
 	}
 

--- a/pkg/types/markers/ssa_test.go
+++ b/pkg/types/markers/ssa_test.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package markers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+)
+
+func TestServerSideApplyOptions(t *testing.T) {
+	cases := map[string]struct {
+		o    ServerSideApplyOptions
+		want string
+	}{
+		"MapType": {
+			o: ServerSideApplyOptions{
+				MapType: ptr.To[MapType](MapTypeAtomic),
+			},
+			want: "+mapType:atomic\n",
+		},
+		"StructType": {
+			o: ServerSideApplyOptions{
+				StructType: ptr.To[StructType](StructTypeAtomic),
+			},
+			want: "+structType:atomic\n",
+		},
+		"ListType": {
+			o: ServerSideApplyOptions{
+				ListType:   ptr.To[ListType](ListTypeMap),
+				ListMapKey: []string{"name", "coolness"},
+			},
+			want: "+listType:map\n+listMapKey:name\n+listMapKey:coolness\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.o.String()
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("o.String(): -want, +got: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes https://github.com/crossplane/upjet/issues/300 (mostly?)

This commit adds SSA merge strategy markers that allow the API server to granularly merge lists, rather than atomically replacing them. Composition functions use SSA, so this change means that a function can return only the list elements it desires (e.g. tags) and those elements will be merged into any existing elements, without replacing them.

For the moment I've only covered two cases:

* Lists that we know are sets of scalar values (generated from Terraform sets)
* Maps of scalar values (generated from Terraform maps)

I'm hopeful that in both of these cases it _should_ be possible to allow the map or set to be granularly merged, not atomically replaced.

https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md

I tried to add a case to `TestBuild`, but then noticed that it appears to be completely unaware of comments. If you'd like this tested, please give me some direction on how and where to do so.

See https://github.com/upbound/provider-aws/pull/968 for a PR generated using this change.