### PR TITLE
Check for nil before calling IsKnown()

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -229,6 +229,22 @@ func (c *TerraformPluginFrameworkConnector) configureProvider(ctx context.Contex
 	return providerServer, nil
 }
 
+// Filter diffs that have unknown plan values, which correspond to
+// computed fields, and null plan values, which correspond to
+// not-specified fields. Such cases cause unnecessary diff detection
+// when only computed attributes or not-specified argument diffs
+// exist in the raw diff and no actual diff exists in the
+// parametrizable attributes.
+func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(rawDiff []tftypes.ValueDiff) bool {
+	filteredDiff := make([]tftypes.ValueDiff, 0)
+	for _, diff := range rawDiff {
+		if diff.Value1 != nil && diff.Value1.IsKnown() && !diff.Value1.IsNull() {
+			filteredDiff = append(filteredDiff, diff)
+		}
+	}
+	return len(filteredDiff) > 0
+}
+
 // getDiffPlanResponse calls the underlying native TF provider's PlanResourceChange RPC,
 // and returns the planned state and whether a diff exists.
 // If plan response contains non-empty RequiresReplace (i.e. the resource needs
@@ -271,20 +287,7 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 		return nil, false, errors.Wrap(err, "cannot compare prior state and plan")
 	}
 
-	// Filter diffs that have unknown plan values, which correspond to
-	// computed fields, and null plan values, which correspond to
-	// not-specified fields. Such cases cause unnecessary diff detection
-	// when only computed attributes or not-specified argument diffs
-	// exist in the raw diff and no actual diff exists in the
-	// parametrizable attributes.
-	filteredDiff := make([]tftypes.ValueDiff, 0)
-	for _, diff := range rawDiff {
-		if diff.Value1 != nil && diff.Value1.IsKnown() && !diff.Value1.IsNull() {
-			filteredDiff = append(filteredDiff, diff)
-		}
-	}
-
-	return planResponse, len(filteredDiff) > 0, nil
+	return planResponse, n.filteredDiffExists(rawDiff), nil
 }
 
 func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg xpresource.Managed) (managed.ExternalObservation, error) { //nolint:gocyclo

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -279,7 +279,7 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 	// parametrizable attributes.
 	filteredDiff := make([]tftypes.ValueDiff, 0)
 	for _, diff := range rawDiff {
-		if diff.Value1.IsKnown() && !diff.Value1.IsNull() {
+		if diff.Value1 != nil && diff.Value1.IsKnown() && !diff.Value1.IsNull() {
 			filteredDiff = append(filteredDiff, diff)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
Check for a non-nil `Value1` before proceeding to call `IsKnown()` and `IsNull()` on it. We noticed a stack trace when running provider-linode v0.22.0 

```
E0725 14:53:33.880315   79095 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 3017 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1039ea0c0, 0x10515e330})
        k8s.io/apimachinery@v0.29.1/pkg/util/runtime/runtime.go:75 +0xdc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:108 +0x118
panic({0x1039ea0c0?, 0x10515e330?})
        runtime/panic.go:770 +0xf0
github.com/crossplane/upjet/pkg/controller.(*terraformPluginFrameworkExternalClient).getDiffPlanResponse(0x14002aa6240, {0x103e14108, 0x14002a1c1c0}, {{0x103e1f810, 0x14002cf0270}, {0x1039bce20, 0x14002ce1b60}})
        github.com/crossplane/upjet@v1.4.0/pkg/controller/external_tfpluginfw.go:282 +0x710
github.com/crossplane/upjet/pkg/controller.(*terraformPluginFrameworkExternalClient).Observe(0x14002aa6240, {0x103e14108, 0x14002a1c1c0}, {0x103e34da8, 0x14002a2a008})
        github.com/crossplane/upjet@v1.4.0/pkg/controller/external_tfpluginfw.go:330 +0x658
github.com/crossplane/upjet/pkg/controller.(*terraformPluginFrameworkAsyncExternalClient).Observe(0x14000891880, {0x103e14108, 0x14002a1c1c0}, {0x103e34da8, 0x14002a2a008})
        github.com/crossplane/upjet@v1.4.0/pkg/controller/external_async_tfpluginfw.go:122 +0x254
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0x140001c7a00, {0x103e14108, 0x14002a1c150}, {{{0x0, 0x0}, {0x14000fafe0c, 0x3}}})
        github.com/crossplane/crossplane-runtime@v1.16.0/pkg/reconciler/managed/reconciler.go:914 +0x3554
github.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile(0x1400069ca00, {0x103e14060, 0x14002a0a210}, {{{0x0, 0x0}, {0x14000fafe0c, 0x3}}})
        github.com/crossplane/crossplane-runtime@v1.16.0/pkg/ratelimiter/reconciler.go:54 +0x178
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x140004d5040, {0x103e14060, 0x14002a0a210}, {{{0x0, 0x0}, {0x14000fafe0c, 0x3}}})
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:119 +0x168
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x140004d5040, {0x103e14060, 0x14002a0a210}, {0x103b24880, 0x14000890dc0})
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:316 +0x3c0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x140004d5040, {0x103e14098, 0x140005e7bd0})
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:266 +0x340
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:227 +0xd0
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 158
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:223 +0x7c4
2024-07-25T14:53:33-07:00       ERROR   Reconciler error        {"controller": "managed/objectstorage.linode.upbound.io/v1alpha1, kind=key", "namespace": "", "name": "foo", "reconcileID": "f491b43c-3e72-4dfe-b646-44c8395c7a72", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        sigs.k8s.io/controller-runtime@v0.17.0/pkg/internal/controller/controller.go:227
```

attaching a debugger and looking at the `rawDiff` slice showed a bunch of resources with a `nil` Value1. Adding a check before calling functions on that value fixed the problem.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
