### PR TITLE
add json encoded debug logging of diff detected instead of GoString to ensure readability

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -447,7 +447,17 @@ func (n *terraformPluginSDKExternal) getResourceDataDiff(tr resource.Terraformed
 		instanceDiff.RawPlan = v
 	}
 	if instanceDiff != nil && !instanceDiff.Empty() {
-		n.logger.Debug("Diff detected", "instanceDiff", instanceDiff.GoString())
+		encodedDiff, err := json.TFParser.Marshal(map[string]any{
+			"attributes":     instanceDiff.Attributes,
+			"destroy":        instanceDiff.Destroy,
+			"destroyTainted": instanceDiff.DestroyTainted,
+			"destroyDeposed": instanceDiff.DestroyDeposed,
+		})
+		if err != nil {
+			n.logger.Debug("Diff detected", "instanceDiff", instanceDiff.GoString())
+		} else {
+			n.logger.Debug("Diff detected", "instanceDiff", string(encodedDiff))
+		}
 		// Assumption: Source of truth when applying diffs, for instance on updates, is instanceDiff.Attributes.
 		// Setting instanceDiff.RawConfig has no effect on diff application.
 		instanceDiff.RawConfig = n.rawConfig


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
This change will provide debug logging in json format instead of go string. This will help when debugging why changes are not affected as this may be the only way you can figure out the different quirks of the cloud provider APIs.

This will remove type information from the output logs, but it will be parsable.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Printed out the new format during test run.

```
2025-02-28T17:39:20+01:00       DEBUG   provider-aws    Diff detected   
{"instanceDiff": "{\"attributes\":
{\"name\":
{\"Old\":\"example2\",
\"New\":\"example\",
\"NewComputed\":false,
\"NewRemoved\":false,
\"NewExtra\":null,
\"RequiresNew\":false,
\"Sensitive\":false,
\"Type\":0}},
\"destroy\":false,
\"destroyTainted\":false,
\"destroyDeposed\":false}"}
```
```
2025-02-28T17:40:28+01:00       DEBUG   provider-aws    Diff detected   
{"instanceDiff": "*terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{
\"name\":*terraform.ResourceAttrDiff{
Old:\"example2\", New:\"example\", 
NewComputed:false, NewRemoved:false, 
NewExtra:interface {}(nil), RequiresNew:false, 
Sensitive:false, Type:0x0}}, Destroy:false, 
DestroyDeposed:false, DestroyTainted:false, 
RawConfig:cty.NilVal, RawState:cty.NilVal, 
RawPlan:cty.NilVal, Meta:map[string]interface {}(nil)}"}
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
