### PR TITLE
Add support for generating MR API for Terraform resource's nested single configuration blocks

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -532,10 +532,28 @@ func (m SchemaElementOptions) AddToObservation(el string) bool {
 	return m[el] != nil && m[el].AddToObservation
 }
 
+// SetEmbeddedObject sets the EmbeddedObject for the specified key.
+func (m SchemaElementOptions) SetEmbeddedObject(el string) {
+	if m[el] == nil {
+		m[el] = &SchemaElementOption{}
+	}
+	m[el].EmbeddedObject = true
+}
+
+// EmbeddedObject returns true if the schema element at the specified path
+// should be generated as an embedded object.
+func (m SchemaElementOptions) EmbeddedObject(el string) bool {
+	return m[el] != nil && m[el].EmbeddedObject
+}
+
 // SchemaElementOption represents configuration options on a schema element.
 type SchemaElementOption struct {
 	// AddToObservation is set to true if the field represented by
 	// a schema element is to be added to the generated CRD type's
 	// Observation type.
 	AddToObservation bool
+	// EmbeddedObject  is set to true if the field represented by
+	// a schema element is to be embedded into its parent instead of being
+	// generated as a single element list.
+	EmbeddedObject bool
 }

--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -45,12 +45,11 @@ func v2ResourceFromTFJSONSchema(s *tfjson.Schema) *schemav2.Resource {
 		toSchemaMap[k] = tfJSONAttributeToV2Schema(v)
 	}
 	for k, v := range s.Block.NestedBlocks {
-		// Note(turkenh): We see resource timeouts here as NestingModeSingle.
-		// However, in plugin SDK resource timeouts is not part of resource
-		// schema map but set as a separate field. So, we just need to ignore
-		// here.
-		// https://github.com/hashicorp/terraform-plugin-sdk/blob/6461ac6e9044a44157c4e2c8aec0f1ab7efc2055/helper/schema/core_schema.go#L315
-		if v.NestingMode == tfjson.SchemaNestingModeSingle {
+		// CRUD timeouts are not part of the generated MR API,
+		// they cannot be dynamically configured and they are determined by either
+		// the underlying Terraform resource configuration or the upjet resource
+		// configuration. Please also see config.Resource.OperationTimeouts.
+		if k == schemav2.TimeoutsConfigKey {
 			continue
 		}
 		toSchemaMap[k] = tfJSONBlockTypeToV2Schema(v)
@@ -102,10 +101,17 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 		v2sch.Type = schemav2.TypeList
 	case tfjson.SchemaNestingModeMap:
 		v2sch.Type = schemav2.TypeMap
-	case tfjson.SchemaNestingModeSingle, tfjson.SchemaNestingModeGroup:
-		panic("unexpected nesting mode: " + nb.NestingMode)
+	case tfjson.SchemaNestingModeSingle:
+		v2sch.Type = schemav2.TypeList
+		v2sch.MinItems = 0
+		v2sch.Required = hasRequiredChild(nb)
+		v2sch.Optional = !v2sch.Required
+		if v2sch.Required {
+			v2sch.MinItems = 1
+		}
+		v2sch.MaxItems = 1
 	default:
-		panic("unknown nesting mode: " + nb.NestingMode)
+		panic("unhandled nesting mode: " + nb.NestingMode)
 	}
 
 	if nb.Block == nil {
@@ -121,18 +127,41 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 		res.Schema[key] = tfJSONAttributeToV2Schema(attr)
 	}
 	for key, block := range nb.Block.NestedBlocks {
-		// Note(turkenh): We see resource timeouts here as NestingModeSingle.
-		// However, in plugin SDK resource timeouts is not part of resource
-		// schema map but set as a separate field. So, we just need to ignore
-		// here.
-		// https://github.com/hashicorp/terraform-plugin-sdk/blob/6461ac6e9044a44157c4e2c8aec0f1ab7efc2055/helper/schema/core_schema.go#L315
-		if block.NestingMode == tfjson.SchemaNestingModeSingle {
-			continue
-		}
+		// Please note that unlike the resource-level CRUD timeout configuration
+		// blocks (as mentioned above), we will generate the timeouts parameters
+		// for any nested configuration blocks, *if they exist*.
+		// We can prevent them here, but they are different than the resource's
+		// top-level CRUD timeouts, so we have opted to generate them.
 		res.Schema[key] = tfJSONBlockTypeToV2Schema(block)
 	}
 	v2sch.Elem = res
 	return v2sch
+}
+
+// checks whether the given tfjson.SchemaBlockType has any required children.
+// Children which are themselves blocks (nested blocks) are
+// checked recursively.
+func hasRequiredChild(nb *tfjson.SchemaBlockType) bool {
+	if nb.Block == nil {
+		return false
+	}
+	for _, a := range nb.Block.Attributes {
+		if a == nil {
+			continue
+		}
+		if a.Required {
+			return true
+		}
+	}
+	for _, b := range nb.Block.NestedBlocks {
+		if b == nil {
+			continue
+		}
+		if hasRequiredChild(b) {
+			return true
+		}
+	}
+	return false
 }
 
 func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //nolint:gocyclo

