### PR TITLE
Add json.Canonicalize to compute a canonical form of serialized JSON objects

### DIFF
--- a/pkg/config/canonical.go
+++ b/pkg/config/canonical.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/crossplane/upjet/pkg/resource/json"
+)
+
+const (
+	errFmtNotJSONString = "parameter at path %q with value %v is not a (JSON) string"
+	errFmtCanonicalize  = "failed to canonicalize the parameter at path %q"
+)
+
+// CanonicalizeJSONParameters returns a ConfigurationInjector that computes
+// and stores the canonical forms of the JSON documents for the specified list
+// of top-level Terraform configuration arguments. Please note that currently
+// only top-level configuration arguments are supported by this function.
+func CanonicalizeJSONParameters(tfPath ...string) ConfigurationInjector {
+	return func(jsonMap map[string]any, tfMap map[string]any) error {
+		for _, param := range tfPath {
+			p, ok := tfMap[param]
+			if !ok {
+				continue
+			}
+			s, ok := p.(string)
+			if !ok {
+				return errors.Errorf(errFmtNotJSONString, param, p)
+			}
+			if s == "" {
+				continue
+			}
+			cJSON, err := json.Canonicalize(s)
+			if err != nil {
+				return errors.Wrapf(err, errFmtCanonicalize, param)
+			}
+			tfMap[param] = cJSON
+		}
+		return nil
+	}
+}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -512,7 +512,7 @@ type CustomDiff func(diff *terraform.InstanceDiff, state *terraform.InstanceStat
 // values from the specified managed resource into the specified configuration
 // map. jsonMap is the map obtained by converting the `spec.forProvider` using
 // the JSON tags and tfMap is obtained by using the TF tags.
-type ConfigurationInjector func(jsonMap map[string]any, tfMap map[string]any)
+type ConfigurationInjector func(jsonMap map[string]any, tfMap map[string]any) error
 
 // SchemaElementOptions represents schema element options for the
 // schema elements of a Resource.

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -136,7 +136,9 @@ func getExtendedParameters(ctx context.Context, tr resource.Terraformed, externa
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get JSON map for the managed resource's spec.forProvider value")
 		}
-		config.TerraformConfigurationInjector(m, params)
+		if err := config.TerraformConfigurationInjector(m, params); err != nil {
+			return nil, errors.Wrap(err, "cannot invoke the configured TerraformConfigurationInjector")
+		}
 	}
 
 	tfID, err := config.ExternalName.GetIDFn(ctx, externalName, params, ts.Map())

--- a/pkg/resource/json/canonical.go
+++ b/pkg/resource/json/canonical.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+const (
+	errFmtJSONUnmarshal = "failed to unmarshal the JSON document: %s"
+	errFmtJSONMarshal   = "failed to marshal the dictionary: %v"
+)
+
+var (
+	cJSON = jsoniter.Config{
+		SortMapKeys: true,
+	}.Froze()
+)
+
+// Canonicalize minifies and orders the keys of the specified JSON document
+// to return a canonical form of it, along with any errors encountered during
+// the process.
+func Canonicalize(json string) (string, error) {
+	var m map[string]any
+	if err := cJSON.Unmarshal([]byte(json), &m); err != nil {
+		return "", errors.Wrapf(err, errFmtJSONUnmarshal, json)
+	}
+	buff, err := cJSON.Marshal(m)
+	return string(buff), errors.Wrapf(err, errFmtJSONMarshal, m)
+}

