### PR TITLE
Remove Resource.SchemaFunc references for compatibility with the older Terraform Plugin SDK versions

### DIFF
--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -328,12 +328,9 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 			}
 			terraformResource = p.TerraformProvider.ResourcesMap[name]
 			if terraformResource.Schema == nil {
-				if terraformResource.SchemaFunc == nil {
-					p.skippedResourceNames = append(p.skippedResourceNames, name)
-					fmt.Printf("Skipping resource %s because it has no schema and no schema function\n", name)
-					continue
-				}
-				terraformResource.Schema = terraformResource.SchemaFunc()
+				p.skippedResourceNames = append(p.skippedResourceNames, name)
+				fmt.Printf("Skipping resource %s because it has no schema\n", name)
+				continue
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
In upjet main HEAD, we've bumped the Terraform plugin SDK version to `v2.30.0`, which has the [`Resource.SchemaFunc`](https://github.com/hashicorp/terraform-plugin-sdk/blob/cc7cc13ce8d10485e88563e8506e36d22ff8f768/helper/schema/resource.go#L76) API. However, there are still providers that depend on the Terraform plugin SDK versions where this API is not yet available. This PR removes the dependency on `Resource.SchemaFunc` so that those providers can now consume `upjet@v1.1.0`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested in the context of https://github.com/upbound/provider-aws/pull/1160 via the uptest run:
https://github.com/upbound/provider-aws/actions/runs/7921053846

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
