### PR TITLE
move RequiresReplace check of plan to Update time instead of Observe & suppress diffs with only computed attributes

### DIFF
--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -165,7 +165,7 @@ func prepareTPFExternalWithTestConfig(testConfig testConfiguration) *terraformPl
 			},
 		},
 		params:                     testConfig.params,
-		plannedState:               plannedStateVal,
+		planResponse:               &tfprotov5.PlanResourceChangeResponse{PlannedState: plannedStateVal},
 		resourceSchema:             schemaResp.Schema,
 		resourceValueTerraformType: tfValueType,
 	}


### PR DESCRIPTION
### Description of your changes

Moves the RequiresReplace check of the Plan to start of the Update, instead of Observe.

Currently plans are checked if they return `RequiresReplace` at diff calculation time at `Observe` calls, and the plan is refused if they require resource replace with an error due to XRM compliance. 
However, this prevents late initialization of MR fields with RequiresReplace during initial creation, due to first observe after creation calculates a diff with `RequiresReplace` that gets rejected, since those fields are not late-initialized yet. Then, the diff planning exists early, not letting it reach to late initialization section.

Therefore the enforcement of the `RequiresReplace` plans are moved to Update time, to let fields late initialize first and enforce it after update decision is made.

Also, this change suppresses diffs with only computed attributes. The current diff detection mechanism compares the plan response and the current state. Plans can contain unknown values for Computed attributes, which is shown as a "false-positive" diff in the current diff logic.

This change suppreses diff elements that has unknown plan value. Note that it does NOT modify the plan itself in any way, just influences the logic of whether there is a diff or not.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested with new opensearchserverless resources in PR https://github.com/upbound/provider-aws/pull/1130 and all existing Terraform Plugin Framework resources

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
