### PR TITLE
Fix singleton list example conversion if there's no annotation

### DIFF
--- a/pkg/examples/conversion/example_conversions.go
+++ b/pkg/examples/conversion/example_conversions.go
@@ -81,7 +81,7 @@ func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licens
 						}
 						converted, err := conversion.Convert(e.Object, conversionPaths, conversion.ToEmbeddedObject)
 						if err != nil {
-							return errors.Wrap(err, "failed to convert example to embedded object")
+							return errors.Wrapf(err, "failed to convert example to embedded object in manifest %s", path)
 						}
 						e.Object = converted
 						e.SetGroupVersionKind(k8sschema.GroupVersionKind{

--- a/pkg/examples/conversion/example_conversions.go
+++ b/pkg/examples/conversion/example_conversions.go
@@ -13,16 +13,21 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/crossplane/upjet/pkg/config"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 
+	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/config/conversion"
 )
 
+// ConvertSingletonListToEmbeddedObject generates the example manifests for
+// the APIs with converted singleton lists in their new API versions with the
+// embedded objects. All manifests under `startPath` are scanned and the
+// header at the specified path `licenseHeaderPath` is used for the converted
+// example manifests.
 func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licenseHeaderPath string) error {
 	resourceRegistry := prepareResourceRegistry(pc)
 
@@ -86,6 +91,10 @@ func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licens
 						})
 					}
 					annotations := e.GetAnnotations()
+					if annotations == nil {
+						annotations = make(map[string]string)
+						log.Printf("Missing annotations: %s", path)
+					}
 					annotations["meta.upbound.io/example-id"] = annotationValue
 					e.SetAnnotations(annotations)
 				}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
If the example manifest being converted with a singleton list has no annotations set, the converter currently panics. This PR proposes to initialize with an empty map to gracefully handle these cases and also logs the problematic manifests so that the missing `meta.upbound.io/example-id` can be added.
 

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested against https://github.com/crossplane-contrib/provider-upjet-aws/pull/1332.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
