### PR TITLE
Fix wildcard expand behavior when if the field path is not found during conversion

### DIFF
--- a/pkg/config/conversion/list_conversion.go
+++ b/pkg/config/conversion/list_conversion.go
@@ -103,7 +103,7 @@ func Convert(params map[string]any, paths []string, mode ListConversionMode, opt
 	pv := fieldpath.Pave(params)
 	for _, fp := range paths {
 		exp, err := pv.ExpandWildcards(fp)
-		if err != nil {
+		if err != nil && !fieldpath.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "cannot expand wildcards for the field path expression %s", fp)
 		}
 		for _, e := range exp {


### PR DESCRIPTION
### Description of your changes

This PR fixes wildcard expand behavior when if the field path is not found during conversion. A not-found check was added.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
