### PR TITLE
Add config.Resource.RemoveSingletonListConversion

### DIFF
--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -373,7 +373,7 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 		p.Resources[name].useTerraformPluginFrameworkClient = isPluginFrameworkResource
 		// traverse the Terraform resource schema to initialize the upjet Resource
 		// configurations
-		if err := TraverseSchemas(name, terraformResource, p.Resources[name], p.schemaTraversers...); err != nil {
+		if err := TraverseSchemas(name, p.Resources[name], p.schemaTraversers...); err != nil {
 			panic(errors.Wrap(err, "failed to execute the Terraform schema traverser chain"))
 		}
 	}

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -373,7 +373,7 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 		p.Resources[name].useTerraformPluginFrameworkClient = isPluginFrameworkResource
 		// traverse the Terraform resource schema to initialize the upjet Resource
 		// configurations
-		if err := traverseSchemas(name, terraformResource, p.Resources[name], p.schemaTraversers...); err != nil {
+		if err := TraverseSchemas(name, terraformResource, p.Resources[name], p.schemaTraversers...); err != nil {
 			panic(errors.Wrap(err, "failed to execute the Terraform schema traverser chain"))
 		}
 	}

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -693,6 +693,28 @@ func (r *Resource) AddSingletonListConversion(tfPath, crdPath string) {
 	r.listConversionPaths[tfPath] = crdPath
 }
 
