### PR TITLE
Ignore specific error that returned by expandWildcard function

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -107,6 +107,9 @@ func GetSensitiveAttributes(from map[string]any, mapping map[string]string) (map
 	for tf := range mapping {
 		fieldPaths, err := paved.ExpandWildcards(tf)
 		if err != nil {
+			if fieldpath.IsNotFound(err) {
+				continue
+			}
 			return nil, errors.Wrap(err, errCannotExpandWildcards)
 		}
 


### PR DESCRIPTION
### Description of your changes

Related to https://github.com/crossplane/crossplane-runtime/pull/627

The issue was observed while testing the GCP certificatemanager.Certificate resource. While trying to get the connection details of this resource, we try to read the self_managed[*].certificate_pem attribute of this resource. If the self_managed object is nil, then we observe an error:

cannot get connection details: cannot get connection details: cannot expand wildcards: cannot expand wildcards for segments: "self_managed[*].certificate_pem": "self_managed": unexpected wildcard usage'

If the value of this field is nil, then we do not want to return an error because there is nothing to read in the sensitive attribute. So, after returning a specific error from the nil case, we are handling this in Upjet by ignoring this error type.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against to the GCP certificatemanager.Certificate resource.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
