### PR TITLE
Fix the return type so it uses Upjet

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -196,9 +196,9 @@ variables in the `Makefile`:
     +   "github.com/myorg/provider-github/config/repository"
      )
 
-     func GetProvider() *tjconfig.Provider {
+     func GetProvider() *ujconfig.Provider {
         ...
-        for _, configure := range []func(provider *tjconfig.Provider){
+        for _, configure := range []func(provider *ujconfig.Provider){
                 // add custom config functions
     -           null.Configure,
     +           repository.Configure,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

The docs show the return type of GetProvider() as Terrajet's *tjconfig.Provider.

Update them to use the Upjet type - *ujconfig.Provider.

Ran into this while following the "Generating a Crossplane provider" guide.

I have:

- [x] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
It's just a doc's change, make reviewable failed for me, but maybe it's to be expected.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
