### PR TITLE
Add a nil check for the calculated instanceDiff while Observe

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -495,6 +495,9 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot compute the instance diff")
 	}
+	if instanceDiff == nil {
+		instanceDiff = tf.NewInstanceDiff()
+	}
 	n.instanceDiff = instanceDiff
 	noDiff := instanceDiff.Empty()
 


### PR DESCRIPTION
### Description of your changes

This PR adds a nil check for the calculated `instanceDiff` while Observe.

Related https://github.com/upbound/provider-aws/issues/1062

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against provider-aws autoscaling.Attachment resource [in this context](https://github.com/upbound/provider-aws/issues/1062).

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
