### PR TITLE
Recover from panics in async external clients

### DIFF
--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -13,6 +14,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/upjet/pkg/config"
@@ -131,6 +133,34 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 	return o, err
 }
 
+// recoverIfPanic recovers from panics, if any. On recovery, API
+// machinery panic handlers are run first. Then, the custom panic
+// handler given as argument is called with the panic message. The
+// implementation follows the outline of panic recovery mechanism in
+// controller-runtime:
+// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.17.3/pkg/internal/controller/controller.go#L105-L112
+func recoverIfPanic(panicHandler func(panicErr error)) {
+	if r := recover(); r != nil {
+		for _, fn := range utilruntime.PanicHandlers {
+			fn(r)
+		}
+
+		err := fmt.Errorf("panic: %v [recovered]", r)
+		panicHandler(err)
+	}
+}
+
+func (n *terraformPluginFrameworkAsyncExternalClient) finishCreate(ctx context.Context, mg xpresource.Managed, errInCreate error) {
+	err := tferrors.NewAsyncCreateFailed(errInCreate)
+	n.opTracker.LastOperation.SetError(err)
+	n.opTracker.logger.Debug("Async create ended.", "error", err)
+
+	n.opTracker.LastOperation.MarkEnd()
+	if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
+		n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
+	}
+}
+
 func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, mg xpresource.Managed) (managed.ExternalCreation, error) {
 	if !n.opTracker.LastOperation.MarkStart("create") {
 		return managed.ExternalCreation{}, errors.Errorf("%s operation that started at %s is still running", n.opTracker.LastOperation.Type, n.opTracker.LastOperation.StartTime().String())
@@ -138,21 +168,28 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel()
+		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
+		defer recoverIfPanic(func(panicErr error) {
+			n.finishCreate(ctx, mg, panicErr)
+		})
 
 		n.opTracker.logger.Debug("Async create starting...")
 		_, err := n.terraformPluginFrameworkExternalClient.Create(ctx, mg)
-		err = tferrors.NewAsyncCreateFailed(err)
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async create ended.", "error", err)
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
-		}
+		n.finishCreate(ctx, mg, err)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
+}
+
+func (n *terraformPluginFrameworkAsyncExternalClient) finishUpdate(ctx context.Context, mg xpresource.Managed, errInUpdate error) {
+	err := tferrors.NewAsyncUpdateFailed(errInUpdate)
+	n.opTracker.LastOperation.SetError(err)
+	n.opTracker.logger.Debug("Async update ended.", "error", err)
+
+	n.opTracker.LastOperation.MarkEnd()
+	if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
+		n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
+	}
 }
 
 func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, mg xpresource.Managed) (managed.ExternalUpdate, error) {
@@ -162,21 +199,28 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel()
+		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
+		defer recoverIfPanic(func(panicErr error) {
+			n.finishUpdate(ctx, mg, panicErr)
+		})
 
 		n.opTracker.logger.Debug("Async update starting...")
 		_, err := n.terraformPluginFrameworkExternalClient.Update(ctx, mg)
-		err = tferrors.NewAsyncUpdateFailed(err)
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async update ended.", "error", err)
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
-		}
+		n.finishUpdate(ctx, mg, err)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()
+}
+
+func (n *terraformPluginFrameworkAsyncExternalClient) finishDelete(ctx context.Context, mg xpresource.Managed, errInDelete error) {
+	err := tferrors.NewAsyncDeleteFailed(errInDelete)
+	n.opTracker.LastOperation.SetError(err)
+	n.opTracker.logger.Debug("Async delete ended.", "error", err)
+
+	n.opTracker.LastOperation.MarkEnd()
+	if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
+		n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
+	}
 }
 
 func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, mg xpresource.Managed) error {
@@ -190,17 +234,14 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel()
+		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
+		defer recoverIfPanic(func(panicErr error) {
+			n.finishDelete(ctx, mg, panicErr)
+		})
 
 		n.opTracker.logger.Debug("Async delete starting...")
-		err := tferrors.NewAsyncDeleteFailed(n.terraformPluginFrameworkExternalClient.Delete(ctx, mg))
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async delete ended.", "error", err)
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
-		}
+		err := n.terraformPluginFrameworkExternalClient.Delete(ctx, mg)
+		n.finishDelete(ctx, mg, err)
 	}()
 
 	return n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -133,31 +133,28 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 	return o, err
 }
 
-// recoverIfPanic recovers from panics, if any. On recovery, API
-// machinery panic handlers are run first. Then, the custom panic
-// handler given as argument is called with the panic message. The
-// implementation follows the outline of panic recovery mechanism in
+// panicHandler wraps an error, so that deferred functions that will
+// be executed on a panic can access the error more conveniently.
+type panicHandler struct {
+	err error
+}
+
+// recoverIfPanic recovers from panics, if any. Calls to this function
+// should be defferred directly: `defer ph.recoverIfPanic()`. Panic
+// recovery won't work if the call is wrapped in another function
+// call, such as `defer func() { ph.recoverIfPanic() }()`. On
+// recovery, API machinery panic handlers run. The implementation
+// follows the outline of panic recovery mechanism in
 // controller-runtime:
 // https://github.com/kubernetes-sigs/controller-runtime/blob/v0.17.3/pkg/internal/controller/controller.go#L105-L112
