### PR TITLE
Add the `Header` Go template variable to setup.go.tmpl

### DIFF
--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -1,3 +1,5 @@
+{{ .Header }}
+
 package controller
 
 import (


### PR DESCRIPTION
### Description of your changes

This PR adds the `Header` Go template variable to `setup.go.tmpl` to generate the license headers to generated setup go files. Now we do not have this and after moving the license statements from tmpl files in this [PR](https://github.com/crossplane/upjet/pull/373), we do not generate these statements.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in this [PR](https://github.com/crossplane-contrib/provider-upjet-azuread/pull/111) locally.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
