### PR TITLE
Set RawConfig on the diff state

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -486,6 +486,7 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 		}
 		stateValueMap = jsonMap
 		newState.RawPlan = stateValue
+		newState.RawConfig = n.rawConfig
 		diffState = newState
 	} else if diffState != nil {
 		diffState.Attributes = nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR proposes a change where we start setting the `RawConfig` (in addition to the `RawPlan` we already set) on the diff state we use while computing the `terraform.InstanceDiff`s. @sergenyalcin has observed the need to do so while validating the `azurerm_web_application_firewall_policy` resource with the new upjet runtime architecture.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested manually against the `azurerm_web_application_firewall_policy` resource in`upbound/provider-azure`.


[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
