### PR TITLE
Expose conversion option to inject key/values in the conversion to list

### DIFF
--- a/pkg/config/tf_conversion.go
+++ b/pkg/config/tf_conversion.go
@@ -64,9 +64,9 @@ func (s singletonListConversion) Convert(params map[string]any, r *Resource, mod
 	var m map[string]any
 	switch mode {
 	case FromTerraform:
-		m, err = conversion.Convert(params, r.TFListConversionPaths(), conversion.ToEmbeddedObject)
+		m, err = conversion.Convert(params, r.TFListConversionPaths(), conversion.ToEmbeddedObject, nil)
 	case ToTerraform:
-		m, err = conversion.Convert(params, r.TFListConversionPaths(), conversion.ToSingletonList)
+		m, err = conversion.Convert(params, r.TFListConversionPaths(), conversion.ToSingletonList, nil)
 	}
 	return m, errors.Wrapf(err, "failed to convert between Crossplane and Terraform layers in mode %q", mode)
 }

--- a/pkg/examples/conversion/example_conversions.go
+++ b/pkg/examples/conversion/example_conversions.go
@@ -79,7 +79,7 @@ func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licens
 							// spec.
 							conversionPaths[i] = "spec.forProvider." + cp
 						}
-						converted, err := conversion.Convert(e.Object, conversionPaths, conversion.ToEmbeddedObject)
+						converted, err := conversion.Convert(e.Object, conversionPaths, conversion.ToEmbeddedObject, nil)
 						if err != nil {
 							return errors.Wrapf(err, "failed to convert example to embedded object in manifest %s", path)
 						}


### PR DESCRIPTION
### Description of your changes

We have observed some issue with the EKS Cluster resource where when we apply the manifest and let it to resolve references to `spec.forProvider.vpcConfig.securityGroupIds`, we noticed the following error in the status:

```
  - lastTransitionTime: "2025-02-06T07:28:46Z"
    message: 'cannot patch the managed resource via server-side apply: Cluster.eks.aws.upbound.io
      "some-eks-cluster" is invalid: [spec.forProvider.vpcConfig: Invalid
      value: "null": spec.forProvider.vpcConfig in body must be of type array: "null",
      <nil>: Invalid value: "null": some validation rules were not checked because
      the object was invalid; correct the existing errors to complete validation]'
    reason: ReconcileError
    status: "False"
    type: Synced
```

Our assumption (which is validated by observing this changes fixes the problem) is as follows:

Server Side Apply uses [merge strategies](https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy) to make decisions during merging changes by various owners/managers. In EKS Cluster object, for `vpcConfig` field, we mark `+listType` as map and `//+listMapKey` as `index`. During conversion between `v1beta1` to `v1beta2`, we convert the that field from array to object, losing the index field since it is not in the schema. This is fine in most cases since in `v1beta1` of the object schema index defaults to `"0"` , even though you don’t provide it.

However, with Server Side Apply, apparently some on the fly conversions happening when different managers using different api versions and losing index field causing unexpected merging results and drop of the whole `spec.forProvider.vpcConfig` object.

I have:

- [ ] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests and a custom build for provider-aw-eks with [this change](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1669).