### PR TITLE
Generate a standalone "zz_generated.terraformed.go" file for each resource

### DIFF
--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -16,125 +16,124 @@ import (
 	"github.com/crossplane/upjet/pkg/resource/json"
 	{{ .Imports }}
 )
-{{ range .Resources }}
-    // GetTerraformResourceType returns Terraform resource type for this {{ .CRD.Kind }}
-    func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
-        return "{{ .Terraform.ResourceType }}"
+
+// GetTerraformResourceType returns Terraform resource type for this {{ .CRD.Kind }}
+func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
+    return "{{ .Terraform.ResourceType }}"
+}
+
+// GetConnectionDetailsMapping for this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetConnectionDetailsMapping() map[string]string {
+  {{- if .Sensitive.Fields }}
+  return map[string]string{ {{range $k, $v := .Sensitive.Fields}}"{{ $k }}": "{{ $v}}", {{end}} }
+  {{- else }}
+  return nil
+  {{- end }}
+}
+
+// GetObservation of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]any, error) {
+    o, err := json.TFParser.Marshal(tr.Status.AtProvider)
+    if err != nil {
+        return nil, err
     }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(o, &base)
+}
 
-    // GetConnectionDetailsMapping for this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetConnectionDetailsMapping() map[string]string {
-      {{- if .Sensitive.Fields }}
-      return map[string]string{ {{range $k, $v := .Sensitive.Fields}}"{{ $k }}": "{{ $v}}", {{end}} }
-      {{- else }}
-      return nil
-      {{- end }}
+// SetObservation for this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]any) error {
+    p, err := json.TFParser.Marshal(obs)
+    if err != nil {
+        return err
     }
+    return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
+}
 
-    // GetObservation of this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]any, error) {
-        o, err := json.TFParser.Marshal(tr.Status.AtProvider)
-        if err != nil {
-            return nil, err
-        }
-        base := map[string]any{}
-        return base, json.TFParser.Unmarshal(o, &base)
+// GetID returns ID of underlying Terraform resource of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetID() string {
+    if tr.Status.AtProvider.ID == nil {
+        return ""
     }
+    return *tr.Status.AtProvider.ID
+}
 
-    // SetObservation for this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]any) error {
-        p, err := json.TFParser.Marshal(obs)
-        if err != nil {
-            return err
-        }
-        return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
+// GetParameters of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]any, error) {
+    p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
+    if err != nil {
+        return nil, err
     }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(p, &base)
+}
 
-    // GetID returns ID of underlying Terraform resource of this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetID() string {
-        if tr.Status.AtProvider.ID == nil {
-            return ""
-        }
-        return *tr.Status.AtProvider.ID
+// SetParameters for this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]any) error {
+    p, err := json.TFParser.Marshal(params)
+    if err != nil {
+        return err
     }
+    return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
+}
 
-    // GetParameters of this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]any, error) {
-        p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
-        if err != nil {
-            return nil, err
-        }
-        base := map[string]any{}
-        return base, json.TFParser.Unmarshal(p, &base)
+// GetInitParameters of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetInitParameters() (map[string]any, error) {
+    p, err := json.TFParser.Marshal(tr.Spec.InitProvider)
+    if err != nil {
+        return nil, err
     }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(p, &base)
+}
 
-    // SetParameters for this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]any) error {
-        p, err := json.TFParser.Marshal(params)
-        if err != nil {
-            return err
-        }
-        return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
+// GetInitParameters of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetMergedParameters(shouldMergeInitProvider bool) (map[string]any, error) {
+    params, err := tr.GetParameters()
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot get parameters for resource '%q'", tr.GetName())
     }
