### PR TITLE
call ApplyTFConversions in Update function from terraform plugin sdk external client

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -696,6 +696,11 @@ func (n *terraformPluginSDKExternal) Update(ctx context.Context, mg xpresource.M
 		return managed.ExternalUpdate{}, err
 	}
 
+	stateValueMap, err = n.config.ApplyTFConversions(stateValueMap, config.FromTerraform)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot convert the singleton lists for the updated resource state value map into embedded objects")
+	}
+
 	err = mg.(resource.Terraformed).SetObservation(stateValueMap)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Errorf("failed to set observation: %v", err)


### PR DESCRIPTION
Not calling ApplyTFConversions in Udate function of tf plugin sdk external client was causing unmarshalling errors for singleton lists.

### Description of your changes

add ApplyTFConversions call in Update function, after marshalling json state and before setting the observation. 

Fixes https://github.com/crossplane/upjet/issues/438

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

There are already tests in place for Update function. 

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
