### PR TITLE
Remove diff calculation in observe-only reconciliation

### DIFF
--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -330,6 +330,10 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 		if e.eventHandler != nil {
 			e.eventHandler.Forget(rateLimiterStatus, mg.GetName())
 		}
+
+		// TODO(cem): Consider skipping diff calculation (terraform plan) to
+		// avoid potential config validation errors in the import path. See
+		// https://github.com/crossplane/upjet/pull/461
 		plan, err := e.workspace.Plan(ctx)
 		if err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errPlan)

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -330,6 +330,9 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 		}
 	}
 
+	// TODO(cem): Consider skipping diff calculation to avoid potential config
+	// validation errors in the import path. See
+	// https://github.com/crossplane/upjet/pull/461
 	planResponse, hasDiff, err := n.getDiffPlanResponse(ctx, tfStateValue)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot calculate diff")

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -111,15 +111,16 @@ type Resource interface {
 }
 
 type terraformPluginSDKExternal struct {
-	ts             terraform.Setup
-	resourceSchema Resource
-	config         *config.Resource
-	instanceDiff   *tf.InstanceDiff
-	params         map[string]any
-	rawConfig      cty.Value
-	logger         logging.Logger
-	metricRecorder *metrics.MetricRecorder
-	opTracker      *AsyncTracker
+	ts                          terraform.Setup
+	resourceSchema              Resource
+	config                      *config.Resource
+	instanceDiff                *tf.InstanceDiff
+	params                      map[string]any
+	rawConfig                   cty.Value
+	logger                      logging.Logger
+	metricRecorder              *metrics.MetricRecorder
+	opTracker                   *AsyncTracker
+	isManagementPoliciesEnabled bool
 }
 
 func getExtendedParameters(ctx context.Context, tr resource.Terraformed, externalName string, cfg *config.Resource, ts terraform.Setup, initParamsMerged bool, kube client.Client) (map[string]any, error) {
@@ -294,14 +295,15 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 	}
 
 	return &terraformPluginSDKExternal{
-		ts:             ts,
-		resourceSchema: c.config.TerraformResource,
-		config:         c.config,
-		params:         params,
-		rawConfig:      rawConfig,
-		logger:         logger,
-		metricRecorder: c.metricRecorder,
-		opTracker:      opTracker,
+		ts:                          ts,
+		resourceSchema:              c.config.TerraformResource,
+		config:                      c.config,
+		params:                      params,
+		rawConfig:                   rawConfig,
+		logger:                      logger,
+		metricRecorder:              c.metricRecorder,
+		opTracker:                   opTracker,
+		isManagementPoliciesEnabled: c.isManagementPoliciesEnabled,
 	}, nil
 }
 
@@ -460,6 +462,7 @@ func (n *terraformPluginSDKExternal) getResourceDataDiff(tr resource.Terraformed
 }
 
 func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.Managed) (managed.ExternalObservation, error) { //nolint:gocyclo
+	var err error
 	n.logger.Debug("Observing the external resource")
 
 	if meta.WasDeleted(mg) && n.opTracker.IsDeleted() {
@@ -492,15 +495,22 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 		diffState.Attributes = nil
 		diffState.ID = ""
 	}
-	instanceDiff, err := n.getResourceDataDiff(mg.(resource.Terraformed), ctx, diffState, resourceExists)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "cannot compute the instance diff")
+
+	n.instanceDiff = nil
+	policySet := sets.New(mg.(resource.Terraformed).GetManagementPolicies()...)
+	observeOnlyPolicy := sets.New(xpv1.ManagementActionObserve)
+	isObserveOnlyPolicy := policySet.Equal(observeOnlyPolicy)
+	if !isObserveOnlyPolicy || !n.isManagementPoliciesEnabled {
+		n.instanceDiff, err = n.getResourceDataDiff(mg.(resource.Terraformed), ctx, diffState, resourceExists)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "cannot compute the instance diff")
+		}
 	}