-
-    // GetInitParameters of this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetInitParameters() (map[string]any, error) {
-        p, err := json.TFParser.Marshal(tr.Spec.InitProvider)
-        if err != nil {
-            return nil, err
-        }
-        base := map[string]any{}
-        return base, json.TFParser.Unmarshal(p, &base)
-    }
-
-    // GetInitParameters of this {{ .CRD.Kind }}
-    func (tr *{{ .CRD.Kind }}) GetMergedParameters(shouldMergeInitProvider bool) (map[string]any, error) {
-        params, err := tr.GetParameters()
-        if err != nil {
-            return nil, errors.Wrapf(err, "cannot get parameters for resource '%q'", tr.GetName())
-        }
-        if !shouldMergeInitProvider {
-            return params, nil
-        }
-
-        initParams, err := tr.GetInitParameters()
-        if err != nil {
-            return nil, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
-        }
-
-        // Note(lsviben): mergo.WithSliceDeepCopy is needed to merge the
-        // slices from the initProvider to forProvider. As it also sets
-        // overwrite to true, we need to set it back to false, we don't
-        // want to overwrite the forProvider fields with the initProvider
-        // fields.
-        err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
-            c.Overwrite = false
-        })
-        if err != nil {
-            return nil, errors.Wrapf(err, "cannot merge spec.initProvider and spec.forProvider parameters for resource '%q'", tr.GetName())
-        }
-
+    if !shouldMergeInitProvider {
         return params, nil
     }
 
-    // LateInitialize this {{ .CRD.Kind }} using its observed tfState.
-    // returns True if there are any spec changes for the resource.
-    func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
-        params := &{{ .CRD.ParametersTypeName }}{}
-        if err := json.TFParser.Unmarshal(attrs, params); err != nil {
-            return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
-        }
-        opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
-        {{ range .LateInitializer.IgnoredFields -}}
-            opts = append(opts, resource.WithNameFilter("{{ . }}"))
-        {{ end }}
-
-        li := resource.NewGenericLateInitializer(opts...)
-        return li.LateInitialize(&tr.Spec.ForProvider, params)
+    initParams, err := tr.GetInitParameters()
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
     }
 
-    // GetTerraformSchemaVersion returns the associated Terraform schema version
-    func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
-        return {{ .Terraform.SchemaVersion }}
+    // Note(lsviben): mergo.WithSliceDeepCopy is needed to merge the
+    // slices from the initProvider to forProvider. As it also sets
+    // overwrite to true, we need to set it back to false, we don't
+    // want to overwrite the forProvider fields with the initProvider
+    // fields.
+    err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
+        c.Overwrite = false
+    })
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot merge spec.initProvider and spec.forProvider parameters for resource '%q'", tr.GetName())
     }
-{{ end }}
+
+    return params, nil
+}
+
+// LateInitialize this {{ .CRD.Kind }} using its observed tfState.
+// returns True if there are any spec changes for the resource.
+func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
+    params := &{{ .CRD.ParametersTypeName }}{}
+    if err := json.TFParser.Unmarshal(attrs, params); err != nil {
+        return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
+    }
+    opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+    {{ range .LateInitializer.IgnoredFields -}}
+        opts = append(opts, resource.WithNameFilter("{{ . }}"))
+    {{ end }}
+
+    li := resource.NewGenericLateInitializer(opts...)
+    return li.LateInitialize(&tr.Spec.ForProvider, params)
+}
+
+// GetTerraformSchemaVersion returns the associated Terraform schema version
+func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
+    return {{ .Terraform.SchemaVersion }}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This PR proposes a change with which we start generating a standalone `zz_generated.terraformed.go` file for each resource. Each resource will now have its own `resource.Terraformed` interface implementation file. The per-group `zz_generated_terraformed.go` is now split into per-resource multiple `zz_generated.terraformed.go` files (if there are multiple resources in a given API group). This helps us while generating multiple versions for the CRDs because we do not generate from scratch the old API versions of a given resource as the generation pipeline is really expensive and instead, reuse the generated old versions.

Note: We will check the implications of this change on the provider repositories, such as the linter running times, etc.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually with https://github.com/upbound/provider-aws/pull/1075.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
