### PR TITLE
Set the ID string to empty string on Terraform state for calculating the diffs

### DIFF
--- a/pkg/controller/external_nofork.go
+++ b/pkg/controller/external_nofork.go
@@ -476,8 +476,8 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 	if diag != nil && diag.HasError() {
 		return managed.ExternalObservation{}, errors.Errorf("failed to observe the resource: %v", diag)
 	}
-	n.opTracker.SetTfState(newState) // TODO: missing RawConfig & RawPlan here...
 	diffState := n.opTracker.GetTfState()
+	n.opTracker.SetTfState(newState) // TODO: missing RawConfig & RawPlan here...
 	resourceExists := newState != nil && newState.ID != ""
 
 	var stateValueMap map[string]any
@@ -492,6 +492,7 @@ func (n *noForkExternal) Observe(ctx context.Context, mg xpresource.Managed) (ma
 		diffState = newState
 	} else if diffState != nil {
 		diffState.Attributes = nil
+		diffState.ID = ""
 	}
 	instanceDiff, err := n.getResourceDataDiff(mg.(resource.Terraformed), ctx, diffState, resourceExists)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
It turns out that using a `nil` `terraform.InstanceState` for new resources while calculating the `terraform.InstanceDiff` breaks the [verify.SetTagsDiff](https://github.com/hashicorp/terraform-provider-aws/blob/943f5ea6f343a8333fbf614fa6e01a6d16df125d/internal/verify/diff.go#L25) implementation. This PR resets the Terraform ID string to the empty string in `terraform.InstanceState` passed down to the `noForkExternal.getResourceDataDiff` so that the issue first observed in the `CustomizeDiff` implementation of `ReplicationGroup.elasticache` is resolved.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via uptest in https://github.com/upbound/provider-aws/pull/1119: https://github.com/upbound/provider-aws/actions/runs/7729719052/job/21073558871


[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
