### PR TITLE
Use granular merge strategy for singleton lists

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -115,6 +115,7 @@ func injectServerSideApplyListMergeKeys(cfg *config.Resource) error { //nolint:g
 		el.Schema[s.ListMergeStrategy.ListMapKeys.InjectedKey.Key] = &schema.Schema{
 			Type:        schema.TypeString,
 			Required:    true,
+			Computed:    sch.Computed,
 			Description: descriptionInjectedKey,
 		}
 		if s.ListMergeStrategy.ListMapKeys.InjectedKey.DefaultValue != "" {


### PR DESCRIPTION
### Description of your changes

Many TF providers nest blocks using a ListType with MaxItems=1, which upjet converts into a list containing a map. The default server side apply merge strategy for lists is atomic, resulting in conflicts between the provider and composition functions. This can be fixed on a case-by-case basis in the providers (https://github.com/crossplane-contrib/provider-upjet-gcp/pull/457), but it seems likely that all of these should be treated as if they were maps (which default to granular merge.)

While it would be great to fix this by flattening the unnecessary array, that would force an API change on all the providers.

This PR instead adjusts the ServerSideApplyMergeStrategies in the config to use ListTypeMap with a defaulted key for a singleton list. It works by altering the config, rather than during creation of Fields, to avoid duplicating the implementation used for ServerSideApplyMergeStrategies.

It also moves the existing server side apply marker defaulting for scalar sets and maps to work in the same way for consistency. I'm not sure that it's necessary to apply the granular strategy in the TypeMap case, as I think that's the k8s default, but I've left it in place to avoid additional changes to the output.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Generated updated GCP provider, which was run in Kind.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
