### PR TITLE
chore: clarify documentation around reference type name

### DIFF
--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -319,7 +319,7 @@ In Upjet, we have a [configuration] to provide this information for a field:
 // Reference represents the Crossplane options used to generate
 // reference resolvers for fields
 type Reference struct {
-    // Type is the type name of the CRD if it is in the same package or
+    // Type is the Go type name of the CRD if it is in the same package or
     // <package-path>.<type-name> if it is in a different package.
     Type string
     // TerraformName is the name of the Terraform resource

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -171,7 +171,7 @@ type References map[string]Reference
 // Reference represents the Crossplane options used to generate
 // reference resolvers for fields
 type Reference struct {
-	// Type is the type name of the CRD if it is in the same package or
+	// Type is the Go type name of the CRD if it is in the same package or
 	// <package-path>.<type-name> if it is in a different package.
 	Type string
 	// TerraformName is the name of the Terraform resource


### PR DESCRIPTION
### Description of your changes

Clarify that it is the Go-specific type name. I made a few mistakes until I ran `make generate` multiple times and realized that it was not the CRD name but the name of the Go object.