### PR TITLE
Add .license files for the JSON test artifacts

### DIFF
--- a/pkg/resource/json/canonical_test.go
+++ b/pkg/resource/json/canonical_test.go
@@ -52,10 +52,10 @@ func TestCanonicalize(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to read expected the output file: %v", err)
 				}
-				expectedOutput = strings.Join(strings.Split(strings.TrimSpace(string(output)), "\n")[3:], "\n")
+				expectedOutput = strings.TrimSpace(string(output))
 			}
 
-			inputJSON := strings.Join(strings.Split(strings.TrimSpace(string(input)), "\n")[3:], "\n")
+			inputJSON := strings.TrimSpace(string(input))
 			canonicalJSON, err := Canonicalize(inputJSON)
 			if err != nil {
 				if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {

--- a/pkg/resource/json/testdata/array.json
+++ b/pkg/resource/json/testdata/array.json
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 [
   {
     "Principal": [

--- a/pkg/resource/json/testdata/array.json.license
+++ b/pkg/resource/json/testdata/array.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/resource/json/testdata/array_canonical.json
+++ b/pkg/resource/json/testdata/array_canonical.json
@@ -1,4 +1,1 @@
-// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 [{"Principal":["arn:aws:iam::153891904029:user/official-provider-testing"],"Rules":[{"Permission":["aoss:*"],"Resource":["index/example-collection/*"],"ResourceType":"index"},{"Permission":["aoss:*"],"Resource":["collection/example-collection"],"ResourceType":"collection"}]}]

--- a/pkg/resource/json/testdata/array_canonical.json.license
+++ b/pkg/resource/json/testdata/array_canonical.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/resource/json/testdata/invalid.json
+++ b/pkg/resource/json/testdata/invalid.json
@@ -1,4 +1,1 @@
-// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 {"a": "b",}

--- a/pkg/resource/json/testdata/invalid.json.license
+++ b/pkg/resource/json/testdata/invalid.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/resource/json/testdata/policy.json
+++ b/pkg/resource/json/testdata/policy.json
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 {
   "Rules": [
     {

--- a/pkg/resource/json/testdata/policy.json.license
+++ b/pkg/resource/json/testdata/policy.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/resource/json/testdata/policy_canonical.json
+++ b/pkg/resource/json/testdata/policy_canonical.json
@@ -1,4 +1,1 @@
-// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 {"AWSOwnedKey":true,"Rules":[{"Resource":["collection/example-collection-2"],"ResourceType":"collection"}]}

--- a/pkg/resource/json/testdata/policy_canonical.json.license
+++ b/pkg/resource/json/testdata/policy_canonical.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
I had previously worked around the complaining reuse action on some JSON test artifacts by processing the (invalid) JSON documents with license headers in the test itself. Learning a [better alternative](https://github.com/fsfe/reuse-action/issues/26), this PR proposes to add the `.license` files.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Reuse action seems to be happy about the change [here](https://github.com/crossplane/upjet/actions/runs/8020325623/job/21909950471?pr=354) and the unit tests are passing [here](https://github.com/crossplane/upjet/actions/runs/8020325624/job/21909959280?pr=354).


[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
