### PR TITLE
Fix the issue of hiding errors

### DIFF
--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -139,13 +139,14 @@ type panicHandler struct {
 	err error
 }
 
-// recoverIfPanic recovers from panics, if any. Calls to this function
-// should be defferred directly: `defer ph.recoverIfPanic()`. Panic
-// recovery won't work if the call is wrapped in another function
-// call, such as `defer func() { ph.recoverIfPanic() }()`. On
-// recovery, API machinery panic handlers run. The implementation
-// follows the outline of panic recovery mechanism in
-// controller-runtime:
+// recoverIfPanic recovers from panics, if any. Upon recovery, the
+// error is set to a recovery message. Otherwise, the error is left
+// unmodified. Calls to this function should be defferred directly:
+// `defer ph.recoverIfPanic()`. Panic recovery won't work if the call
+// is wrapped in another function call, such as `defer func() {
+// ph.recoverIfPanic() }()`. On recovery, API machinery panic handlers
+// run. The implementation follows the outline of panic recovery
+// mechanism in controller-runtime:
 // https://github.com/kubernetes-sigs/controller-runtime/blob/v0.17.3/pkg/internal/controller/controller.go#L105-L112
 func (ph *panicHandler) recoverIfPanic() {
 	if r := recover(); r != nil {

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -148,7 +148,6 @@ type panicHandler struct {
 // controller-runtime:
 // https://github.com/kubernetes-sigs/controller-runtime/blob/v0.17.3/pkg/internal/controller/controller.go#L105-L112
 func (ph *panicHandler) recoverIfPanic() {
-	ph.err = nil
 	if r := recover(); r != nil {
 		for _, fn := range utilruntime.PanicHandlers {
 			fn(r)


### PR DESCRIPTION
### Description of your changes

We encountered an issue where error messages were hidden/not visible in recent provider releases. When we try to create a resource with incorrect or incomplete configuration, it gets stuck at creating false. See the discussion [here](https://github.com/crossplane-contrib/provider-upjet-gcp/issues/611#issuecomment-2334093794).

Since `recoverIfPanic` is executed first, we pass `ph.err` as nil to the finishing operations, which causes the error to be hidden.

This PR removes `ph.err = nil` from the `recoverIfPanic` func.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

After running make run in the main branch of `crossplane-contrib/provider-upjet-gcp` apply the following resource below:
```
apiVersion: cloudplatform.gcp.upbound.io/v1beta1
kind: ProjectIAMMember
metadata:
  name: project-iam-member2
spec:
  forProvider:
    member: <redacted>
    role: "roles/viewer"
    project: xxx
```
- Before this fix, the creating status gets stuck at false
```
  conditions:
  - lastTransitionTime: "2024-09-09T17:11:57Z"
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2024-09-09T17:11:57Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2024-09-09T17:12:01Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```
- After `go mod edit -replace=github.com/crossplane/upjet=github.com/turkenf/upjet@fix-nil-err`
```
  conditions:
  - lastTransitionTime: "2024-09-09T17:22:07Z"
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2024-09-09T17:23:56Z"
    message: 'create failed: async create failed: failed to create the resource: [{0
      Request `Create IAM Members roles/viewer serviceAccount:<redacted>
      for project "xxx"` returned error: Error retrieving IAM policy for project "xxx":
      googleapi: Error 403: The caller does not have permission, forbidden  []}]'
    reason: ReconcileError
    status: "False"
    type: Synced
  - lastTransitionTime: "2024-09-09T17:23:56Z"
    message: 'async create failed: failed to create the resource: [{0 Request `Create
      IAM Members roles/viewer serviceAccount:<redacted>
      for project "xxx"` returned error: Error retrieving IAM policy for project "xxx":
      googleapi: Error 403: The caller does not have permission, forbidden  []}]'
    reason: AsyncCreateFailure
    status: "False"
    type: LastAsyncOperation
```



[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
