### PR TITLE
Call the registered schema.CustomizeDiffFunc functions in the Terraform SDK-based external client

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -416,7 +416,7 @@ func getTimeoutParameters(config *config.Resource) map[string]any { //nolint:goc
 
 func (n *noForkExternal) getResourceDataDiff(tr resource.Terraformed, ctx context.Context, s *tf.InstanceState, resourceExists bool) (*tf.InstanceDiff, error) { //nolint:gocyclo
 	resourceConfig := tf.NewResourceConfigRaw(n.params)
-	instanceDiff, err := schema.InternalMap(n.config.TerraformResource.Schema).Diff(ctx, s, resourceConfig, nil, n.ts.Meta, false)
+	instanceDiff, err := schema.InternalMap(n.config.TerraformResource.Schema).Diff(ctx, s, resourceConfig, n.config.TerraformResource.CustomizeDiff, n.ts.Meta, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get *terraform.InstanceDiff")
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR starts passing the registered `schema.CustomizeDiffFunc`s to the `schema.schemaMap.Diff` function so that the available `CustomizeDiff` functions in the underlying Terraform provider are utilized. We had previously considered using these custom diff functions but we could not do so previously.

The strategy is now to start supplying the custom diff functions from the native schema by default but for the providers that we need to validate these registered functions are working as intended, we will just remove, and thus prevent, the custom diff functions from the schema.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested in https://github.com/upbound/provider-gcp/pull/424 with the BucketACL.storage` resource.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
