### PR TITLE
Cache the error from the last asynchronous reconciliation

### DIFF
--- a/pkg/terraform/operation.go
+++ b/pkg/terraform/operation.go
@@ -43,14 +43,26 @@ func (o *Operation) MarkEnd() {
 	o.endTime = &now
 }
 
-// Flush cleans the operation information.
+// Flush cleans the operation information including the registered error from
+// the last reconciliation.
+// Deprecated: Please use Clear, which allows optionally preserving the error
+// from the last reconciliation to implement proper SYNC status condition for
+// the asynchronous external clients.
 func (o *Operation) Flush() {
+	o.Clear(false)
+}
+
+// Clear clears the operation information optionally preserving the last
+// registered error from the last reconciliation.
+func (o *Operation) Clear(preserveError bool) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.Type = ""
 	o.startTime = nil
 	o.endTime = nil
-	o.err = nil
+	if !preserveError {
+		o.err = nil
+	}
 }
 
 // IsEnded returns whether the operation has ended, regardless of its result.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Related issue: https://github.com/crossplane-contrib/provider-upjet-aws/issues/1164

This PR proposes a set of changes to:
- Cache the error from the last asynchronous reconciliation to return it in the next asynchronous reconciliation for the Terraform plugin SDK & framework based external clients.
- Set the "Synced" status condition to "False" in the async CallbackFn to immediately update it when the async operation fails.
- Set the "Synced" status condition to "True" when the async operation succeeds, or when the external client's Observe call reveals an up-to-date external resource which is not scheduled for deletion.

These changes result in the `Synced` status condition to being set to `False` when the asynchronously executing reconciliation operation encounters an error. Previously, we used to set a `LastAsyncOperation` to signal an error that the last asynchronous operation has encountered but we did not set the `Synced` status condition to `False`, which is a violation of the XRM contract.

The same issue exists also for the Terraform CLI-based asynchronous external client but we will address that client in a follow-up PR.

I have:

- [x] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested by updating a `Policy.iam` resource with an invalid policy document as described in https://github.com/crossplane-contrib/provider-upjet-aws/issues/1164. Without the proposed changes here, here's a log of the registered `Synced` status condition values after each reconciliation when a bad policy document is specified. Initially, the policy document is a valid one:
```
True
True
True
True
True
True
True
True
True
True
True
True
True
```
Here, the first reconciliation is done on a valid document, and the remaining ones are done on an invalid document (the ones on invalid document are exponentially backed-off).

And with the proposed changes, here are the logs for the same scenario:
```
True
True
False
False
False
False
False
False
False
False
False
False
False
False
```
So, after the asynchronous reconciliation encounters an error, the `Synced` condition is set to `False` and it's stable, i.e., it does not oscillate between the `True` & `False` states as long as the desired policy document stays invalid (with a bad syntax). When it's set to a valid document, the `Synced` condition is stably set to `True` (stays at the state `True`). 

And here's the full `status.conditions` in error state:
```yaml
status:
...
  conditions:
  - lastTransitionTime: "2024-04-24T20:39:29Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-04-24T21:19:43Z"
    message: "update failed: async update failed: failed to update the resource: [{0
      updating IAM Policy (arn:aws:iam::...:policy/test-policy): MalformedPolicyDocument:
      Syntax errors in policy.\n\tstatus code: 400, request id: 761851df-687a-4c66-984f-d0cd7b212b96
      \ []}]"
    reason: ReconcileError
    status: "False"
    type: Synced
  - lastTransitionTime: "2024-04-24T21:19:43Z"
    message: "async update failed: failed to update the resource: [{0 updating IAM
      Policy (arn:aws:iam::...:policy/test-policy): MalformedPolicyDocument:
      Syntax errors in policy.\n\tstatus code: 400, request id: 761851df-687a-4c66-984f-d0cd7b212b96
      \ []}]"
    reason: AsyncUpdateFailure
    status: "False"
    type: LastAsyncOperation
```

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
