### PR TITLE
Do not duplicate base package controllers in the monolithic provider

### DIFF
--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -52,7 +52,11 @@ func (cc ResourceConfiguratorChain) Configure(r *Resource) {
 type BasePackages struct {
 	APIVersion []string
 	// Deprecated: Use ControllerMap instead.
-	Controller    []string
+	Controller []string
+	// ControllerMap is a map from:
+	// <API group name>/<resource name> to <provider package name>.
+	// An example is "azure/resourcegroup: config", where "config" represents
+	// the config package (provider family package).
 	ControllerMap map[string]string
 }
 

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -207,7 +207,11 @@ func (r *PipelineRunner) Run(pc *config.Provider) []string { //nolint:gocyclo
 					panic(errors.Wrapf(err, "cannot generate controller for resource %s", name))
 				}
 				controllerPkgMap[shortGroup] = append(controllerPkgMap[shortGroup], ctrlPkgPath)
-				controllerPkgMap[config.PackageNameMonolith] = append(controllerPkgMap[config.PackageNameMonolith], ctrlPkgPath)
+				// if the controller is not already added as a base package controller
+				// to the monolith provider.
+				if len(pc.BasePackages.ControllerMap[strings.TrimPrefix(ctrlPkgPath, strings.TrimSuffix(r.ModulePathControllers, "/")+"/")]) == 0 {
+					controllerPkgMap[config.PackageNameMonolith] = append(controllerPkgMap[config.PackageNameMonolith], ctrlPkgPath)
+				}
 				if err := exampleGen.Generate(group, version, resources[name]); err != nil {
 					panic(errors.Wrapf(err, "cannot generate example manifest for resource %s", name))
 				}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

As we are introducing readiness probes for the family provider `upbound/provider-azure` in https://github.com/crossplane-contrib/provider-upjet-azure/pull/1074, an existing bug for the monolithic provider package becomes visible. If a provider family configures base package controllers other than the default `providerconfig` controller, the monolithic provider attempts to start those controllers twice.

This used to be a non-issue back then when we introduced the configuration options for base package controllers but now the monolithic provider fails to start because multiple controllers will be publishing metrics using the same names, which is refused by controller-runtime during provider setup.

We have the `local-deploy` job as part of the build pipeline that's supposed to have caught this issue but because the provider did not have readiness probes enabled, that bug has survived.

But now that we are introducing readiness probes in uptest runs and with the `local-deploy` job, this bug becomes visible in https://github.com/crossplane-contrib/provider-upjet-azure/pull/1074.

We may convert the local variable `controllerPkgMap` to a map to prevent duplicates but that would result in a much larger change, that's not necessary for now. Could be part of a larger refactoring effort...

Note: Although we are no longer publishing the monolithic providers for provider families, they are still being used for development & testing.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Validated with `upbound/provider-azure` (Github repo: `crossplane-contrib/provider-upjet-azure`) & https://github.com/crossplane-contrib/provider-upjet-azure/pull/1074.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
