### PR TITLE
Removing the applying of StateFuncs to parameters

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -158,13 +158,13 @@ func getExtendedParameters(ctx context.Context, tr resource.Terraformed, externa
 	return params, nil
 }
 
-func (c *TerraformPluginSDKConnector) processParamsWithStateFunc(schemaMap map[string]*schema.Schema, params map[string]any) map[string]any {
+func (c *TerraformPluginSDKConnector) processParamsWithHCLParser(schemaMap map[string]*schema.Schema, params map[string]any) map[string]any {
 	if params == nil {
 		return params
 	}
 	for key, param := range params {
 		if sc, ok := schemaMap[key]; ok {
-			params[key] = c.applyStateFuncToParam(sc, param)
+			params[key] = c.applyHCLParserToParam(sc, param)
 		} else {
 			params[key] = param
 		}
@@ -172,7 +172,7 @@ func (c *TerraformPluginSDKConnector) processParamsWithStateFunc(schemaMap map[s
 	return params
 }
 
-func (c *TerraformPluginSDKConnector) applyStateFuncToParam(sc *schema.Schema, param any) any { //nolint:gocyclo
+func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, param any) any { //nolint:gocyclo
 	if param == nil {
 		return param
 	}
@@ -185,7 +185,7 @@ func (c *TerraformPluginSDKConnector) applyStateFuncToParam(sc *schema.Schema, p
 		// TypeMap only supports schema in Elem
 		if mapSchema, ok := sc.Elem.(*schema.Schema); ok && okParam {
 			for pk, pv := range pmap {
-				pmap[pk] = c.applyStateFuncToParam(mapSchema, pv)
+				pmap[pk] = c.applyHCLParserToParam(mapSchema, pv)
 			}
 			return pmap
 		}
@@ -196,13 +196,13 @@ func (c *TerraformPluginSDKConnector) applyStateFuncToParam(sc *schema.Schema, p
 		pArray, okParam := param.([]any)
 		if setSchema, ok := sc.Elem.(*schema.Schema); ok && okParam {
 			for i, p := range pArray {
-				pArray[i] = c.applyStateFuncToParam(setSchema, p)
+				pArray[i] = c.applyHCLParserToParam(setSchema, p)
 			}
 			return pArray
 		} else if setResource, ok := sc.Elem.(*schema.Resource); ok {
 			for i, p := range pArray {
 				if resParam, okRParam := p.(map[string]any); okRParam {
-					pArray[i] = c.processParamsWithStateFunc(setResource.Schema, resParam)
+					pArray[i] = c.processParamsWithHCLParser(setResource.Schema, resParam)
 				}
 			}
 		}
@@ -216,16 +216,8 @@ func (c *TerraformPluginSDKConnector) applyStateFuncToParam(sc *schema.Schema, p
 				param = hclProccessedParam
 			}
 		}
-		if sc.StateFunc != nil {
-			return sc.StateFunc(param)
-		}
 		return param
-	case schema.TypeBool, schema.TypeInt, schema.TypeFloat:
-		if sc.StateFunc != nil {
-			return sc.StateFunc(param)
-		}
-		return param
-	case schema.TypeInvalid:
+	case schema.TypeBool, schema.TypeInt, schema.TypeFloat, schema.TypeInvalid:
 		return param
 	default:
 		return param
@@ -252,7 +244,7 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the extended parameters for resource %q", mg.GetName())
 	}
-	params = c.processParamsWithStateFunc(c.config.TerraformResource.Schema, params)
+	params = c.processParamsWithHCLParser(c.config.TerraformResource.Schema, params)
 
 	schemaBlock := c.config.TerraformResource.CoreConfigSchema()
 	rawConfig, err := schema.JSONMapToStateValue(params, schemaBlock)

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -176,7 +176,7 @@ func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, p
 	if param == nil {
 		return param
 	}
-	switch sc.Type {
+	switch sc.Type { //nolint:exhaustive
 	case schema.TypeMap:
 		if sc.Elem == nil {
 			return param
@@ -216,8 +216,6 @@ func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, p
 				param = hclProccessedParam
 			}
 		}
-		return param
-	case schema.TypeBool, schema.TypeInt, schema.TypeFloat, schema.TypeInvalid:
 		return param
 	default:
 		return param


### PR DESCRIPTION
### Description of your changes
Relevant PR: https://github.com/upbound/provider-aws/pull/1188


This PR removes the applying of `StateFunc`s to parameters. This PR contains a fix for the https://github.com/upbound/provider-aws/issues/1109.

In the Diff function of [terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk/blob/d924635d4ed38beb1cc8295e9e9769a7fe2c6be8/helper/schema/schema.go#L1547), the StateFuncs have already applied to parameters. So, when we apply the StateFuncs before the `Observe`, the StateFuncs is called two times.

Big portion of the StateFuncs are idempotents like `NomalizeJson`, `strings.ToUpper` etc. However, some of them are not idempotent and we observed the problem in this type of case.

During the investigations of https://github.com/upbound/provider-aws/issues/1109 issue, we observed that a problematic behavior in upjet side. The `aws.ec2.Instance` resource's field `user_data` has a `StateFunc` that calculates the hash of the provided string and stores this hash value of string in status. For this resource the StateFunc is not idempotent and this causes a problem because we call the StateFunc two times. Result of this behavior, we calculate the wrong input for the resoruce.

This PR proposes removal of applying the StateFuncs to parameters. We will continue to process HCL expressions in parameters.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against the following resources that have different StateFuncs (in AWS):

- ec2.Instance
- networkmanager.CoreNetwork
- dynamodb.Table

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
