### PR TITLE
Add a new late-init configuration to skip already filled field in spec.initProvider

### DIFF
--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -138,7 +138,7 @@ func TestDefaultResource(t *testing.T) {
 	// TODO(muvaf): Find a way to compare function pointers.
 	ignoreUnexported := []cmp.Option{
 		cmpopts.IgnoreFields(Sensitive{}, "fieldPaths", "AdditionalConnectionDetailsFn"),
-		cmpopts.IgnoreFields(LateInitializer{}, "ignoredCanonicalFieldPaths"),
+		cmpopts.IgnoreFields(LateInitializer{}, "ignoredCanonicalFieldPaths", "conditionalIgnoredCanonicalFieldPaths"),
 		cmpopts.IgnoreFields(ExternalName{}, "SetIdentifierArgumentFn", "GetExternalNameFn", "GetIDFn"),
 		cmpopts.IgnoreUnexported(Resource{}),
 		cmpopts.IgnoreUnexported(reflect.ValueOf(identityConversion).Elem().Interface()),

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -220,10 +220,20 @@ type LateInitializer struct {
 	// "block_device_mappings.ebs".
 	IgnoredFields []string
 
+	// ConditionalIgnoredFields are the field paths to be skipped during
+	// late-initialization if they are filled in spec.initProvider.
+	ConditionalIgnoredFields []string
+
 	// ignoredCanonicalFieldPaths are the Canonical field paths to be skipped
 	// during late-initialization. This is filled using the `IgnoredFields`
 	// field which keeps Terraform paths by converting them to Canonical paths.
 	ignoredCanonicalFieldPaths []string
+
+	// conditionalIgnoredCanonicalFieldPaths are the Canonical field paths to be
+	// skipped during late-initialization if they are filled in spec.initProvider.
+	// This is filled using the `ConditionalIgnoredFields` field which keeps
+	// Terraform paths by converting them to Canonical paths.
+	conditionalIgnoredCanonicalFieldPaths []string
 }
 
 // GetIgnoredCanonicalFields returns the ignoredCanonicalFields
@@ -237,6 +247,19 @@ func (l *LateInitializer) AddIgnoredCanonicalFields(cf string) {
 		l.ignoredCanonicalFieldPaths = make([]string, 0)
 	}
 	l.ignoredCanonicalFieldPaths = append(l.ignoredCanonicalFieldPaths, cf)
+}
+
+// GetConditionalIgnoredCanonicalFields returns the conditionalIgnoredCanonicalFieldPaths
+func (l *LateInitializer) GetConditionalIgnoredCanonicalFields() []string {
+	return l.conditionalIgnoredCanonicalFieldPaths
+}
+
+// AddConditionalIgnoredCanonicalFields sets conditional ignored canonical fields
+func (l *LateInitializer) AddConditionalIgnoredCanonicalFields(cf string) {
+	if l.conditionalIgnoredCanonicalFieldPaths == nil {
+		l.conditionalIgnoredCanonicalFieldPaths = make([]string, 0)
+	}
+	l.conditionalIgnoredCanonicalFieldPaths = append(l.conditionalIgnoredCanonicalFieldPaths, cf)
 }
 
 // GetFieldPaths returns the fieldPaths map for Sensitive

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -124,6 +124,15 @@ func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
     {{ range .LateInitializer.IgnoredFields -}}
         opts = append(opts, resource.WithNameFilter("{{ . }}"))
     {{ end }}
+    {{- if gt (len .LateInitializer.ConditionalIgnoredFields) 0 -}}
+        initParams, err := tr.GetInitParameters()
+        if err != nil {
+            return false, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
+        }
+        {{ range .LateInitializer.ConditionalIgnoredFields -}}
+            opts = append(opts, resource.WithConditionalFilter("{{ . }}", initParams))
+        {{ end }}
+    {{ end }}
 
     li := resource.NewGenericLateInitializer(opts...)
     return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -59,7 +59,8 @@ func (tg *TerraformedGenerator) Generate(cfgs []*terraformedInput, apiVersion st
 			"Fields": cfg.Sensitive.GetFieldPaths(),
 		}
 		vars["LateInitializer"] = map[string]any{
-			"IgnoredFields": cfg.LateInitializer.GetIgnoredCanonicalFields(),
+			"IgnoredFields":            cfg.LateInitializer.GetIgnoredCanonicalFields(),
+			"ConditionalIgnoredFields": cfg.LateInitializer.GetConditionalIgnoredCanonicalFields(),
 		}
 
 		if err := trFile.Write(filePath, vars, os.ModePerm); err != nil {

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -104,7 +104,7 @@ func getDocString(cfg *config.Resource, f *Field, tfPath []string) string { //no
 }
 
 // NewField returns a constructed Field object.
-func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema, snakeFieldName string, tfPath, xpPath, names []string, asBlocksMode bool) (*Field, error) {
+func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema, snakeFieldName string, tfPath, xpPath, names []string, asBlocksMode bool) (*Field, error) { //nolint:gocyclo // easy to follow
 	f := &Field{
 		Schema:         sch,
 		Name:           name.NewFromSnake(snakeFieldName),
@@ -159,6 +159,12 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 		//  doesn't match anything, it's no-op in late-init logic anyway.
 		if ignoreField == traverser.FieldPath(f.TerraformPaths) {
 			cfg.LateInitializer.AddIgnoredCanonicalFields(traverser.FieldPath(f.CanonicalPaths))
+		}
+	}
+
+	for _, ignoreField := range cfg.LateInitializer.ConditionalIgnoredFields {
+		if ignoreField == traverser.FieldPath(f.TerraformPaths) {
+			cfg.LateInitializer.AddConditionalIgnoredCanonicalFields(traverser.FieldPath(f.CanonicalPaths))
 		}
 	}
 


### PR DESCRIPTION
### Description of your changes

This PR adds a new late-init API to skip already filled field in `spec.initProvider`.

Even though a field is specified in initProvider, it is late-init for forProvider. This can cause problems in some cases because `forProvider` is more powerful. With this new configuration API, the late-init operation of the field in `forProvider` can be skipped for fields set in `initProvider`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in provider-aws by using this configuration. The example configuration for aws ec2.Subnet resource:

```go
	p.AddResourceConfigurator("aws_subnet", func(r *config.Resource) {
		r.LateInitializer = config.LateInitializer{
			ConditionalIgnoredFields: []string{
				"cidr_block",
			},
		}
	})
```

Generated `LateInitialize` function:

```go
func (tr *Subnet) LateInitialize(attrs []byte) (bool, error) {
	params := &SubnetParameters_2{}
	if err := json.TFParser.Unmarshal(attrs, params); err != nil {
		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
	}
	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
	initParams, err := tr.GetInitParameters()
	if err != nil {
		return false, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
	}
	opts = append(opts, resource.WithConditionalFilter("CidrBlock", initParams))

	li := resource.NewGenericLateInitializer(opts...)
	return li.LateInitialize(&tr.Spec.ForProvider, params)
}
```

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
