### PR TITLE
feat: add AddReference method to References

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -197,12 +197,28 @@ type TFPluginFrameworkOptions struct {
 	ComputedIdentifierAttributes []string
 }
 
+var ErrReferenceAlreadyExists = errors.New("reference for field already exists")
+
 // References represents reference resolver configurations for the fields of a
 // given resource. Key should be the field path of the field to be referenced.
 // The key is the Terraform field path of the field to be referenced.
 // Example: "vpc_id" or "forwarding_rule.certificate_name" in case of nested
 // in another object.
 type References map[string]Reference
+
+// AddReference adds a reference configuration for the given field path.
+// The fieldPath is the Terraform field path of the field to be referenced.
+//
+// Example: "vpc_id" or "forwarding_rule.certificate_name" in case of nested
+// in another object.
+func (r References) AddReference(fieldPath string, ref Reference) error {
+	if _, ok := r[fieldPath]; ok {
+		return ErrReferenceAlreadyExists
+	}
+
+	r[fieldPath] = ref
+	return nil
+}
 
 // Reference represents the Crossplane options used to generate
 // reference resolvers for fields

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -296,3 +296,34 @@ func TestRemoveSingletonListConversion(t *testing.T) {
 		})
 	}
 }
+
+func TestReferences_AddReference(t *testing.T) {
+	t.Run("Adding a reference", func(t *testing.T) {
+		r := &Resource{References: References{}}
+		err := r.References.AddReference("forwarding_rule.certificate_name", Reference{
+			TerraformName: "digitalocean_certificate",
+		})
+		if err != nil {
+			t.Fatalf("AddReference() got error: %v", err)
+		}
+		if len(r.References) != 1 {
+			t.Fatalf("AddReference() got error: %v", err)
+		}
+	})
+	t.Run("Adding twice a reference for a given field", func(t *testing.T) {
+		r := &Resource{References: References{}}
+		err := r.References.AddReference("forwarding_rule.certificate_name", Reference{
+			TerraformName: "digitalocean_certificate",
+		})
+		if err != nil {
+			t.Fatalf("AddReference() got error: %v", err)
+		}
+
+		err = r.References.AddReference("forwarding_rule.certificate_name", Reference{
+			TerraformName: "digitalocean_certificate",
+		})
+		if !errors.Is(err, ErrReferenceAlreadyExists) {
+			t.Fatalf("AddReference() should have returned an error")
+		}
+	})
+}


### PR DESCRIPTION
### Description of your changes

@haarchri was helping at https://github.com/crossplane-contrib/provider-upjet-digitalocean/pull/41 (thank you), and during the code review, I noticed a oversee where he replaced the existing `r.References` as follow:

```diff
diff --git a/config/provider.go b/config/provider.go
index 83eada3..8e69d59 100644
--- a/config/provider.go
+++ b/config/provider.go
@@ -294,13 +294,9 @@ func GetProvider() *ujconfig.Provider {
 			Type:          referenceType(pc, “project”, “v1alpha1", “Project”),
 			TerraformName: “digitalocean_project”,
 		}
-
-		r.References = map[string]ujconfig.Reference{
-			“forwarding_rule.certificate_name”: {
-				TerraformName: “digitalocean_certificate”,
-			},
+		r.References[“forwarding_rule.certificate_name”] = ujconfig.Reference{
+			TerraformName: “digitalocean_certificate”,
 		}
-
 	})
 	pc.AddResourceConfigurator(“digitalocean_domain”, func(r *ujconfig.Resource) {
 		r.ShortGroup = “dns”
```

I am glad that I saw the diff, but honestly, this is a straightforward thing to miss when they are so much code-generated files noise, or people tend to ignore those.

As @haarchri explained, "That's why I prefer this, for example, https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/config/elbv2/config.go#L13," which is a really common scenario.

I never considered using the existing style. I didn't think much about it. He didn’t try to break things. Still, we ran into the issue. Since we are talking about "style" here, it is really difficult to be objective and define who is more proper.

So, the fix here is to expose an SDK API that avoids such a mistake.

I am not proposing adding getters and setters everywhere either, just reacting to the situation and figuring out how to mitigate the issues in the future; as I usually say, "let the code teach you what to do, not the other way around."

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Unit Testing

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
