### PR TITLE
Move license statements to separate files (for tmpl files) to prevent license statement duplication

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/controller.go.tmpl.license
+++ b/pkg/pipeline/templates/controller.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/conversion_hub.go.tmpl
+++ b/pkg/pipeline/templates/conversion_hub.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/conversion_hub.go.tmpl.license
+++ b/pkg/pipeline/templates/conversion_hub.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/conversion_spoke.go.tmpl
+++ b/pkg/pipeline/templates/conversion_spoke.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/conversion_spoke.go.tmpl.license
+++ b/pkg/pipeline/templates/conversion_spoke.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/crd_types.go.tmpl.license
+++ b/pkg/pipeline/templates/crd_types.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/groupversion_info.go.tmpl
+++ b/pkg/pipeline/templates/groupversion_info.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/groupversion_info.go.tmpl.license
+++ b/pkg/pipeline/templates/groupversion_info.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/register.go.tmpl
+++ b/pkg/pipeline/templates/register.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/register.go.tmpl.license
+++ b/pkg/pipeline/templates/register.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -1,4 +1,3 @@
-
 package controller
 
 import (

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
 
 package controller
 

--- a/pkg/pipeline/templates/setup.go.tmpl.license
+++ b/pkg/pipeline/templates/setup.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
-//
-// SPDX-License-Identifier: Apache-2.0
-
 {{ .Header }}
 
 {{ .GenStatement }}

--- a/pkg/pipeline/templates/terraformed.go.tmpl.license
+++ b/pkg/pipeline/templates/terraformed.go.tmpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Description of your changes

This PR moves license statements to separate files (for tmpl files) to prevent license statement duplication.

We have injected the license statements from the providers during generation. If we explicitly add the license statements to the tmpl files, related license lines are being generate as duplicate. This PR prevents this duplication.

Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in https://github.com/crossplane-contrib/provider-upjet-azuread/pull/111