### PR TITLE
fix unintentional modification of slice in GetSensitiveParameters

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -168,9 +168,8 @@ func GetSensitiveParameters(ctx context.Context, client SecretClient, from runti
 		return err
 	}
 	pavedTF := fieldpath.Pave(into)
-	prefixes := []string{"spec.initProvider.", "spec.forProvider."}
-
 	for tfPath, jsonPath := range mapping {
+		prefixes := []string{"spec.initProvider.", "spec.forProvider."}
 		jp := jsonPath
 		groups := reFieldPathSpec.FindStringSubmatch(jsonPath)
 		if len(groups) == 3 {


### PR DESCRIPTION
### Description of your changes

Fixes the `prefixes` slice variable scope in GetSensitiveParameters()

During resolution of sensitive values in secret ref, https://github.com/crossplane/upjet/pull/406 introduced support for secret refs from `initProvider` fields, which introduced a `prefixes` slice to both check fieldpaths starting with `spec.forProvider` and `spec.initProvider`

In https://github.com/crossplane/upjet/pull/417, `prefixes` slice was modified in the case of fieldspaths starting with `status.atProvider.`  in response to fix the associated issue. 

However, `prefixes` slice (that is scoped outside of for loop) was being modified in the for loop for the case above, causing remaining iterations to unintentionally operate on modified slice, resulting some secretRef fields to be not resolved into the parameters, thus failing the resource create/update operations

Affected resources are those who have connection details mapping entries include a fieldpath with `.status.atProvider` followed by some `.spec.forProvider` and `.spec.initProvider` entries.

Related https://github.com/crossplane-contrib/provider-upjet-azure/pull/873

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually and uptest at: https://github.com/crossplane-contrib/provider-upjet-azure/pull/873

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
