### PR TITLE
Add reference fields to the InitProvider

### DIFF
--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -351,11 +351,11 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames, add
 			f.TFTag = strings.TrimSuffix(f.TFTag, ",omitempty")
 		}
 		r.addParameterField(f, field)
-		r.addInitField(f, field, g.Package)
+		r.addInitField(f, field, g, typeNames.InitTypeName)
 	}
 
 	if f.Reference != nil {
-		r.addReferenceFields(g, typeNames.ParameterTypeName, f)
+		r.addReferenceFields(g, typeNames.ParameterTypeName, f, false)
 	}
 
 	// Note(lsviben): All fields are optional because observation fields are
@@ -401,7 +401,7 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames, add
 // an earlier step, so they cannot be included as well. Plus probably they
 // should also not change for Create and Update steps.
 func (f *Field) isInit() bool {
-	return !f.Identifier && f.Reference == nil && (f.TFTag != "-" || f.Injected)
+	return !f.Identifier && f.TFTag != "-"
 }
 
 func getDescription(s string) string {

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -401,7 +401,7 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames, add
 // an earlier step, so they cannot be included as well. Plus probably they
 // should also not change for Create and Update steps.
 func (f *Field) isInit() bool {
-	return !f.Identifier && f.TFTag != "-"
+	return !f.Identifier && (f.TFTag != "-" || f.Injected)
 }
 
 func getDescription(s string) string {


### PR DESCRIPTION
### Description of your changes

Fixes #307 

This PR supports generation of reference fields and reference resolver functions to the InitProvider.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This PR tested against to the upjet-based provider-aws

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
