### PR TITLE
Add config.Resource.PreviousVersions to specify the previous versions of an MR API

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -401,6 +401,11 @@ type Resource struct {
 	// Version is the API version being generated for the corresponding CRD.
 	Version string
 
+	// PreviousVersions is the list of API versions previously generated for this
+	// resource for multi-versioned managed resources. upjet will attempt to load
+	// the type definitions from these previous versions if configured.
+	PreviousVersions []string
+
 	// ControllerReconcileVersion is the CRD API version the associated
 	// controller will watch & reconcile. If left unspecified,
 	// defaults to the value of Version. This configuration parameter

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -541,6 +541,9 @@ type Resource struct {
 	// conflict. By convention, also used in upjet, the field name is preceded by
 	// the value of the generated Kind, for example:
 	// "TagParameters": "ClusterTagParameters"
+	// Deprecated: OverrideFieldNames has been deprecated in favor of loading
+	// the already existing type names from the older versions of the MR APIS
+	// via the PreviousVersions API.
 	OverrideFieldNames map[string]string
 
 	// requiredFields are the fields that will be marked as required in the

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -98,6 +98,10 @@ func Run(pc *config.Provider, rootDir string) { //nolint:gocyclo
 			tfGen := NewTerraformedGenerator(versionGen.Package(), rootDir, group, version)
 			ctrlGen := NewControllerGenerator(rootDir, pc.ModulePath, group)
 
+			if err := versionGen.InsertPreviousObjects(versions); err != nil {
+				panic(errors.Wrapf(err, "cannot insert type definitions from the previous versions into the package scope for group %q", group))
+			}
+
 			for _, name := range sortedResources(resources) {
 				paramTypeName, err := crdGen.Generate(resources[name])
 				if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
When generating new versions of the CRD APIs associated with a managed resource, upjet's code generation pipeline can potentially run into the following issue:
- We are generating a (new) API version `v1beta2` for resource `B`
- There exists another resource `A` in the same group as `B`, whose API is generated at `v1beta1`
- These resources share some common parameters (configuration arguments) with identical canonical paths
- upjet's code generation pipeline can normally resolve such conflicts while generating the Go struct names however it relies on a static pipeline that assumes all the types available are being generated. In our case, `v1beta1` version of the `B` resource API is not generated and hence upjet is not aware of it. This results in name conflicts for the generated types.

We have a roadmap item to modularize the code generation pipeline to make it more dynamic and scalable but it's a much larger effort. As a workaround, we had introduced the `config.Resource.OverrideFieldNames` API through which one can override the name upjet is generating for a CRD type. However, this requires manual configuration. 

For most cases, this has been feasible as we rarely do bulk breaking changes in the MR APIs. However recently, we are rolling out API changes across the official providers that replace the singleton lists in the MR APIs with embedded objects (please see https://github.com/crossplane/upjet/pull/387 and https://github.com/crossplane-contrib/provider-upjet-gcp/pull/508 for more context). Such systemic changes affecting multiple resources can result in a need to override the generated type names for many resources. What's worse, @sergenyalcin identified in https://github.com/crossplane-contrib/provider-upjet-azure/pull/733 that the current `config.Resource.OverrideFieldNames` API is unable to handle certain types of overrides where we need to override the same leaf at multiple paths. We need to be able to specify the canonical paths of the overrides being defined.

So, we've decided to address this issue by making upjet's code generation pipelines aware of the existing previous versions of the CRDs (MR APIs). One can configure an older version of an API as follows:
```go
p.AddResourceConfigurator("aws_msk_cluster", func(r *config.Resource) {
  r.Version = "v1beta2"
  r.PreviousVersions = []string{"v1beta1"}
  ...
```

While generating the CRDs in a package, upjet will then load the type definitions from these previous versions specified and use them as input to its already existing name conflict resolution function. 

We also deprecate the `config.Resource.OverrideFieldNames` API whose only known use case is preventing the type name conflicts in the generated CRDs. So, `config.Resource.OverrideFieldNames` is deprecated in favor of the ``config.Resource.PreviousVersions`-based mechanism described above.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested in the context of https://github.com/crossplane-contrib/provider-upjet-azure/pull/733 & https://github.com/crossplane-contrib/provider-upjet-gcp/pull/508. As an example, please observe the changes in [here](https://github.com/crossplane-contrib/provider-upjet-gcp/pull/508/commits/f425b8d317a9de21c069549c79fd049eefcc4138), where the API is replaced and we observe no diff in the generated APIs.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