-	if instanceDiff == nil {
-		instanceDiff = tf.NewInstanceDiff()
+	if n.instanceDiff == nil {
+		n.instanceDiff = tf.NewInstanceDiff()
 	}
-	n.instanceDiff = instanceDiff
-	noDiff := instanceDiff.Empty()
+
+	noDiff := n.instanceDiff.Empty()
 
 	if !resourceExists && mg.GetDeletionTimestamp() != nil {
 		gvk := mg.GetObjectKind().GroupVersionKind()
@@ -533,7 +543,6 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot marshal the attributes of the new state for late-initialization")
 		}
 
-		policySet := sets.New[xpv1.ManagementAction](mg.(resource.Terraformed).GetManagementPolicies()...)
 		policyHasLateInit := policySet.HasAny(xpv1.ManagementActionLateInitialize, xpv1.ManagementActionAll)
 		if policyHasLateInit {
 			specUpdateRequired, err = mg.(resource.Terraformed).LateInitialize(buff)

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -497,7 +497,7 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 	}
 
 	n.instanceDiff = nil
-	policySet := sets.New(mg.(resource.Terraformed).GetManagementPolicies()...)
+	policySet := sets.New[xpv1.ManagementAction](mg.(resource.Terraformed).GetManagementPolicies()...)
 	observeOnlyPolicy := sets.New(xpv1.ManagementActionObserve)
 	isObserveOnlyPolicy := policySet.Equal(observeOnlyPolicy)
 	if !isObserveOnlyPolicy || !n.isManagementPoliciesEnabled {

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -510,7 +510,7 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 		n.instanceDiff = tf.NewInstanceDiff()
 	}
 
-	noDiff := n.instanceDiff.Empty()
+	hasDiff := !n.instanceDiff.Empty()
 
 	if !resourceExists && mg.GetDeletionTimestamp() != nil {
 		gvk := mg.GetObjectKind().GroupVersionKind()
@@ -556,11 +556,11 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 			return managed.ExternalObservation{}, errors.Errorf("could not set observation: %v", err)
 		}
 
-		if noDiff {
+		if !hasDiff {
 			n.metricRecorder.SetReconcileTime(mg.GetName())
 		}
 		if !specUpdateRequired {
-			resource.SetUpToDateCondition(mg, noDiff)
+			resource.SetUpToDateCondition(mg, !hasDiff)
 		}
 		// check for an external-name change
 		if nameChanged, err := n.setExternalName(mg, stateValueMap); err != nil {
@@ -572,7 +572,7 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 
 	return managed.ExternalObservation{
 		ResourceExists:          resourceExists,
-		ResourceUpToDate:        noDiff,
+		ResourceUpToDate:        !hasDiff,
 		ConnectionDetails:       connDetails,
 		ResourceLateInitialized: specUpdateRequired,
 	}, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1597.

While importing a DynamoDB Table, in the linked issue, Terraform executes [`CustomizeDiff` functions](https://github.com/hashicorp/terraform-provider-aws/blob/v5.82.2/internal/service/dynamodb/table.go#L69) when Upjet calculates the diff in `Observe()`. [One of the `CustomizeDiff` functions](https://github.com/hashicorp/terraform-provider-aws/blob/v5.82.2/internal/service/dynamodb/table.go#L74) is a validation function that checks whether the configuration that is subject to diff is valid. Because the configuration is practically empty — it only contains the resource name in the import path — validation fails and returns an error, which in turn causes our `Observe()` to fail.

I've checked how the behavior of managed reconciler changes for observe-only reconciliation. When Upjet always returns `ResourceUpToDate = true`, [this block](https://github.com/crossplane/crossplane-runtime/blob/v1.17.0/pkg/reconciler/managed/reconciler.go#L1235-L1254) executes. Otherwise, when Upjet calculates the diff and returns `ResourceUpToDate` accordingly, [this block](https://github.com/crossplane/crossplane-runtime/blob/v1.17.0/pkg/reconciler/managed/reconciler.go#L1260-L1266) executes in case `ResourceUpToDate = false`. The difference between those two blocks are (1) debug messages and (2) metric records.

The difference doesn't matter for the import path, in which `ResourceUpToDate` doesn't make much sense. We can consider `ResourceUpToDate = true`, by definition, which is the case in this PR. The difference might matter in observe-only reconciliation that is not an import operation.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

I tested manually, using the resource manifest given in the linked issue above. Here are the steps I followed:
1. Create the resource with `deletionPolicy: Orphan`.
2. Delete the resource.
3. Import the resource with `managementPolicies: ["Observe"]`.
4. Check that the import succeeded without any errors in the debug console.
5. Copy essential fields from `status.atProvider` to `spec.forProvider`.
6. Set `managementPolicies: ["*"]`.
7. Add a tag to the resource and check if the update succeeded without any errors in the console.

In addition to DynamoDB Table, I tested a VPC resource as well.

I also ran Uptests in https://github.com/crossplane-contrib/provider-upjet-aws/pull/1651.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
