### PR TITLE
feat(changelogs): add support for change logs in controller templates

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -9,6 +9,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	xpfeature "github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -133,6 +134,10 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		if err := mgr.Add(stateMetricsRecorder); err != nil {
 			return errors.Wrap(err, "cannot register MR state metrics recorder for kind {{ .TypePackageAlias }}{{ .CRD.Kind }}List")
 		}
+	}
+
+	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
+		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
 	}
 
 	r := managed.NewReconciler(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), opts...)


### PR DESCRIPTION
### Description of your changes

This PR adds change logs support to upjet. I was a bit surprised, but from my testing it seems that the only change needed to upjet itself is within the controller template. The rest is within providers, such as https://github.com/crossplane-contrib/provider-upjet-aws/compare/main...jbw976:provider-upjet-aws:changelogs.

Using https://github.com/crossplane-contrib/provider-kubernetes/pull/354 as a model, the change in this PR simply checks to see if the alpha change logs feature is enabled in the crossplane-runtime features, and if so the change log client from the controller options is added to the managed reconciler options. That's it 😇 

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

I have consumed this change in provider-upjet-aws in my [`changelogs` branch](https://github.com/crossplane-contrib/provider-upjet-aws/compare/main...jbw976:provider-upjet-aws:changelogs) and published a build to `index.docker.io/jbw976/provider-aws-s3:v1.21.1-18.ga1784c7e5.dirty`.

This flow and experience can be seen in more detail in https://github.com/jbw976/demo-upjet-changelogs.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
