### PR TITLE
[draft]: Type-changing conversion functions

### DIFF
--- a/pkg/config/conversion/conversions.go
+++ b/pkg/config/conversion/conversions.go
@@ -7,6 +7,7 @@ package conversion
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -148,6 +149,104 @@ func NewFieldRenameConversion(sourceVersion, sourceField, targetVersion, targetF
 		baseConversion: newBaseConversion(sourceVersion, targetVersion),
 		sourceField:    sourceField,
 		targetField:    targetField,
+	}
+}
+
+type TypeChangingMode = int
+
+const (
+	// FloatToString converts a *float64 to a string, using an empty string for nil
+	FloatToString = iota
+	// StringToFloat converts a string to a *float64, using nil for an empty string.
+	// I don't know what I should have it do if the string is not a number. Panic?
+	// Return empty string?
+	StringToFloat
+)
+
+type typeChangingFieldCopy struct {
+	baseConversion
+	paths []string
+	mode  TypeChangingMode
+}
+
+func (f *typeChangingFieldCopy) ConvertPaved(src, target *fieldpath.Paved) (bool, error) {
+	// TODO maybe refactor to instantiate these so I can extract their gvk for error messages
+	if !f.Applicable(&unstructured.Unstructured{Object: src.UnstructuredContent()},
+		&unstructured.Unstructured{Object: target.UnstructuredContent()}) {
+		return false, nil
+	}
+
+	modified := false
+	for _, p := range f.paths {
+		exp, err := src.ExpandWildcards(p)
+		if err != nil {
+			return modified, errors.Wrapf(err, "cannot expand wildcards for the field path expression %s", p)
+		}
+		for _, e := range exp {
+			v, err := src.GetValue(e)
+			if fieldpath.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return modified, errors.Wrapf(err, "failed to get the field %q from the %s conversion source object", e, f.sourceVersion)
+			}
+			switch f.mode {
+			case FloatToString:
+				// While the go stdlibrary unmarshalls all json numbers as float64, crossplane-runtime (perhaps accidentally?) uses
+				// the kubernetes json library, which delegates to UnmarshallCaseSensitivePreserveInts, which sometimes unmarshalls numbers
+				// to float64 and sometimes to int64.
+				// In order to be compatible with both types of deserialization, this can handle either float or int types.
+				strVal := fmt.Sprintf("%v", v)
+				if _, err := strconv.ParseFloat(strVal, 64); err != nil {
+					return modified, errors.Errorf("expected number at field %q with value %s in %s, got %T", e, f.sourceVersion, strVal, v)
+				}
+				err = target.SetValue(e, strVal)
+				if err != nil {
+					return modified, errors.Wrapf(err, "failed to set the field %q of the %s conversion target object", e, f.targetVersion)
+				}
+				modified = true
+			case StringToFloat:
+				strVal, ok := v.(string)
+				if !ok {
+					return modified, errors.Errorf("expected string at field %q in %s, got %T", e, f.sourceVersion, v)
+				}
+				if strVal != "" {
+					parsed, err := strconv.ParseFloat(strVal, 64)
+					if err != nil {
+						return modified, errors.Wrapf(err, "converting %s from %s to %s: failed to parse string %q as float64", e, f.sourceVersion, f.targetVersion, strVal)
+					}
+					// SetValue does a round trip json serialization/deserialization step using the kubernetes JSON library,
+					// which converts floats which are whole numbers to integers
+					err = target.SetValue(e, parsed)
+					if err != nil {
+						return modified, errors.Wrapf(err, "failed to set the field %q of the %s conversion target object", e, f.targetVersion)
+					}
+					modified = true
+				} else {
+					// Special behavior for if a string field is defined and set to "" to remove the existing contents of the field.
+					// I believe this is necessary because otherwise we would be unable to unset anything, but I need to think about it
+					// some more.
+					err := target.DeleteField(e)
+					if err != nil {
+						return modified, errors.Wrapf(err, "failed to unset the field %q of the %s conversion target object", e, f.targetVersion)
+					}
+					modified = true
+				}
+			}
+		}
+
+	}
+	return modified, nil
+}
+
+// NewTypeChangeConversion returns a new Conversion that implements a
+// conversion from the specified `sourceVersion` to the specified
+// `targetVersion` of an API that also changes the type of the field.
+func NewTypeChangeConversion(sourceVersion, targetVersion string, paths []string, mode TypeChangingMode) Conversion {
+	return &typeChangingFieldCopy{
+		baseConversion: newBaseConversion(sourceVersion, targetVersion),
+		paths:          paths,
+		mode:           mode,
 	}
 }
 

