### PR TITLE
Handle JSON arrays in json.Canonicalize

### DIFF
--- a/pkg/resource/json/canonical.go
+++ b/pkg/resource/json/canonical.go
@@ -24,10 +24,10 @@ var (
 // to return a canonical form of it, along with any errors encountered during
 // the process.
 func Canonicalize(json string) (string, error) {
-	var m map[string]any
-	if err := cJSON.Unmarshal([]byte(json), &m); err != nil {
+	var d any
+	if err := cJSON.Unmarshal([]byte(json), &d); err != nil {
 		return "", errors.Wrapf(err, errFmtJSONUnmarshal, json)
 	}
-	buff, err := cJSON.Marshal(m)
-	return string(buff), errors.Wrapf(err, errFmtJSONMarshal, m)
+	buff, err := cJSON.Marshal(d)
+	return string(buff), errors.Wrapf(err, errFmtJSONMarshal, d)
 }

--- a/pkg/resource/json/canonical_test.go
+++ b/pkg/resource/json/canonical_test.go
@@ -21,9 +21,13 @@ func TestCanonicalize(t *testing.T) {
 		expectedFile string
 		err          error
 	}{
-		"SuccessfulConversion": {
+		"SuccessfulObjectConversion": {
 			inputFile:    "policy.json",
 			expectedFile: "policy_canonical.json",
+		},
+		"SuccessfulArrayConversion": {
+			inputFile:    "array.json",
+			expectedFile: "array_canonical.json",
 		},
 		"NoopConversion": {
 			inputFile:    "policy_canonical.json",

--- a/pkg/resource/json/testdata/array.json
+++ b/pkg/resource/json/testdata/array.json
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+[
+  {
+    "Principal": [
+      "arn:aws:iam::153891904029:user/official-provider-testing"
+    ],
+    "Rules": [
+      {
+        "Permission": [
+          "aoss:*"
+        ],
+        "Resource": [
+          "index/example-collection/*"
+        ],
+        "ResourceType": "index"
+      },
+      {
+        "Permission": [
+          "aoss:*"
+        ],
+        "Resource": [
+          "collection/example-collection"
+        ],
+        "ResourceType": "collection"
+      }
+    ]
+  }
+]

--- a/pkg/resource/json/testdata/array_canonical.json
+++ b/pkg/resource/json/testdata/array_canonical.json
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+[{"Principal":["arn:aws:iam::153891904029:user/official-provider-testing"],"Rules":[{"Permission":["aoss:*"],"Resource":["index/example-collection/*"],"ResourceType":"index"},{"Permission":["aoss:*"],"Resource":["collection/example-collection"],"ResourceType":"collection"}]}]


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR adds support for handling JSON arrays in addition to objects in `json.Canonicalize`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested in the context of https://github.com/upbound/provider-aws/pull/1130 with the `AccessPolicy.opensearchserverless` resource. The policy document for that resource is a JSON array.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
