### PR TITLE
Late Init: include zero values behind pointers

### DIFF
--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -134,8 +134,6 @@ func zeroValueJSONOmitEmptyFilter(cName string) ValueFilter {
 			return true
 		case (k == reflect.Slice || k == reflect.Map) && v.Len() == 0:
 			return true
-		case k == reflect.Ptr && v.Elem().IsZero():
-			return true
 		default:
 			return false
 		}

--- a/pkg/resource/lateinit_test.go
+++ b/pkg/resource/lateinit_test.go
@@ -478,13 +478,24 @@ func TestLateInitialize(t *testing.T) {
 			wantModified: false,
 			wantCRObject: &nestedStruct4{},
 		},
-		"TestSkipOmitemptyTaggedPtrElem": {
+		"TestIncludeZeroValuePtrElem": {
 			args: args{
 				desiredObject: &nestedStruct4{},
 				observedObject: &nestedStruct4{
 					F1: &testStringEmpty,
 				},
 				opts: []GenericLateInitializerOption{WithZeroValueJSONOmitEmptyFilter(CNameWildcard)},
+			},
+			wantModified: true,
+			wantCRObject: &nestedStruct4{
+				F1: &testStringEmpty,
+			},
+		},
+		"TestSkipNilPtrElem": {
+			args: args{
+				desiredObject:  &nestedStruct4{},
+				observedObject: &nestedStruct4{},
+				opts:           []GenericLateInitializerOption{WithZeroValueJSONOmitEmptyFilter(CNameWildcard)},
 			},
 			wantModified: false,
 			wantCRObject: &nestedStruct4{},


### PR DESCRIPTION
### TL;DR ###
During LateInit, Upjets `WithZeroValueJSONOmitEmptyFilter` filters pointers that point to a zero value,. It does NOT, hoever, filter structs only including fields that are pointers to zero-values. This is inconsistent. This PR fixes it by not filtering pointers to zero-values anymore, but only if the pointer itself is nil.

### Origin story ###
I am working on upjetting the auth0/auth0 provider. The Auth0 API is very picky on PATCH requests, which surfaced an (imho) issue in how upjet deals in LateInit when deciding which values to include.

<!-- Auth as a particular bool property [1], which is always set to true and MUST NOT be sent during a PATCH, even if the value is identical. Throws a 400

Auth0 has a nested object [2], that, if sent, must at least include one of the properties in this object. Sending `flags: {}` in this place throws a 400. -->

So in `auth0_tenant.flags`, there are a lot of boolean flags, most of which are set to false by default. Except `enable_sso`, that is always true nowadays and cannot be changed.
It must also not ever be sent in a HTTP PATCH, even if the value is unchanged. This throws a 400.

With a default upjet resource config, after the first Observe, exactly this flag set to true ends up in spec (and none other):
```yaml
...
forProvider:
  flags: # from late init
    - enableSso: true # from late init
```
An Update will now include this in the terraform file, it ends up in the Http Patch and i get an eternal 400. But suspiciously, all other flags are missing. Why is especially this problematic one included, out of all of them?

So i add the flag to LateInit.IgnoreFields. Now i end up with:
```yaml
...
forProvider:
  flags: # from late init
    - {} # from late init
```
This triggers another annoying issue with AUth0: When sending an empty flags object, i get another 400 that i must at least include one flag.

At this point the question became: Why is only the one flag included in late init - and why, when ignored, i still get an empty flags object?

### The issue ###
After some debugging, the issue lies in `pkg/resource/lateinit.go -> zeroValueJSONOmitEmptyFilter`, which is generated into all resources.
Here, we look at two cases:
1. When a field of type struct is tested, L133 `case v.IsZero():` asks the go reflect package, if this is a zero value. Go reflect will test all fields inside the struct if they are zero. *A non-nil pointer field is considered not zero*
2. When a field of type ptr is tested, L137 `case k == reflect.Ptr && v.Elem().IsZero():` upjet overrides Go's behavior, and treats both the nilp ptr and also a derefenced zero value as zero.

In my case, `flags: [{}]` ends up in spec, because a struct with only ptr fields, where at least one ptr is not nil, is not considered a zero value. With current upjet behavior, the fields inside are considered zero though.

This behavior should be changed by treating a `*T` pointing to the zero value of `T` as non-zero. Intuitively, boolean flags set to false are valid config options and part of the "source of truth", crossplane wants to hold. The same imho holds true for other primitive values such as `""`, `0` etc. If the upstream API returns these values, they are a setting that is set. Imho this would also be more in line with https://docs.crossplane.io/latest/concepts/managed-resources/#late-initialization.

<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
It removes the case that tests for a ptr. A ptr would only be filtered if it is `nil`, due to `case v.IsZero()`. If not, it goes to the default case, which is "not filtered".

I changed the corresponding test and added a second one for the new behavior.
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I changed https://github.com/jwefers/provider-auth0 to use my fork of upjet with this PR applied.
It behaves as desired: all values, including false booleans, empty strings, 0 ints, that are explicitly configured in the tenant, are now late-init'd into spec.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
