### PR TITLE
fix image links in configuring-a-resource

### DIFF
--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -262,7 +262,7 @@ further examples under `config/<group>/config.go` in their repositories.
 
 _Please see [this figure] to understand why we really need 3 different functions
 to configure external names and, it visualizes which is used how:_
-![Alt text](../images/upjet-externalname.png) _Note that, initially, GetIDFn
+![Alt text](../docs/images/upjet-externalname.png) _Note that, initially, GetIDFn
 will use the external-name annotation to set the terraform.tfstate id and, after
 that, it uses the terraform.tfstate id to update the external-name annotation.
 For cases where both values are different, both GetIDFn and GetExternalNameFn
@@ -899,7 +899,7 @@ initializers for a resource.
 [Computed]: https://github.com/hashicorp/terraform-plugin-sdk/blob/e3325b095ef501cf551f7935254ce942c44c1af0/helper/schema/schema.go#L139
 [tags_all for jet AWS resources]: https://github.com/upbound/provider-aws/blob/main/config/overrides.go#L62
 [AWS region]: https://github.com/upbound/provider-aws/blob/main/config/overrides.go#L32
-[this figure]: ../images/upjet-externalname.png
+[this figure]: ../docs/images/upjet-externalname.png
 [Initializers]: #initializers
 [InitializerFns]: https://github.com/crossplane/upjet/blob/main/pkg/config/resource.go#L297
 [NewInitializerFn]: https://github.com/crossplane/upjet/blob/main/pkg/config/resource.go#L210


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

Fix some of the links for `configuring-a-resource`
After making this change the image correctly appears in the documentation:
![image](https://github.com/crossplane/upjet/assets/14805373/ae93453e-0fc5-4e5e-b4f9-eb4c5e0d7146)


<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [X ] Read and followed Upjet's [contribution process].
- [X ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