--- a/pkg/config/conversion/conversions_test.go
+++ b/pkg/config/conversion/conversions_test.go
@@ -411,6 +411,98 @@ func TestSingletonListConversion(t *testing.T) {
 				},
 			},
 		},
+		"SuccessfulNestedToEmbeddedObjectConversion": {
+			reason: "Successful conversion from a nested singleton list to an embedded object.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": []map[string]any{
+										{
+											"k": "v",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				crdPaths:      []string{"o", "o[*].n"},
+				mode:          ToEmbeddedObject,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": map[string]any{
+								"n": map[string]any{
+									"k": "v",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SuccessfulNestedToEmbeddedObjectConversionPartial": {
+			reason: "Successful conversion from an singleton list nested in a non-singleton list to an embedded object nested in a list.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": []map[string]any{
+										{
+											"k": "v",
+										},
+									},
+								},
+								{
+									"n": []map[string]any{
+										{
+											"k": "v2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				crdPaths:      []string{"o[*].n"},
+				mode:          ToEmbeddedObject,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": map[string]any{
+										"k": "v",
+									},
+								},
+								{
+									"n": map[string]any{
+										"k": "v2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"SuccessfulToSingletonListConversion": {
 			reason: "Successful conversion from an embedded object to a singleton list.",
 			args: args{
@@ -437,6 +529,98 @@ func TestSingletonListConversion(t *testing.T) {
 							"o": []map[string]any{
 								{
 									"k": "v",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SuccessfulNestedToSingletonListConversion": {
+			reason: "Successful conversion from a nested embedded object to a singleton list.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": map[string]any{
+								"n": map[string]any{
+									"k": "v",
+								},
+							},
+						},
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				crdPaths:      []string{"o", "o[*].n"},
+				mode:          ToSingletonList,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": []map[string]any{
+										{
+											"k": "v",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SuccessfulNestedToSingletonListConversionPartial": {
+			reason: "Successful conversion from an embedded object nested in a non-singleton list to a nested list.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": map[string]any{
+										"k": "v",
+									},
+								},
+								{
+									"n": map[string]any{
+										"k": "v2",
+									},
+								},
+							},
+						},
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				crdPaths:      []string{"o[*].n"},
+				mode:          ToSingletonList,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"spec": map[string]any{
+						"initProvider": map[string]any{
+							"o": []map[string]any{
+								{
+									"n": []map[string]any{
+										{
+											"k": "v",
+										},
+									},
+								},
+								{
+									"n": []map[string]any{
+										{
+											"k": "v2",
+										},
+									},
 								},
 							},
 						},

--- a/pkg/config/conversion/conversions_test.go
+++ b/pkg/config/conversion/conversions_test.go
@@ -346,6 +346,361 @@ func TestIdentityConversion(t *testing.T) {
 	}
 }
 
+func TestTypeConversion(t *testing.T) {
+	type args struct {
+		sourceVersion string
+		sourceMap     map[string]any
+		targetVersion string
+		targetMap     map[string]any
+		paths         []string
+		mode          TypeChangingMode
+	}
+	type want struct {
+		converted bool
+		err       error
+		targetMap map[string]any
+	}
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"SuccessfulConversionWholeNumberFloatToStringTopLevel": {
+			reason: "Successfully convert a top-level integer-valued float to a string.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k1": 1,
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: FloatToString,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"k1": "1",
+					"k2": "v2",
+				},
+			},
+		},
+		"SuccessfulConversionFloatToStringTopLevel": {
+			reason: "Successfully convert a top-level float to a string.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k1": 1.23,
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": 12,
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: FloatToString,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"k1": "1.23",
+					"k2": "v2",
+				},
+			},
+		},
+		"SuccessfulConversionFloatToStringMultipleValuesComplexPath": {
+			reason: "Successfully convert multiple floats to strings with complex path expressions",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"l1": []map[string]any{
+						{
+							"a": 48,
+						},
+						{
+							"a": 12,
+						},
+					},
+					"l2": []map[string]any{
+						{
+							"c": 13,
+						},
+					},
+					"o1": map[string]any{
+						"b": 14,
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				paths: []string{
+					"l1[*].a",
+					"l2[0].c",
+					"o1.b",
+				},
+				mode: FloatToString,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"l1": []map[string]any{
+						{
+							"a": "48",
+						},
+						{
+							"a": "12",
+						},
+					},
+					"l2": []map[string]any{
+						{
+							"c": "13",
+						},
+					},
+					"o1": map[string]any{
+						"b": "14",
+					},
+				},
+			},
+		},
+		"SuccessfulConversionWholeNumberStringToFloatTopLevel": {
+			reason: "Successfully convert a top-level integer-valued string to a float.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k1": "1",
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: StringToFloat,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"k1": 1,
+					"k2": "v2",
+				},
+			},
+		},
+		"SuccessfulConversionStringToFloatTopLevel": {
+			reason: "Successfully convert a top-level string to a float.",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k1": "1.23",
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: StringToFloat,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"k1": 1.23,
+					"k2": "v2",
+				},
+			},
+		},
+		"SuccessfulConversionStringToFloatMultipleValuesComplexPath": {
+			reason: "Successfully convert multiple strings to floats with complex path expressions",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"l1": []map[string]any{
+						{
+							"a": "48",
+						},
+						{
+							"a": "12",
+						},
+					},
+					"l2": []map[string]any{
+						{
+							"c": "13",
+						},
+					},
+					"o1": map[string]any{
+						"b": "14",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap:     map[string]any{},
+				paths: []string{
+					"l1[*].a",
+					"l2[0].c",
+					"o1.b",
+				},
+				mode: StringToFloat,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"l1": []map[string]any{
+						{
+							"a": 48,
+						},
+						{
+							"a": 12,
+						},
+					},
+					"l2": []map[string]any{
+						{
+							"c": 13,
+						},
+					},
+					"o1": map[string]any{
+						"b": 14,
+					},
+				},
+			},
+		},
+		"StringToFloatWithEmptyInputShouldNullOutExistingValue": {
+			reason: "Successfully remove a value from the target map when the source value is an empty string",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k1": "",
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: StringToFloat,
+			},
+			want: want{
+				converted: true,
+				targetMap: map[string]any{
+					"k2": "v2",
+				},
+			},
+		},
+		"FloatToStringWithNullInputShouldBeSkipped": {
+			reason: "Leaves the target unchanged if the field path is not present",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: FloatToString,
+			},
+			want: want{
+				converted: false,
+				targetMap: map[string]any{
+					"k1": "wrong",
+					"k2": "v2",
+				},
+			},
+		},
+		"StringToFloatWithNullInputShouldBeSkipped": {
+			reason: "Leaves the target unchanged if the field path is not present",
+			args: args{
+				sourceVersion: AllVersions,
+				sourceMap: map[string]any{
+					"k2": "v2",
+					"k3": map[string]any{
+						"nk1": "nv1",
+					},
+				},
+				targetVersion: AllVersions,
+				targetMap: map[string]any{
+					"k2": "v2",
+					"k1": "wrong",
+				},
+				paths: []string{
+					"k1",
+				},
+				mode: StringToFloat,
+			},
+			want: want{
+				converted: false,
+				targetMap: map[string]any{
+					"k1": "wrong",
+					"k2": "v2",
+				},
+			},
+		},
+	}
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			c := NewTypeChangeConversion(tc.args.sourceVersion, tc.args.targetVersion, tc.args.paths, tc.args.mode)
+			sourceMap, err := roundTrip(tc.args.sourceMap)
+			if err != nil {
+				t.Fatalf("Failed to preprocess tc.args.sourceMap: %v", err)
+			}
+			targetMap, err := roundTrip(tc.args.targetMap)
+			if err != nil {
+				t.Fatalf("Failed to preprocess tc.args.targetMap: %v", err)
+			}
+			converted, err := c.(*typeChangingFieldCopy).ConvertPaved(fieldpath.Pave(sourceMap), fieldpath.Pave(targetMap))
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("\n%s\nConvertPaved(source, target): -wantErr, +gotErr:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.converted, converted); diff != "" {
+				t.Errorf("\n%s\nConvertPaved(source, target): -wantConverted, +gotConverted:\n%s", tc.reason, diff)
+			}
+			m, err := roundTrip(tc.want.targetMap)
+			if err != nil {
+				t.Fatalf("Failed to preprocess tc.want.targetMap: %v", err)
+			}
+			if diff := cmp.Diff(m, targetMap); diff != "" {
+				t.Errorf("\n%s\nConvertPaved(source, target): -wantTarget, +gotTarget:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestDefaultPathPrefixes(t *testing.T) {
 	// no need for a table-driven test here as we assert all the parameter roots
 	// in the MR schema are asserted.

--- a/pkg/config/conversion/list_conversion_test.go
+++ b/pkg/config/conversion/list_conversion_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	kjson "sigs.k8s.io/json"
 )
 
 func TestConvert(t *testing.T) {
@@ -470,5 +471,5 @@ func roundTrip(m map[string]any) (map[string]any, error) {
 		return nil, err
 	}
 	var r map[string]any
-	return r, jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(buff, &r)
+	return r, kjson.UnmarshalCaseSensitivePreserveInts(buff, &r)
 }

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -337,7 +337,7 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 		if (isTerraformPluginSDK && isPluginFrameworkResource) || (isTerraformPluginSDK && isCLIResource) || (isPluginFrameworkResource && isCLIResource) {
 			panic(errors.Errorf(`resource %q is specified in more than one include list. It should appear in at most one of the lists "IncludeList", "TerraformPluginSDKIncludeList" or "TerraformPluginFrameworkIncludeList"`, name))
 		}
-		if len(terraformResource.Schema) == 0 || matches(name, p.SkipList) || (!matches(name, p.IncludeList) && !isTerraformPluginSDK && !isPluginFrameworkResource) {
+		if len(terraformResource.Schema) == 0 || matches(name, p.SkipList) || (!isCLIResource && !isTerraformPluginSDK && !isPluginFrameworkResource) {
 			p.skippedResourceNames = append(p.skippedResourceNames, name)
 			continue
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

I have added functionality to change the type of a specified list of field paths between two CRD versions.

This is a prerequisite for my work-in-progress to upgrade the terraform provider in provider-upjet-aws, in which [one resource is migrated from the terraform plugin sdk to the terraform plugin framework](https://github.com/crossplane-contrib/provider-upjet-aws/issues/1725), resulting in several field paths changing type from string to float. I probably could have done it entirely in provider-upjet-aws, by writing a custom conversion that acted on the `Managed` level, but the idea of making something reusable was appealing, and could be reused to gracefully handle issues like https://github.com/crossplane-contrib/provider-upjet-aws/issues/1682 in the future.

While testing my code, I discovered that the tests for singleton list conversions were using standard go json serialization/deserialization, while crossplane-runtime actually uses kubernetes json serialization/deserialization, which differ in their handling of json `number`s (go always deserializes to float, while k8s deserializes to either float or int depending on the value). I fixed the test function to match what crossplane-runtime does, and am including the additional unit tests I wrote when I was debugging this. I put these in a separate commit so that they can be included even if the more significant change proves unwise.

### Open questions
This is still a draft/proof-of-concept. I've given very little thought to things like "which file should this go in" or "what should that be named" and would appreciate opinions from others. 

One significant long-term question is how we want to handle numeric fields. Currently, for SDK resources, in the four official providers, they are sometimes floats and sometimes strings, depending on the options configured in the terraform schema. In most cases, the actual values need to be integers, but it's not obvious to me how to detect in which cases they should be integers, except perhaps a manually-maintained list of field paths to override.  

There's a [TODO](https://github.com/crossplane/upjet/blob/72675757bb33ae6153813b0f6d1d0bf7bba9dba3/pkg/types/conversion/tfjson/tfjson.go#L226-L238) in the code that converts a tfjson schema to a terraform sdkv2 schema to figure out handling of floats with IntOrString, but as far as I can tell that's not even started.  I remember reading somewhere that floats are discouraged in kubernetes CRDs. 



I have:

- [ ] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

I'm testing this with provider-upjet-aws. I'll link to this PR when I open the PR there. 

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
