### PR TITLE
remove id validation from setExternalName for resources without id field

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -568,13 +568,9 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 }
 
 func (n *terraformPluginFrameworkExternalClient) setExternalName(mg xpresource.Managed, stateValueMap map[string]interface{}) (bool, error) {
-	id, ok := stateValueMap["id"]
-	if !ok || id.(string) == "" {
-		return false, nil
-	}
 	newName, err := n.config.ExternalName.GetExternalNameFn(stateValueMap)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to compute the external-name from the state map of the resource with the ID %s", id)
+		return false, errors.Wrap(err, "failed to compute the external-name from the state map")
 	}
 	oldName := meta.GetExternalName(mg)
 	// we have to make sure the newly set external-name is recorded


### PR DESCRIPTION
### Description of your changes

Removes id validation in setExternalName for tf-plugin-framework resources.
adds the original hotfix #503 to main.

Context:
In TF plugin-framework, resources do not necessarily have the `id` attribute. They might have other identifying fields. Therefore, in their external name configurations, they might not rely on the `id` when obtaining their external names.
For such resources, currently`setExternalName()` never succeeds, as they cannot pass the `id` existence check. This check is not relevant for plugin-framework resources.

Original PR description:

- Remove id field existence check in setExternalName function
- Allow external name calculation for resources without id field
- Update error message to remove id reference 


I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Manually tested in this [PR](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1794)
```
NAME                                                     SYNCED   READY   EXTERNAL-NAME                          AGE
instancestate.rds.aws.upbound.io/example-instancestate   True     True    terraform-20250612082629339100000001   21m
```

And with uptest in this [PR](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1801):

- [Uptest-examples/apigateway/v1beta1/account.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609316294)
- [Uptest-examples/appconfig/v1beta1/environment.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609798811)
- [Uptest-examples/codeguruprofiler/v1beta1/profilinggroup.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609882703)
- [Uptest-examples/cognitoidp/v1beta1/userpoolclient.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609950056)
- [Uptest-examples/dynamodb/v1beta1/resourcepolicy.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609929091)
- [Uptest-examples/ec2/v1beta1/securitygroupegressrule.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609979236)
- [Uptest-examples/ec2/v1beta1/securitygroupingressrule.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609981018)
- [Uptest-examples/eks/v1beta1/podidentityassociation.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610025478)
- [Uptest-examples/elasticache/v1beta1/serverlesscache.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610012224)
- [Uptest-examples/s3/v1beta1/directorybucket.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610041113)

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
