### PR TITLE
Fix go code spacing in configuration-a-resource.md

### DIFF
--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -363,11 +363,11 @@ case, we would need to provide the full path. Referencing to a [kms key] from
 
 ```go
 func Configure(p *config.Provider) {
- p.AddResourceConfigurator("aws_ebs_volume", func(r *config.Resource) {
-  r.References["kms_key_id"] = config.Reference{
-   Type: "github.com/crossplane-contrib/provider-tf-aws/apis/kms/v1alpha1.Key",
-  }
- })
+    p.AddResourceConfigurator("aws_ebs_volume", func(r *config.Resource) {
+        r.References["kms_key_id"] = config.Reference{
+           Type: "github.com/crossplane-contrib/provider-tf-aws/apis/kms/v1alpha1.Key",
+        }
+    })
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes minor spacing issue in one of the Go examples.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
