### PR TITLE
Fix slice type sensitive fieldpath generation

### DIFF
--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -268,7 +268,13 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 		return nil, true, nil
 	}
 	sfx := "SecretRef"
-	cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths)+sfx)
+	switch f.FieldType.String() {
+	case "string", "*string", "map[string]string", "map[string]*string":
+		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths)+sfx)
+	case "[]string", "[]*string":
+		f.CRDPaths[len(f.CRDPaths)-2] = f.CRDPaths[len(f.CRDPaths)-2] + sfx
+		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths))
+	}
 	// todo(turkenh): do we need to support other field types as sensitive?
 	if f.FieldType.String() != "string" && f.FieldType.String() != "*string" && f.FieldType.String() != "[]string" &&
 		f.FieldType.String() != "[]*string" && f.FieldType.String() != "map[string]string" && f.FieldType.String() != "map[string]*string" {

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -268,12 +268,12 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 		return nil, true, nil
 	}
 	sfx := "SecretRef"
-	switch f.FieldType.String() {
-	case "string", "*string", "map[string]string", "map[string]*string":
-		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths)+sfx)
-	case "[]string", "[]*string":
+	switch f.FieldType.(type) {
+	case *types.Slice:
 		f.CRDPaths[len(f.CRDPaths)-2] = f.CRDPaths[len(f.CRDPaths)-2] + sfx
 		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths))
+	default:
+		cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+fieldPathWithWildcard(f.CRDPaths)+sfx)
 	}
 	// todo(turkenh): do we need to support other field types as sensitive?
 	if f.FieldType.String() != "string" && f.FieldType.String() != "*string" && f.FieldType.String() != "[]string" &&


### PR DESCRIPTION
### Description of your changes

This PR fixes sensitive fieldpath generation for slices. In the current behavior, we do not have any handling mechanism for slices while calculating the fieldpath. With this PR we will have this.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested on this [PR](https://github.com/upbound/provider-aws/pull/1170). And observed two diffs in generated fieldpaths:

```
modified:   apis/elasticache/v1beta1/zz_user_terraformed.go
modified:   apis/memorydb/v1beta1/zz_user_terraformed.go
```

Diffs respectively:

```
-       return map[string]string{"authentication_mode[*].passwords[*]": "spec.forProvider.authenticationMode[*].passwords[*]SecretRef", "passwords[*]": "spec.forProvider.passwords[*]SecretRef"}
+       return map[string]string{"authentication_mode[*].passwords[*]": "spec.forProvider.authenticationMode[*].passwordsSecretRef[*]", "passwords[*]": "spec.forProvider.passwordsSecretRef[*]"}
```

```
-       return map[string]string{"authentication_mode[*].passwords[*]": "spec.forProvider.authenticationMode[*].passwords[*]SecretRef"}
+       return map[string]string{"authentication_mode[*].passwords[*]": "spec.forProvider.authenticationMode[*].passwordsSecretRef[*]"}
```
[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
