### PR TITLE
Add external API calls metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -44,6 +44,20 @@ var (
 		Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 300, 600, 1800, 3600},
 	}, []string{"operation"})
 
+	// ExternalAPICalls is a counter metric of the number of external
+	// API calls. "service" and "operation" labels could be used to
+	// classify calls into a two-level hierarchy, in which calls are
+	// "operations" that belong to a "service". Users should beware of
+	// performance implications of high cardinality that could occur
+	// when there are many services and operations. See:
+	// https://prometheus.io/docs/practices/naming/#labels
+	ExternalAPICalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNSUpjet,
+		Subsystem: promSysResource,
+		Name:      "external_api_calls_total",
+		Help:      "The number of external API calls.",
+	}, []string{"service", "operation"})
+
 	// DeletionTime is the histogram metric for collecting statistics on the
 	// intervals between the deletion timestamp and the moment when
 	// the resource is observed to be missing (actually deleted).
@@ -174,5 +188,5 @@ func (r *MetricRecorder) Start(ctx context.Context) error {
 }
 
 func init() {
-	metrics.Registry.MustRegister(CLITime, CLIExecutions, TFProcesses, TTRMeasurements, ExternalAPITime, DeletionTime, ReconcileDelay)
+	metrics.Registry.MustRegister(CLITime, CLIExecutions, TFProcesses, TTRMeasurements, ExternalAPITime, ExternalAPICalls, DeletionTime, ReconcileDelay)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Add a metric to count the number of external API calls, so that provider users can monitor their API call rate. Doing so is essential in addressing rate limiting concerns.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

In my `provider-upjet-aws` code I called, `metrics.ExternalAPICalls.WithLabelValues("myService", "myOperation").Inc()`. I observed the effect by visiting `localhost:8080/metrics`, which is the provider's Prometheus metrics endpoint.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