--- a/pkg/resource/json/canonical_test.go
+++ b/pkg/resource/json/canonical_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+)
+
+func TestCanonicalize(t *testing.T) {
+	tests := map[string]struct {
+		inputFile    string
+		expectedFile string
+		err          error
+	}{
+		"SuccessfulConversion": {
+			inputFile:    "policy.json",
+			expectedFile: "policy_canonical.json",
+		},
+		"NoopConversion": {
+			inputFile:    "policy_canonical.json",
+			expectedFile: "policy_canonical.json",
+		},
+		"InvalidJSON": {
+			inputFile: "invalid.json",
+			err:       errors.Wrap(errors.New(`ReadString: expects " or n, but found }, error found in #10 byte of ...|"a": "b",}|..., bigger context ...|{"a": "b",}|...`), `failed to unmarshal the JSON document: {"a": "b",}`),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			input, err := os.ReadFile(filepath.Join("testdata", tc.inputFile))
+			if err != nil {
+				t.Fatalf("Failed to read the input file: %v", err)
+			}
+
+			expectedOutput := ""
+			if tc.expectedFile != "" {
+				output, err := os.ReadFile(filepath.Join("testdata", tc.expectedFile))
+				if err != nil {
+					t.Fatalf("Failed to read expected the output file: %v", err)
+				}
+				expectedOutput = strings.Join(strings.Split(strings.TrimSpace(string(output)), "\n")[3:], "\n")
+			}
+
+			inputJSON := strings.Join(strings.Split(strings.TrimSpace(string(input)), "\n")[3:], "\n")
+			canonicalJSON, err := Canonicalize(inputJSON)
+			if err != nil {
+				if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
+					t.Fatalf("Canonicalize(...): -wantErr, +gotErr: %s", diff)
+				}
+				return
+			}
+			if diff := cmp.Diff(expectedOutput, canonicalJSON); diff != "" {
+				t.Errorf("Canonicalize(...): -want, +got: \n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resource/json/testdata/invalid.json
+++ b/pkg/resource/json/testdata/invalid.json
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+{"a": "b",}

--- a/pkg/resource/json/testdata/policy.json
+++ b/pkg/resource/json/testdata/policy.json
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+{
+  "Rules": [
+    {
+      "ResourceType": "collection",
+      "Resource": [
+        "collection/example-collection-2"
+      ]
+    }
+  ],
+  "AWSOwnedKey": true
+}

--- a/pkg/resource/json/testdata/policy_canonical.json
+++ b/pkg/resource/json/testdata/policy_canonical.json
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+{"AWSOwnedKey":true,"Rules":[{"Resource":["collection/example-collection-2"],"ResourceType":"collection"}]}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
This PR introduces the utility function `json.Canonicalize` to compute a canonical form of the serialized JSON objects. The canonical form is the minified JSON (white-space removed) with the object keys sorted.

Based on this utility, we also introduce the `config.CanonicalizeJSONParameters` that returns a [`config.TerraformConfigurationInjector`](https://github.com/crossplane/upjet/blob/f6a1a0de74519634fd9e53d4f42cf7ee32fcd05e/pkg/config/resource.go#L444) for converting the specified list of top-level Terraform arguments with JSON values into their canonical forms. An example configuration is as follows:
```go
// Configure adds configurations for the opensearchserverless group.
func Configure(p *config.Provider) {
	p.AddResourceConfigurator("aws_opensearchserverless_security_policy", func(r *config.Resource) {
		r.TerraformConfigurationInjector = config.CanonicalizeJSONParameters("policy")
	})
}
```
, where `policy` is a JSON security policy configuration. Assuming the following resource manifest:
```yaml
apiVersion: opensearchserverless.aws.upbound.io/v1beta1
kind: SecurityPolicy
metadata:
  annotations:
    meta.upbound.io/example-id: opensearchserverless/v1beta1/securitypolicy
  labels:
    testing.upbound.io/example-name: example
  name: example-os-sp-alper
spec:
  forProvider:
    name: example-os-sp-alper
    description: encryption security policy for example-collection
    policy: |
      {
        "Rules": [
          {
            "ResourceType": "collection",
            "Resource": [
              "collection/example-collection-2"
            ]
          }
        ],
        "AWSOwnedKey": true
      }
    region: us-east-1
    type: encryption
```
, the computed canonical form for the policy document is:
```json
{"AWSOwnedKey":true,"Rules":[{"Resource":["collection/example-collection-2"],"ResourceType":"collection"}]}
```

This PR also changes the function signature for the [`config.ConfigurationInjector`](https://github.com/crossplane/upjet/blob/f6a1a0de74519634fd9e53d4f42cf7ee32fcd05e/pkg/config/resource.go#L515) function type to:
```go
type ConfigurationInjector func(jsonMap map[string]any, tfMap map[string]any) error
```
, adding an `error` return value to be able to report errors while injecting Terraform configuration arguments. This is a breaking change and we assume the official providers are the only ones using this `type`.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->



I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested in the context of https://github.com/upbound/provider-aws/pull/1130 & https://github.com/upbound/provider-aws/pull/1150.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
