### PR TITLE
Validate that `ts.FrameworkProvider` is not nil to avoid panic

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -202,6 +202,10 @@ func (c *TerraformPluginFrameworkConnector) getResourceSchema(ctx context.Contex
 // at the terraform setup layer with the relevant provider meta if needed
 // by the provider implementation.
 func (c *TerraformPluginFrameworkConnector) configureProvider(ctx context.Context, ts terraform.Setup) (tfprotov5.ProviderServer, error) {
+	if ts.FrameworkProvider == nil {
+		return nil, fmt.Errorf("cannot retrieve framework provider")
+	}
+
 	var schemaResp fwprovider.SchemaResponse
 	ts.FrameworkProvider.Schema(ctx, fwprovider.SchemaRequest{}, &schemaResp)
 	if schemaResp.Diagnostics.HasError() {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fetching the ts.FrameworkProvider.Schema field panics if the FrameworkProvider struct is not set / nil. This panic can be seen here and has been validated locally: https://github.com/grafana/crossplane-provider-grafana/issues/262

This PR adds some validation that the FrameworkProvider is not nil before continuing. It returns an error message if it is nil. This will help with debugging the issue in `crossplane-provider-grafana`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