+// RemoveSingletonListConversion removes the singleton list conversion
+// for the specified Terraform configuration path. Also unsets the path's
+// embedding mode. The specified fieldpath expression must be a Terraform
+// field path with or without the wildcard segments. Returns true if
+// the path has already been registered for singleton list conversion.
+func (r *Resource) RemoveSingletonListConversion(tfPath string) bool {
+	nPath := strings.ReplaceAll(tfPath, "[*]", "")
+	nPath = strings.ReplaceAll(nPath, "[0]", "")
+	for p := range r.listConversionPaths {
+		n := strings.ReplaceAll(p, "[*]", "")
+		n = strings.ReplaceAll(n, "[0]", "")
+		if n == nPath {
+			delete(r.listConversionPaths, p)
+			if r.SchemaElementOptions[n] != nil {
+				r.SchemaElementOptions[n].EmbeddedObject = false
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // SetEmbeddedObject sets the EmbeddedObject for the specified key.
 // The key is a Terraform field path without the wildcard segments.
 func (m SchemaElementOptions) SetEmbeddedObject(el string) {

--- a/pkg/config/schema_conversions.go
+++ b/pkg/config/schema_conversions.go
@@ -17,7 +17,11 @@ type ResourceSetter interface {
 	SetResource(r *Resource)
 }
 
-func traverseSchemas(tfName string, tfResource *schema.Resource, r *Resource, visitors ...traverser.SchemaTraverser) error {
+// TraverseSchemas visits the specified schema belonging to the Terraform
+// resource with the given name and given upjet resource configuration using
+// the specified visitors. If any visitors report an error, traversal is
+// stopped and the error is reported to the caller.
+func TraverseSchemas(tfName string, tfResource *schema.Resource, r *Resource, visitors ...traverser.SchemaTraverser) error {
 	// set the upjet Resource configuration as context for the visitors that
 	// satisfy the ResourceSetter interface.
 	for _, v := range visitors {

--- a/pkg/config/schema_conversions.go
+++ b/pkg/config/schema_conversions.go
@@ -18,11 +18,14 @@ type ResourceSetter interface {
 	SetResource(r *Resource)
 }
 
+// ResourceSchema represents a provider's resource schema.
+type ResourceSchema map[string]*Resource
+
 // TraverseTFSchemas traverses the Terraform schemas of all the resources of
 // the Provider `p` using the specified visitors. Reports any errors
 // encountered.
-func (p *Provider) TraverseTFSchemas(visitors ...traverser.SchemaTraverser) error {
-	for name, cfg := range p.Resources {
+func (s ResourceSchema) TraverseTFSchemas(visitors ...traverser.SchemaTraverser) error {
+	for name, cfg := range s {
 		if err := TraverseSchemas(name, cfg, visitors...); err != nil {
 			return errors.Wrapf(err, "failed to traverse the schema of the Terraform resource with name %q", name)
 		}

--- a/pkg/config/schema_conversions_test.go
+++ b/pkg/config/schema_conversions_test.go
@@ -155,7 +155,7 @@ func TestSingletonListEmbedder(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			e := &SingletonListEmbedder{}
 			r := DefaultResource(tt.args.name, tt.args.resource, nil, nil)
-			err := TraverseSchemas(tt.args.name, tt.args.resource, r, e)
+			err := TraverseSchemas(tt.args.name, r, e)
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Fatalf("\n%s\ntraverseSchemas(name, schema, ...): -wantErr, +gotErr:\n%s", tt.reason, diff)
 			}

--- a/pkg/config/schema_conversions_test.go
+++ b/pkg/config/schema_conversions_test.go
@@ -155,7 +155,7 @@ func TestSingletonListEmbedder(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			e := &SingletonListEmbedder{}
 			r := DefaultResource(tt.args.name, tt.args.resource, nil, nil)
-			err := traverseSchemas(tt.args.name, tt.args.resource, r, e)
+			err := TraverseSchemas(tt.args.name, tt.args.resource, r, e)
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Fatalf("\n%s\ntraverseSchemas(name, schema, ...): -wantErr, +gotErr:\n%s", tt.reason, diff)
 			}

--- a/pkg/config/schema_conversions_test.go
+++ b/pkg/config/schema_conversions_test.go
@@ -155,7 +155,10 @@ func TestSingletonListEmbedder(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			e := &SingletonListEmbedder{}
 			r := DefaultResource(tt.args.name, tt.args.resource, nil, nil)
-			err := TraverseSchemas(tt.args.name, r, e)
+			s := ResourceSchema{
+				tt.args.name: r,
+			}
+			err := s.TraverseTFSchemas(e)
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Fatalf("\n%s\ntraverseSchemas(name, schema, ...): -wantErr, +gotErr:\n%s", tt.reason, diff)
 			}

--- a/pkg/schema/traverser/access.go
+++ b/pkg/schema/traverser/access.go
@@ -18,7 +18,7 @@ type SchemaAccessor func(*schema.Schema) error
 // the accessors. The terminal node at the end of the specified path must be
 // a *schema.Resource or an error will be reported. The specified path must
 // have at least one component.
-func AccessSchema(sch any, path []string, accessors ...SchemaAccessor) error {
+func AccessSchema(sch any, path []string, accessors ...SchemaAccessor) error { //nolint:gocyclo // easier to follow the flow
 	if len(path) == 0 {
 		return errors.New("empty path specified while accessing the Terraform resource schema")
 	}

--- a/pkg/schema/traverser/access.go
+++ b/pkg/schema/traverser/access.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traverser
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pkg/errors"
+)
+
+// SchemaAccessor is a function that accesses and potentially modifies a
+// Terraform schema.
+type SchemaAccessor func(*schema.Schema) error
+
+// AccessSchema accesses the schema element at the specified path and calls
+// the given schema accessors in order. Reports any errors encountered by
+// the accessors. The terminal node at the end of the specified path must be
+// a *schema.Resource or an error will be reported. The specified path must
+// have at least one component.
+func AccessSchema(sch any, path []string, accessors ...SchemaAccessor) error {
+	if len(path) == 0 {
+		return errors.New("empty path specified while accessing the Terraform resource schema")
+	}
+	k := path[0]
+	path = path[1:]
+	switch s := sch.(type) {
+	case *schema.Schema:
+		if len(path) == 0 {
+			return errors.Errorf("terminal node at key %q is a *schema.Schema", k)
+		}
+		if k != wildcard {
+			return errors.Errorf("expecting a wildcard key but encountered the key %q", k)
+		}
+		if err := AccessSchema(s.Elem, path, accessors...); err != nil {
+			return err
+		}
+	case *schema.Resource:
+		c := s.Schema[k]
+		if c == nil {
+			return errors.Errorf("schema element for key %q is nil", k)
+		}
+		if len(path) == 0 {
+			for _, a := range accessors {
+				if err := a(c); err != nil {
+					return errors.Wrapf(err, "failed to call the accessor function on the schema element at key %q", k)
+				}
+			}
+			return nil
+		}
+		if err := AccessSchema(c, path, accessors...); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("unknown schema element type %T at key %q", s, k)
+	}
+	return nil
+}

--- a/pkg/schema/traverser/maxitemssync.go
+++ b/pkg/schema/traverser/maxitemssync.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traverser
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pkg/errors"
+)
+
+// maxItemsSync is a visitor to sync the MaxItems constraints from the
+// Go schema to the JSON schema. We've observed that some MaxItems constraints
+// in the JSON schemas are not set where the corresponding MaxItems constraints
+// in the Go schemas are set to 1. This inconsistency results in some singleton
+// lists not being properly converted in the MR API whereas at runtime we may
+// try to invoke the corresponding Terraform conversion functions. This
+// traverser can mitigate such inconsistencies by syncing the MaxItems
+// constraints from the Go schema to the JSON schema.
+type maxItemsSync struct {
+	NoopTraverser
+
+	jsonSchema TFResourceSchema
+}
+
+// NewMaxItemsSync returns a new schema traverser capable of
+// syncing the MaxItems constraints from the Go schema to the specified JSON
+// schema. This will ensure the generation time and the runtime schema MaxItems
+// constraints will be consistent. This is needed only if the generation time
+// and runtime schemas differ.
+func NewMaxItemsSync(s TFResourceSchema) SchemaTraverser {
+	return &maxItemsSync{
+		jsonSchema: s,
+	}
+}
+
+func (m *maxItemsSync) VisitResource(r *ResourceNode) error {
+	// this visitor only works on singleton lists
+	if (r.Schema.Type != schema.TypeList && r.Schema.Type != schema.TypeSet) || r.Schema.MaxItems != 1 {
+		return nil
+	}
+	return errors.Wrapf(AccessSchema(m.jsonSchema[r.TFName], r.TFPath,
+		func(s *schema.Schema) error {
+			s.MaxItems = 1
+			return nil
+		}), "failed to access the schema element at path %v for resource %q", r.TFPath, r.TFName)
+}

--- a/pkg/schema/traverser/maxitemssync_test.go
+++ b/pkg/schema/traverser/maxitemssync_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package traverser
+
+import (
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestMaxItemsSync(t *testing.T) {
+	type args struct {
+		srcSchema    TFResourceSchema
+		targetSchema TFResourceSchema
+	}
+	type want struct {
+		targetSchema TFResourceSchema
+		err          error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"SyncMaxItemsConstraints": {
+			reason: `maxItemsSync traverser can successfully sync the "MaxItems = 1" constraints from the source schema to the target schema.`,
+			args: args{
+				srcSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 1,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+				targetSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 0,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				targetSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 1,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"NoSyncMaxItems": {
+			reason: "If the MaxItems constraint is greater than 1, then maxItemsSync should not sync the constraint.",
+			args: args{
+				srcSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 2,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+				targetSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 0,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				targetSchema: map[string]*schema.Resource{
+					"test_resource": {
+						Schema: map[string]*schema.Schema{
+							"argument": {
+								MaxItems: 0,
+								Type:     schema.TypeList,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			copySrc := copySchema(tc.args.srcSchema)
+			got := tc.args.srcSchema.Traverse(NewMaxItemsSync(tc.args.targetSchema))
+			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nMaxItemsSync: -wantErr, +gotErr: \n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nMaxItemsSync: -wantErr, +gotErr: \n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(copySrc, tc.srcSchema); diff != "" {
+				t.Errorf("%s\nMaxItemsSync: -wantSourceSchema, +gotSourceSchema: \n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.targetSchema, tc.args.targetSchema); diff != "" {
+				t.Errorf("%s\nMaxItemsSync: -wantTargetSchema, +gotTargetSchema: \n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func copySchema(s TFResourceSchema) TFResourceSchema {
+	result := make(TFResourceSchema)
+	for k, v := range s {
+		c := *v
+		for n, s := range v.Schema {
+			// not a deep copy but sufficient to check the schema constraints
+			s := *s
+			c.Schema[n] = &s
+		}
+		result[k] = &c
+	}
+	return result
+}

--- a/pkg/schema/traverser/traverse.go
+++ b/pkg/schema/traverser/traverse.go
@@ -144,9 +144,9 @@ func (n NoopTraverser) VisitResource(*ResourceNode) error {
 // TFResourceSchema represents a provider's Terraform resource schema.
 type TFResourceSchema map[string]*schema.Resource
 
-// TraverseTFSchemas traverses the receiver schema using the specified
+// Traverse traverses the receiver schema using the specified
 // visitors. Reports any errors encountered by the visitors.
-func (s TFResourceSchema) TraverseTFSchemas(visitors ...SchemaTraverser) error {
+func (s TFResourceSchema) Traverse(visitors ...SchemaTraverser) error {
 	for n, r := range s {
 		if err := Traverse(n, r, visitors...); err != nil {
 			return errors.Wrapf(err, "failed to traverse the schema of the Terraform resource with name %q", n)

--- a/pkg/schema/traverser/traverse.go
+++ b/pkg/schema/traverser/traverse.go
@@ -140,3 +140,17 @@ func (n NoopTraverser) VisitSchema(*SchemaNode) error {
 func (n NoopTraverser) VisitResource(*ResourceNode) error {
 	return nil
 }
+
+// TFResourceSchema represents a provider's Terraform resource schema.
+type TFResourceSchema map[string]*schema.Resource
+
+// TraverseTFSchemas traverses the receiver schema using the specified
+// visitors. Reports any errors encountered by the visitors.
+func (s TFResourceSchema) TraverseTFSchemas(visitors ...SchemaTraverser) error {
+	for n, r := range s {
+		if err := Traverse(n, r, visitors...); err != nil {
+			return errors.Wrapf(err, "failed to traverse the schema of the Terraform resource with name %q", n)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

For Terraform resources with single nested configuration blocks, we had previously introduced the [`config.Resource.SetEmbeddedObject`](https://github.com/crossplane/upjet/blob/a444cc1abcd33a361bf406f87d4f729a26d6fdae/pkg/config/resource.go#L698) that configures the field at a specified path as an embedded object rather than a singleton list. Such resources (an example is [`SecurityConfig.opensearchserverless`'s `samlOptions` field](https://github.com/crossplane-contrib/provider-upjet-aws/blob/40abec2fd4618af0b9b1896e0908a53f7071cf85/config/opensearchserverless/config.go#L14) in `crossplane-contrrib/provider-upjet-aws`) already embedded nested blocks as objects despite their schemas are declared as singleton lists. Unfortunatelly, this nesting information is not immediately available in the JSON schema and this is also the reason we have `Resource.SetEmbeddedObject` in the very first place.

For such fields, we need to prevent the singleton list to embedded object conversion at the Crossplane level because that singleton list must have already been generated as an embedded object. This is because Terraform also expects a single nested block as opposed to a list for such configuration arguments. 

Currently, the [schema traverser responsible for converting singleton lists to embedded objects](https://github.com/crossplane/upjet/blob/a444cc1abcd33a361bf406f87d4f729a26d6fdae/pkg/config/schema_conversions.go#L41) treats them as regular singleton lists as what it processes is the JSON schema and we don't have the nested block information in that schema. This PR adds `config.Resource.RemoveSingletonListConversion` so that it becomes possible to override the decisions made by the singleton list conversion schema traverser.

An example usage is as follows:
```go
	p.AddResourceConfigurator("aws_opensearchserverless_security_config", func(r *config.Resource) {
		r.RemoveSingletonListConversion("saml_options")
		// set the path saml_options as an embedded object to honor
		// its single nested block schema. We need to have it converted
		// into an embedded object but there's no need for
		// the Terraform conversion (it already needs to be treated
		// as an object at the Terraform layer and in the current MR API,
		// it's already an embedded object).
		r.SchemaElementOptions.SetEmbeddedObject("saml_options")
	})
```

This effectively prevents a new API version for the `SecurityConfig.opensearchserverless`, which would be identical (apart from the version number) to the current version and the invalid API converters installed between these two identical versions.

This PR also introduces `traverser.TFResourceSchema.Traverse`, which can be used to traverse the Terraform schemas of all the resources of a `config.Provider`. Another traverser, `traverser.maxItemsSync` can be used to sync the `MaxItems` constraints from a source schema to a target schema. An example usage is as follows:
```go
if err := traverser.TFResourceSchema(sdkProvider.ResourcesMap).Traverse(traverser.NewMaxItemsSync(p.ResourcesMap)); err != nil {
			return nil, errors.Wrap(err, "cannot sync the MaxItems constraints between the Go schema and the JSON schema")
		}
```
In this example, we would like to sync the `MaxItems` constraints from the Go schemas represented with `sdkProvider.ResourcesMap` into the JSON schemas represented with `p.ResourcesMap`. For more details, please refer to https://github.com/crossplane-contrib/provider-upjet-gcp/pull/537.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Has been validated in the context of https://github.com/crossplane-contrib/provider-upjet-aws/pull/1332.

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
