### PR TITLE
Remove id validation from setExternalName for framework resources without id field

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -564,13 +564,9 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 }
 
 func (n *terraformPluginFrameworkExternalClient) setExternalName(mg xpresource.Managed, stateValueMap map[string]interface{}) (bool, error) {
-	id, ok := stateValueMap["id"]
-	if !ok || id.(string) == "" {
-		return false, nil
-	}
 	newName, err := n.config.ExternalName.GetExternalNameFn(stateValueMap)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to compute the external-name from the state map of the resource with the ID %s", id)
+		return false, errors.Wrap(err, "failed to compute the external-name from the state map")
 	}
 	oldName := meta.GetExternalName(mg)
 	// we have to make sure the newly set external-name is recorded


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

This PR removes id validation from setExternalName for framework resources without id field
- Remove id field existence check in setExternalName function
- Allow external name calculation for resources without id field
- Update error message to remove id reference 


<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->


I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Manually tested in this [PR](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1794)
```
NAME                                                     SYNCED   READY   EXTERNAL-NAME                          AGE
instancestate.rds.aws.upbound.io/example-instancestate   True     True    terraform-20250612082629339100000001   21m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
