### PR TITLE
Fix template link in documentation

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -377,7 +377,7 @@ your provider, you can learn more about
 [testing your resources](testing-with-uptest.md) with Uptest.
 
 [Terraform GitHub provider]: https://registry.terraform.io/providers/integrations/github/latest/docs
-[upjet-provider-template]: https://github.com/crossplane/upjet-provider-template
+[upjet-provider-template]: https://github.com/upbound/upjet-provider-template
 [upbound/build]: https://github.com/upbound/build
 [github_repository]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
 [github_branch]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch


### PR DESCRIPTION
### Description of your changes

The first link needed for a beginner to start with the provider generation was broken. It now points to the updated repository location.

I have:

- [x] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
