### PR TITLE
Swap SYNCED and READY columns in output

### DIFF
--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -45,8 +45,8 @@ type {{ .CRD.Kind }}Status struct {
 // +kubebuilder:storageversion
 
 // {{ .CRD.Kind }} is the Schema for the {{ .CRD.Kind }}s API. {{ .CRD.Description }}
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,{{ .Provider.ShortName }}}{{ if .CRD.Path }},path={{ .CRD.Path }}{{ end }}


### PR DESCRIPTION
### Description of your changes
Crossplane creates CRDs for Claims and Composites with the additionalPrinterColumns "SYNCED" and "READY" in that order.

This PR modifies the code generation to use the same order of SYNCED and READY instead of the current READY and SYNCED.

Fixes #359 

I have:

- [X] Read and followed Upjet's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Generated the Upbound provider-aws using these changes and confirmed that the CRDs were generated with the SYNCED and READY fields in that order