### PR TITLE
Generate Secret References for Sensitive Parameters under the spec.initProvider API tree

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -127,7 +127,7 @@ func GetSensitiveAttributes(from map[string]any, mapping map[string]string) (map
 			// Note(turkenh): k8s secrets uses a strict regex to validate secret
 			// keys which does not allow having brackets inside. So, we need to
 			// do a conversion to be able to store as connection secret keys.
-			// See https://github.com/crossplane/upjet/pull/94 for
+			// See https://github.com/crossplane/terrajet/pull/94 for
 			// more details.
 			k, err := fieldPathToSecretKey(fp)
 			if err != nil {

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -283,9 +283,9 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 	switch f.FieldType.(type) {
 	case *types.Slice:
 		f.CRDPaths[len(f.CRDPaths)-2] = f.CRDPaths[len(f.CRDPaths)-2] + sfx
-		cfg.Sensitive.AddFieldPath(traverser.FieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+traverser.FieldPathWithWildcard(f.CRDPaths))
+		cfg.Sensitive.AddFieldPath(traverser.FieldPathWithWildcard(f.TerraformPaths), traverser.FieldPathWithWildcard(f.CRDPaths))
 	default:
-		cfg.Sensitive.AddFieldPath(traverser.FieldPathWithWildcard(f.TerraformPaths), "spec.forProvider."+traverser.FieldPathWithWildcard(f.CRDPaths)+sfx)
+		cfg.Sensitive.AddFieldPath(traverser.FieldPathWithWildcard(f.TerraformPaths), traverser.FieldPathWithWildcard(f.CRDPaths)+sfx)
 	}
 	// todo(turkenh): do we need to support other field types as sensitive?
 	if f.FieldType.String() != "string" && f.FieldType.String() != "*string" && f.FieldType.String() != "[]string" &&

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -50,6 +50,9 @@ type Field struct {
 	// Injected is set if this Field is an injected field to the Terraform
 	// schema as an object list map key for server-side apply merges.
 	Injected bool
+	// Sensitive is set if this Field holds sensitive data and is thus
+	// generated as a secret reference.
+	Sensitive bool
 }
 
 // getDocString tries to extract the documentation string for the specified
@@ -268,6 +271,7 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 	if err != nil {
 		return nil, false, err
 	}
+	f.Sensitive = true
 
 	if IsObservation(f.Schema) {
 		cfg.Sensitive.AddFieldPath(traverser.FieldPathWithWildcard(f.TerraformPaths), "status.atProvider."+traverser.FieldPathWithWildcard(f.CRDPaths))
@@ -415,7 +419,7 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames, add
 // an earlier step, so they cannot be included as well. Plus probably they
 // should also not change for Create and Update steps.
 func (f *Field) isInit() bool {
-	return !f.Identifier && (f.TFTag != "-" || f.Injected)
+	return !f.Identifier && (f.TFTag != "-" || f.Injected || f.Sensitive)
 }
 
 func getDescription(s string) string {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
While working on adding the `User.mq` resource in `crossplane-contrib/provider-upjet-aws`, we hit the limitation that currently we do not generate secret references for the sensitive parameters under the `spec.initProvider` API. Currently, one can specify an  ActiveMQ broker user with `crossplane-contrib/provider-upjet-aws` as follows:
```yaml
apiVersion: mq.aws.upbound.io/v1beta1
kind: Broker
metadata:
  name: test-broker
spec:
  forProvider:
    ...
    user:
    - passwordSecretRef:
        key: password
        name: mq-secret
        namespace: upbound-system
      username: admin
```

However, we cannot fully specify the broker user using the `spec.initProvider` API tree because there's no `spec.initProvider.user[*].passwordSecretRef` and a partial specification like the following:

```yaml
apiVersion: mq.aws.upbound.io/v1beta1
kind: Broker
metadata:
  name: test-broker
spec:
  forProvider:
    # broker users are defined under spec.initProvider
    ...
  initProvider:
    user:
      username: admin
```
will not function as the required user password is missing in the user specification, which renders the `spec.initProvider.user` API useless.

This PR adds support for the generation of secret references for sensitive parameters under the `spec.initProvider` API tree. As a result, it now becomes possible to fully specify a broker user as follows:
```yaml
apiVersion: mq.aws.upbound.io/v1beta1
kind: Broker
metadata:
  name: test-broker
spec:
  initProvider:
    ...
    user:
    - passwordSecretRef:
        key: password
        name: mq-secret
        namespace: upbound-system
      username: admin
  forProvider:
    ...
```

The PR proposes both the code generation changes & the runtime secret resolution changes:
### Code generation changes:
1. Upjet now generates the secret references under the `spec.initProvider` API tree. As an example, `Broker.mq` now has `spec.initProvider.user[*].passwordSecretRef` as a sensitive parameter.
2. This will result in the marking of certain previously required sensitive fields as optional under the `spec.forProvider` API tree because they have now counterparts under the `spec.initProvider` subtree, i.e., they can now be specified from under `spec.initProvider`.
3. Upjet now generates, in `zz_*_terraformed.go` files, connection details mappings without the `spec.forProvider` prefixes in CRD paths. For example, what upjet used to generate as follows:
```yaml
// GetConnectionDetailsMapping for this SharedDirectory
func (tr *SharedDirectory) GetConnectionDetailsMapping() map[string]string {
  return map[string]string{"notes": "spec.forProvider.notesSecretRef"}
}
```
now becomes:
```yaml
// GetConnectionDetailsMapping for this SharedDirectory
func (tr *SharedDirectory) GetConnectionDetailsMapping() map[string]string {
  return map[string]string{"notes": "notesSecretRef"}
}

```
This is because, the mapping is now not 1:1. The sensitive value for the `notes` Terraform configuration argument can now be resolved from either a `spec.forProvider` reference or a `soec.initProvider` reference.

### Runtime changes:
Upjet runtime now has to be able to resolve secret references from under the `spec.initProvider` tree and the mapping between the Terraform configuration arguments & secret references is no longer one-to-one. If both a `spec.initProvider` and a `spec.forProvider` secret reference target the same Terraform configuration argument, then the `spec.forProvider`'s reference prevails over.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested via the `User.users` `crossplane-contrib/provider-upjet-azuread` resource.


[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
