### PR TITLE
fix broken link in docs

### DIFF
--- a/docs/testing-with-uptest.md
+++ b/docs/testing-with-uptest.md
@@ -186,7 +186,7 @@ mentioned in the next parts.
   resources, but if you want to see the value of conditions in your tests in
   your local environment (during manual tests) you need to add this condition
   manually. For the goal and details of this status condition please see this
-  PR: https://github.com/upbound/crossplane/pull/23
+  PR: https://github.com/crossplane/upjet/pull/23
 
 > [!NOTE]
 > The resources that are tried to be created may have dependencies. For example,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
While investigating #327, I found this in the documentation, but the link went to an unrelated PR. This file was last changed by @jeanduplessis in ba13938 when migrating from upbound to crossplane. Maybe some automation went wrong there? 

I have:

- [ ] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The new link is not broken ;)

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
