### PR TITLE
fix diff state not being set to freshly observed state for non-existing resources

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -474,8 +474,8 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 	if diag != nil && diag.HasError() {
 		return managed.ExternalObservation{}, errors.Errorf("failed to observe the resource: %v", diag)
 	}
-	diffState := n.opTracker.GetTfState()
 	n.opTracker.SetTfState(newState) // TODO: missing RawConfig & RawPlan here...
+	diffState := n.opTracker.GetTfState()
 	resourceExists := newState != nil && newState.ID != ""
 
 	var stateValueMap map[string]any


### PR DESCRIPTION
### Description of your changes
Fixes diff state not being set to freshly observed (nil) state for non-existing resources.
This causes reconstructed prior state being used at diff that causes parsing issues for fields with validations.

Will fix https://github.com/upbound/provider-aws/issues/1071, after consumed at `provider-aws`

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Consumed at a local provider-aws build and tested with manifests specified in https://github.com/upbound/provider-aws/issues/1071 and issue is not observed.