--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -94,7 +94,7 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 		v2sch.Computed = true
 	}
 
-	switch nb.NestingMode {
+	switch nb.NestingMode { //nolint:exhaustive
 	case tfjson.SchemaNestingModeSet:
 		v2sch.Type = schemav2.TypeSet
 	case tfjson.SchemaNestingModeList:

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -154,7 +154,7 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 		}
 	}
 
-	fieldType, initType, err := g.buildSchema(f, cfg, names, r)
+	fieldType, initType, err := g.buildSchema(f, cfg, names, fieldPath(append(tfPath, snakeFieldName)), r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot infer type from schema of field %s", f.Name.Snake)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Related with: https://github.com/upbound/provider-aws/issues/889, https://github.com/upbound/provider-aws/pull/1130

While generating the managed resource (MR) API for Terraform's [aws_opensearchserverless_security_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_config) resource, we've observed that the required parameter [`saml_options`](https://registry.terraform.io/providers/hashicorp/aws/5.31.0/docs/resources/opensearchserverless_security_config#argument-reference) is not generated and thus, the resulting API is not usable. @erhancagirici did an initial analysis and the root cause of the issue turns out to be upjet skipping code generation for nested configuration blocks with the [`SchemaNestingModeSingle`](https://github.com/hashicorp/terraform-json/blob/1498774802abe883780f85a5feb87d8e371d0884/schemas.go#L142) nesting mode. Looks like we have initially chosen to do so to prevent the code generation for the resource CRUD timeout parameter generation for each MR API and opted for a static CRUD timeout configuration for the generated MRs (it's currently not possible to configure such timeouts dynamically at runtime).

However, this is a blocker for the generation of resources with a required nested configuration block in single mode.

This PR still prevents the generation of top-level CRUD timeouts for the `resource.Terraformed` resources (so we still don't allow dynamic configuration of such timeouts) but allows the code generation for other nested configuration blocks in single mode. We now filter the top-level CRUD timeout configuration blocks by name (instead of the previous nesting mode based approach). 

For the converted configuration blocks, [`Schema.MaxItems`](https://github.com/hashicorp/terraform-plugin-sdk/blob/fee8c9c56c78fbcbc3b28508d1d174fc395e10bc/helper/schema/schema.go#L234) is always set to 1, and if there are any required mappings for the configuration block, [`Schema.MinItems`](https://github.com/hashicorp/terraform-plugin-sdk/blob/fee8c9c56c78fbcbc3b28508d1d174fc395e10bc/helper/schema/schema.go#L241) is also set to 1, together with the `Optional` and `Required` attributes. The [`Schema.Type`](https://github.com/hashicorp/terraform-plugin-sdk/blob/fee8c9c56c78fbcbc3b28508d1d174fc395e10bc/helper/schema/schema.go#L62) is always [`schema.TypeList`](https://github.com/hashicorp/terraform-plugin-sdk/blob/fee8c9c56c78fbcbc3b28508d1d174fc395e10bc/helper/schema/valuetype.go#L20) for such nested configuration blocks. Thus they are modeled as lists with length constraints.

This PR also introduces the `config.SchemaElementOption.EmbeddedObject` API which can be used to configure upjet's code generation pipeline to generate an embedded object instead of a singleton list. We've chosen this explicit approach instead of making the schema block information available to the code generation pipeline and automatically deducing the schema elements with the single nesting mode with the following motivations:
1. Currently, we don't want to generate embedded objects for all singleton lists
1. We need to be careful converting singleton lists (without the single nesting mode) into embedded objects because the `MaxLength = 1` constraint on them could change in the future depending on their semantics. So we need to be careful with any sort of automatic conversions and plan ahead for API changes (possibly via [conversion functions](https://github.com/crossplane/upjet/pull/321) but converting between a new API supporting multiple elements in a list and an older API with an embedded object is cumbersome to implement in our generated APIs with the proper backwards compatibility constraints).
1. There are currently only two resources in the Terraform AWS provider that use single nesting mode, one of them being the `aws_opensearchserverless_security_config` resource's `saml_options` field. So, a manual configuration approach is okay until we would like to tackle with #136 (which is subject to [2] above). 
An example configuration for the `aws_opensearchserverless_security_config` resource's `saml_options` configuration is as follows:
```go
	p.AddResourceConfigurator("aws_opensearchserverless_security_config", func(r *config.Resource) {
		r.SchemaElementOptions.SetEmbeddedObject("saml_options")
	})
```
The specified path is the Terraform path of the schema element which is to be generated as an embedded object without any indices or wildcards (the same syntax for the `config.SchemaElementOptions.SetAddToObservation`). Please note that the code generation pipeline currently makes no checks on the size constraints of the list, i.e., it does not assert that the specified path is a singleton list (due to [3] above, this is a very special case we need to handle for just two resources).

We also add the `config.ExternalNameFrom` external-name configuration with this PR. `ExternalNameFrom` is an `ExternalName` configuration which uses a parent configuration as its base and modifies any of the `GetIDFn`,
`GetExternalNameFn` or `SetIdentifierArgumentsFn` functions of the configuration. This enables us to reuse the existing `ExternalName` configurations with modifications in their behaviors via compositions. As an example in https://github.com/upbound/provider-aws, there are resources that lend themselves to [config.TemplatedStringAsIdentifier](https://github.com/crossplane/upjet/blob/66ff8b2211cf36293f0218f01a6ab6719ecf95f4/pkg/config/externalname.go#L102) but fail or misbehave when the Terraform ID string is initially invalid due to a missing external-name annotation. A common workaround is to use a default string for the external-name if it's missing (that should never resolve to an existing external resource). This can now be achieved with a configuration like the following:
```go
// templatedStringWithDefaultedName is a config.TemplatedStringAsIdentifier
// that sets the external-name to the given default value if it's empty.
// This is required for certain Terraform resources which reject or misbehave
// when their IDs are initially constructed with an empty external-name
// annotation value.
func templatedStringWithDefaultedName(nameFieldPath, tmpl, defaultName string) config.ExternalName {
	return config.NewExternalNameFrom(config.TemplatedStringAsIdentifier(nameFieldPath, tmpl),
		config.WithGetIDFn(func(fn config.GetIDFn, ctx context.Context, externalName string, parameters map[string]any, terraformProviderConfig map[string]any) (string, error) {
			if externalName == "" {
				externalName = defaultName
			}
			return fn(ctx, externalName, parameters, terraformProviderConfig)
		}))
}
```
This [`ExternalName`](https://github.com/crossplane/upjet/blob/66ff8b2211cf36293f0218f01a6ab6719ecf95f4/pkg/config/resource.go#L118) configuration will use the supplied `defaultName` when the external-name annotation is empty to prevent the underlying resource from misbehaving.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via https://github.com/upbound/provider-aws/pull/1130.


[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
