### PR TITLE
Set the RawPlan for a new terraform.InstanceState returned from an observation

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -496,7 +496,7 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 			addTTR(mg)
 		}
 		mg.SetConditions(xpv1.Available())
-		stateValueMap, err := n.fromInstanceStateToJSONMap(newState)
+		stateValueMap, _, err := n.fromInstanceStateToJSONMap(newState)
 		if err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot convert instance state to JSON map")
 		}
@@ -601,12 +601,12 @@ func (n *noForkExternal) Create(ctx context.Context, mg xpresource.Managed) (man
 	}
 	n.opTracker.SetTfState(newState)
 
-	stateValueMap, err := n.fromInstanceStateToJSONMap(newState)
+	stateValueMap, _, err := n.fromInstanceStateToJSONMap(newState)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "failed to convert instance state to map")
 	}
 	if _, err := n.setExternalName(mg, stateValueMap); err != nil {
-		return managed.ExternalCreation{}, errors.Wrapf(err, "failed to set the external-name of the managed resource during create")
+		return managed.ExternalCreation{}, errors.Wrap(err, "failed to set the external-name of the managed resource during create")
 	}
 	err = mg.(resource.Terraformed).SetObservation(stateValueMap)
 	if err != nil {
@@ -655,7 +655,7 @@ func (n *noForkExternal) Update(ctx context.Context, mg xpresource.Managed) (man
 	}
 	n.opTracker.SetTfState(newState)
 
-	stateValueMap, err := n.fromInstanceStateToJSONMap(newState)
+	stateValueMap, _, err := n.fromInstanceStateToJSONMap(newState)
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
@@ -686,15 +686,15 @@ func (n *noForkExternal) Delete(ctx context.Context, _ xpresource.Managed) error
 	return nil
 }
 
-func (n *noForkExternal) fromInstanceStateToJSONMap(newState *tf.InstanceState) (map[string]interface{}, error) {
+func (n *noForkExternal) fromInstanceStateToJSONMap(newState *tf.InstanceState) (map[string]interface{}, cty.Value, error) {
 	impliedType := n.config.TerraformResource.CoreConfigSchema().ImpliedType()
 	attrsAsCtyValue, err := newState.AttrsAsObjectValue(impliedType)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not convert attrs to cty value")
+		return nil, cty.NilVal, errors.Wrap(err, "could not convert attrs to cty value")
 	}
 	stateValueMap, err := schema.StateValueToJSONMap(attrsAsCtyValue, impliedType)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not convert instance state value to JSON")
+		return nil, cty.NilVal, errors.Wrap(err, "could not convert instance state value to JSON")
 	}
-	return stateValueMap, nil
+	return stateValueMap, attrsAsCtyValue, nil
 }

--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -17,7 +17,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	tfdiag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tf "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
@@ -104,8 +104,8 @@ func getJSONMap(mg xpresource.Managed) (map[string]any, error) {
 }
 
 type Resource interface {
-	Apply(ctx context.Context, s *tf.InstanceState, d *tf.InstanceDiff, meta interface{}) (*tf.InstanceState, diag.Diagnostics)
-	RefreshWithoutUpgrade(ctx context.Context, s *tf.InstanceState, meta interface{}) (*tf.InstanceState, diag.Diagnostics)
+	Apply(ctx context.Context, s *tf.InstanceState, d *tf.InstanceDiff, meta interface{}) (*tf.InstanceState, tfdiag.Diagnostics)
+	RefreshWithoutUpgrade(ctx context.Context, s *tf.InstanceState, meta interface{}) (*tf.InstanceState, tfdiag.Diagnostics)
 }
 
 type noForkExternal struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR sets the `RawPlan` for a new `terraform.InstanceState` returned from an observation. We need this to get the registered `schema.Resource.CustomizeDiff` functions working in the context of https://github.com/upbound/provider-aws/pull/1037, which bumps the underlying Terraform AWS provider version to `v5.31.0`.

It also adds an import alias for the `github.com/hashicorp/terraform-plugin-sdk/v2/diag` package as the `diag` package name collides with some existing variable names.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via uptest in https://github.com/upbound/provider-aws/actions/runs/7300282700

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