-func recoverIfPanic(panicHandler func(panicErr error)) {
+func (ph *panicHandler) recoverIfPanic() {
+	ph.err = nil
 	if r := recover(); r != nil {
 		for _, fn := range utilruntime.PanicHandlers {
 			fn(r)
 		}
 
-		err := fmt.Errorf("panic: %v [recovered]", r)
-		panicHandler(err)
-	}
-}
-
-func (n *terraformPluginFrameworkAsyncExternalClient) finishCreate(ctx context.Context, mg xpresource.Managed, errInCreate error) {
-	err := tferrors.NewAsyncCreateFailed(errInCreate)
-	n.opTracker.LastOperation.SetError(err)
-	n.opTracker.logger.Debug("Async create ended.", "error", err)
-
-	n.opTracker.LastOperation.MarkEnd()
-	if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
-		n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
+		ph.err = fmt.Errorf("recovered from panic: %v", r)
 	}
 }
 
@@ -168,28 +165,30 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
-		defer recoverIfPanic(func(panicErr error) {
-			n.finishCreate(ctx, mg, panicErr)
-		})
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
+		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncCreateFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async create ended.", "error", err)
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async create starting...")
-		_, err := n.terraformPluginFrameworkExternalClient.Create(ctx, mg)
-		n.finishCreate(ctx, mg, err)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Create(ctx, mg)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
-}
-
-func (n *terraformPluginFrameworkAsyncExternalClient) finishUpdate(ctx context.Context, mg xpresource.Managed, errInUpdate error) {
-	err := tferrors.NewAsyncUpdateFailed(errInUpdate)
-	n.opTracker.LastOperation.SetError(err)
-	n.opTracker.logger.Debug("Async update ended.", "error", err)
-
-	n.opTracker.LastOperation.MarkEnd()
-	if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
-		n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
-	}
 }
 
 func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, mg xpresource.Managed) (managed.ExternalUpdate, error) {
@@ -199,28 +198,30 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
-		defer recoverIfPanic(func(panicErr error) {
-			n.finishUpdate(ctx, mg, panicErr)
-		})
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
+		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncUpdateFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async update ended.", "error", err)
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async update starting...")
-		_, err := n.terraformPluginFrameworkExternalClient.Update(ctx, mg)
-		n.finishUpdate(ctx, mg, err)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Update(ctx, mg)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()
-}
-
-func (n *terraformPluginFrameworkAsyncExternalClient) finishDelete(ctx context.Context, mg xpresource.Managed, errInDelete error) {
-	err := tferrors.NewAsyncDeleteFailed(errInDelete)
-	n.opTracker.LastOperation.SetError(err)
-	n.opTracker.logger.Debug("Async delete ended.", "error", err)
-
-	n.opTracker.LastOperation.MarkEnd()
-	if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
-		n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
-	}
 }
 
 func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, mg xpresource.Managed) error {
@@ -234,14 +235,27 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, 
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
-		defer cancel() // Cancel the context after panic recovery, because the context is used in the custom panic handler below.
-		defer recoverIfPanic(func(panicErr error) {
-			n.finishDelete(ctx, mg, panicErr)
-		})
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
+		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncDeleteFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async delete ended.", "error", err)
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async delete starting...")
-		err := n.terraformPluginFrameworkExternalClient.Delete(ctx, mg)
-		n.finishDelete(ctx, mg, err)
+		ph.err = n.terraformPluginFrameworkExternalClient.Delete(ctx, mg)
 	}()
 
 	return n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -143,18 +143,27 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
 		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncCreateFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async create ended.", "error", err, "tfID", n.opTracker.GetTfID())
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async create starting...", "tfID", n.opTracker.GetTfID())
-		_, err := n.terraformPluginSDKExternal.Create(ctx, mg)
-		err = tferrors.NewAsyncCreateFailed(err)
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async create ended.", "error", err, "tfID", n.opTracker.GetTfID())
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
-		}
+		_, ph.err = n.terraformPluginSDKExternal.Create(ctx, mg)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
@@ -167,18 +176,27 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
 		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncUpdateFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async update ended.", "error", err, "tfID", n.opTracker.GetTfID())
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async update starting...", "tfID", n.opTracker.GetTfID())
-		_, err := n.terraformPluginSDKExternal.Update(ctx, mg)
-		err = tferrors.NewAsyncUpdateFailed(err)
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async update ended.", "error", err, "tfID", n.opTracker.GetTfID())
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
-		}
+		_, ph.err = n.terraformPluginSDKExternal.Update(ctx, mg)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()
@@ -195,17 +213,27 @@ func (n *terraformPluginSDKAsyncExternal) Delete(_ context.Context, mg xpresourc
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
 	go func() {
+		// The order of deferred functions, executed last-in-first-out, is
+		// significant. The context should be canceled last, because it is
+		// used by the finishing operations. Panic recovery should execute
+		// first, because the finishing operations report the panic error,
+		// if any.
+		var ph panicHandler
 		defer cancel()
+		defer func() { // Finishing operations
+			err := tferrors.NewAsyncDeleteFailed(ph.err)
+			n.opTracker.LastOperation.SetError(err)
+			n.opTracker.logger.Debug("Async delete ended.", "error", err, "tfID", n.opTracker.GetTfID())
+
+			n.opTracker.LastOperation.MarkEnd()
+			if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
+				n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
+			}
+		}()
+		defer ph.recoverIfPanic()
 
 		n.opTracker.logger.Debug("Async delete starting...", "tfID", n.opTracker.GetTfID())
-		err := tferrors.NewAsyncDeleteFailed(n.terraformPluginSDKExternal.Delete(ctx, mg))
-		n.opTracker.LastOperation.SetError(err)
-		n.opTracker.logger.Debug("Async delete ended.", "error", err, "tfID", n.opTracker.GetTfID())
-
-		n.opTracker.LastOperation.MarkEnd()
-		if cErr := n.callback.Destroy(mg.GetName())(err, ctx); cErr != nil {
-			n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
-		}
+		ph.err = n.terraformPluginSDKExternal.Delete(ctx, mg)
 	}()
 
 	return n.opTracker.LastOperation.Error()


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This PR implements a panic recovery mechanism for async external clients. [Controller runtime](https://github.com/kubernetes-sigs/controller-runtime) can be [configured to recover from panics](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.17.3/pkg/controller/controller.go#L46-L48), which Crossplane runtime adopted in https://github.com/crossplane/crossplane-runtime/pull/493. Unfortunately, that recovery mechanism doesn't apply to the Goroutines started by async external clients ([an example](https://github.com/crossplane/upjet/blob/main/pkg/controller/external_async_tfpluginfw.go#L140-L153)). Therefore, panics in async code would crash pods as reported in https://github.com/crossplane-contrib/provider-upjet-aws/issues/1242. 

With this PR, panic is logged and reconciliation continues, without the pod crashing.
```console
2024-08-22T12:20:22+03:00	DEBUG	provider-aws	Async create ended.	{"trackerUID": "b1a58d9b-2236-4740-9a90-c169b5d2e538", "resourceName": "test-async-panic-handler-securitygroupingressrule", "gvk": "ec2.aws.upbound.io/v1beta1, Kind=SecurityGroupIngressRule", "error": "async create failed: panic: runtime error: index out of range [0] with length 0 [recovered]"}
```

There is one behavioral difference compared to the sync external client panic handling: Upon panicking during resource creation, async external client continues reconciling the resource and panicking each time, whereas sync external client stops reconciliation because of the existence of `external-create-failed` annotation on the resource. The async behavior is different, because Crossplane runtime is not async aware. Async clients let Crossplane runtime set `external-create-succeeded` annotation in order to be able to do the creation asynchronously. Having `external-create-succeeded` annotation prevents reconciliation from stopping even in the existence of `external-create-failed` annotation.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Thanks to @haarchri's [discovery](https://github.com/crossplane-contrib/provider-upjet-aws/issues/1242#issuecomment-2270899346), I triggered a panic using the manifest below. [`SecurityGroupIngressRule`](https://github.com/hashicorp/terraform-provider-aws/blob/v5.58.0/internal/service/ec2/vpc_security_group_ingress_rule.go#L43) is a Terraform Plugin Framework resource, whereas [`SecurityGroup`](https://github.com/hashicorp/terraform-provider-aws/blob/v5.58.0/internal/service/ec2/vpc_security_group.go#L36) and [`VPC`](https://github.com/hashicorp/terraform-provider-aws/blob/v5.58.0/internal/service/ec2/vpc_.go#L40) are Plugin SDKv2 resources.

```yaml
apiVersion: ec2.aws.upbound.io/v1beta1
kind: SecurityGroupIngressRule
metadata:
  name: test-async-panic-handler-securitygroupingressrule
spec:
  forProvider:
    # Omitting `cidrIpv4` panics the provider.
    # cidrIpv4: 10.0.0.0/8
    fromPort: 8080
    ipProtocol: tcp
    region: us-west-1
    securityGroupIdRef:
      name: test-async-panic-handler-securitygroup
    tags:
      Name: test-async-panic-handler-securitygroupingressrule
    toPort: 8080

---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: SecurityGroup
metadata:
  name: test-async-panic-handler-securitygroup
spec:
  forProvider:
    region: us-west-1
    tags:
      Name: test-async-panic-handler-securitygroup
    vpcIdRef:
      name: test-async-panic-handler-vpc

---
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
metadata:
  name: test-async-panic-handler-vpc
spec:
  forProvider:
    cidrBlock: 172.16.0.0/16
    region: us-west-1
    tags:
      Name: test-async-panic-handler-vpc
```

[Terraform provider panics](https://github.com/upbound/terraform-provider-aws/blob/v5.58.0-upjet.1/internal/service/ec2/vpc_security_group_ingress_rule.go#L84) with message:

```console
E0822 12:19:21.286186   84654 runtime.go:79] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
```

[contribution process]: https://github.com/crossplane/upjet/blob/master/CONTRIBUTING.md
