### PR TITLE
Custom state check configuration for TF plugin framework resources

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -519,11 +519,11 @@ type Resource struct {
 	// Terraform InstanceDiff is computed during reconciliation.
 	TerraformCustomDiff CustomDiff
 
-	// TerraformPluginFrameworkStateEmptyCheckFn allows customizing the logic
+	// TerraformPluginFrameworkIsStateEmptyFn allows customizing the logic
 	// for determining whether a Terraform Plugin Framework state value should
 	// be considered empty/nil for resource existence checks. If not set, the
 	// default behavior uses tfStateValue.IsNull().
-	TerraformPluginFrameworkStateEmptyCheckFn TerraformPluginFrameworkStateEmptyCheckFn
+	TerraformPluginFrameworkIsStateEmptyFn TerraformPluginFrameworkIsStateEmptyFn
 
 	// ServerSideApplyMergeStrategies configures the server-side apply merge
 	// strategy for the fields at the given map keys. The map key is
@@ -650,12 +650,12 @@ type CustomDiff func(diff *terraform.InstanceDiff, state *terraform.InstanceStat
 // the JSON tags and tfMap is obtained by using the TF tags.
 type ConfigurationInjector func(jsonMap map[string]any, tfMap map[string]any) error
 
-// TerraformPluginFrameworkStateEmptyCheckFn is a function that determines whether
+// TerraformPluginFrameworkIsStateEmptyFn is a function that determines whether
 // a Terraform Plugin Framework state value should be considered empty/nil for the
 // purpose of determining resource existence. This allows providers to implement
 // custom logic to handle cases where the standard IsNull() check is insufficient,
 // such as when provider interceptors add fields like region to all state values.
-type TerraformPluginFrameworkStateEmptyCheckFn func(ctx context.Context, tfStateValue tftypes.Value, resourceSchema rschema.Schema) (bool, error)
+type TerraformPluginFrameworkIsStateEmptyFn func(ctx context.Context, tfStateValue tftypes.Value, resourceSchema rschema.Schema) (bool, error)
 
 // SchemaElementOptions represents schema element options for the
 // schema elements of a Resource.

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -15,6 +15,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
@@ -517,6 +519,12 @@ type Resource struct {
 	// Terraform InstanceDiff is computed during reconciliation.
 	TerraformCustomDiff CustomDiff
 
+	// TerraformPluginFrameworkStateEmptyCheckFn allows customizing the logic
+	// for determining whether a Terraform Plugin Framework state value should
+	// be considered empty/nil for resource existence checks. If not set, the
+	// default behavior uses tfStateValue.IsNull().
+	TerraformPluginFrameworkStateEmptyCheckFn TerraformPluginFrameworkStateEmptyCheckFn
+
 	// ServerSideApplyMergeStrategies configures the server-side apply merge
 	// strategy for the fields at the given map keys. The map key is
 	// a Terraform configuration argument path such as a.b.c, without any
@@ -641,6 +649,13 @@ type CustomDiff func(diff *terraform.InstanceDiff, state *terraform.InstanceStat
 // map. jsonMap is the map obtained by converting the `spec.forProvider` using
 // the JSON tags and tfMap is obtained by using the TF tags.
 type ConfigurationInjector func(jsonMap map[string]any, tfMap map[string]any) error
+
+// TerraformPluginFrameworkStateEmptyCheckFn is a function that determines whether
+// a Terraform Plugin Framework state value should be considered empty/nil for the
+// purpose of determining resource existence. This allows providers to implement
+// custom logic to handle cases where the standard IsNull() check is insufficient,
+// such as when provider interceptors add fields like region to all state values.
+type TerraformPluginFrameworkStateEmptyCheckFn func(ctx context.Context, tfStateValue tftypes.Value, resourceSchema rschema.Schema) (bool, error)
 
 // SchemaElementOptions represents schema element options for the
 // schema elements of a Resource.

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -330,8 +330,8 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 		// Resource state is not null, assume it exists
 		resourceExists = true
 		// If a custom empty state check function is configured, use it to verify existence
-		if n.config.TerraformPluginFrameworkStateEmptyCheckFn != nil {
-			isEmpty, err := n.config.TerraformPluginFrameworkStateEmptyCheckFn(ctx, tfStateValue, n.resourceSchema)
+		if n.config.TerraformPluginFrameworkIsStateEmptyFn != nil {
+			isEmpty, err := n.config.TerraformPluginFrameworkIsStateEmptyFn(ctx, tfStateValue, n.resourceSchema)
 			if err != nil {
 				return managed.ExternalObservation{}, errors.Wrap(err, "cannot check if TF State is empty")
 			}


### PR DESCRIPTION
### Description of your changes

We observed that a new region interceptor for the AWS TF Framework Plugin resources was introduced. This interceptor intervenes between API calls and the upjet fw controller and unconditionally injects the `region` into the state.

In the upjet fw controllers, we rely on the API request will return the uninterpreted state (the original form). If this state does not reflect the actual state, it will affect the decision-making processes of the upjet fw controller.

For example, in the `Observe` call of the upjet fw controller, we decide whether a resource exists by checking whether the returned state is null. However, as pointed out, the interceptor always injects the region field. So, every null check will return false, which means that this check will not work correctly. Also, the TF plugin framework's internal decisions rely on performing checks based on whether the state is null or not.

To handle this problem, we introduced a new configuration mechanism for framework resources. At this resource level, it will provide a generic structure for resolving this issue. The goal is to write custom state checks based on specific conditions at the provider and resource levels to determine whether the state is truly empty.

The main reasons for implementing this generically are to avoid moving provider—and resource-specific logic to upjet, to enable the creation of custom empty checkers at the resource level capable of handling the effects of different interceptors in specific situations, and to keep the scope of this change provider—and resource-specific.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally for a few TF plugin framework resources.

<img width="768" height="47" alt="Screenshot 2025-07-25 at 15 47 37" src="https://github.com/user-attachments/assets/f2e84cab-1531-40ef-aea3-67d5c538e3b2" />

<img width="915" height="155" alt="Screenshot 2025-07-25 at 15 51 35" src="https://github.com/user-attachments/assets/e040b84c-144c-4438-a059-beeed7b1951d" />

<img width="915" height="155" alt="Screenshot 2025-07-25 at 15 52 22" src="https://github.com/user-attachments/assets/70e8bc09-8a7c-4c2c-bb85-565522cd6360" />

<img width="943" height="155" alt="Screenshot 2025-07-25 at 16 03 37" src="https://github.com/user-attachments/assets/b31b1470-8dbc-48cd-baa0-c5e0e2926d50" />

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
