### PR TITLE
Parametrize the registry name of the provider

### DIFF
--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -47,6 +47,9 @@ type ProviderRequirement struct {
 
 	// Version of the provider. An example value is "4.0"
 	Version string
+
+	// Registry of the provider. An example value is `provider["registry.terraform.io/%s"]`
+	Registry string
 }
 
 // ProviderConfiguration holds the setup configuration body


### PR DESCRIPTION
### Description of your changes

This PR parametrizes the registry name of the provider. For some private registries the hardcoded registry is not valid.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
