### PR TITLE
Add config.Provider.ExampleManifestConfiguration to configure the example manifest generation pipeline

### DIFF
--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -60,6 +60,15 @@ type BasePackages struct {
 	ControllerMap map[string]string
 }
 
+// ExampleManifestConfiguration is the configuration for example manifest
+// generation pipeline.
+type ExampleManifestConfiguration struct {
+	// ManagedResourceNamespace is the namespace used for the namespace-scoped
+	// managed resource example manifests. Default namespace is upbound-system
+	// if not overridden.
+	ManagedResourceNamespace string
+}
+
 // Provider holds configuration for a provider to be generated with Upjet.
 type Provider struct {
 	// TerraformResourcePrefix is the prefix used in all resources of this
@@ -152,6 +161,10 @@ type Provider struct {
 	// TerraformPluginFrameworkProvider is the Terraform provider reference
 	// in Terraform Plugin Framework compatible format
 	TerraformPluginFrameworkProvider fwprovider.Provider
+
+	// ExampleManifestConfiguration is the optional example manifest
+	// generation pipeline configuration for the provider.
+	ExampleManifestConfiguration ExampleManifestConfiguration
 
 	// refInjectors is an ordered list of `ReferenceInjector`s for
 	// injecting references across this Provider's resources.
@@ -284,6 +297,14 @@ func WithMainTemplate(template string) ProviderOption {
 func WithSchemaTraversers(traversers ...traverser.SchemaTraverser) ProviderOption {
 	return func(p *Provider) {
 		p.schemaTraversers = traversers
+	}
+}
+
+// WithExampleManifestConfiguration configures the example manifest generation
+// pipeline for the provider.
+func WithExampleManifestConfiguration(emc ExampleManifestConfiguration) ProviderOption {
+	return func(p *Provider) {
+		p.ExampleManifestConfiguration = emc
 	}
 }
 

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -124,9 +124,9 @@ func (r *PipelineRunner) Run(pc *config.Provider) []string { //nolint:gocyclo
 		resourcesGroups[group][resource.Version][name] = resource
 	}
 
-	var exampleGeneratorOpts []examples.GeneratorOption
+	exampleGeneratorOpts := []examples.GeneratorOption{examples.WithCRDScope(r.Scope), examples.WithNamespace(pc.ExampleManifestConfiguration.ManagedResourceNamespace)}
 	if r.Scope == tjtypes.CRDScopeNamespaced {
-		exampleGeneratorOpts = append(exampleGeneratorOpts, examples.WithLocalSecretRefs(), examples.WithNamespacedExamples())
+		exampleGeneratorOpts = append(exampleGeneratorOpts, examples.WithLocalSecretRefs())
 	}
 	exampleGen := examples.NewGenerator(r.DirExamples, r.ModulePathAPIs, pc.ShortName, pc.Resources, exampleGeneratorOpts...)
 	if err := exampleGen.SetReferenceTypes(pc.Resources); err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Add `config.Provider.ExampleManifestConfiguration` to configure the example manifest generation pipeline at provider scope. Provider authors may use it to configure provider-level aspects of the example manifest generation pipeline as follows:

```go
...
pc := ujconfig.NewProvider([]byte(providerSchema), resourcePrefix, modulePath, []byte(providerMetadata),
		ujconfig.WithRootGroup("template.m.crossplane.io"),
		ujconfig.WithIncludeList(ExternalNameConfigured()),
		ujconfig.WithFeaturesPackage("internal/features"),
		ujconfig.WithDefaultResourceOptions(
			ExternalNameConfigurations(),
		),
		ujconfig.WithExampleManifestConfiguration(ujconfig.ExampleManifestConfiguration{
			ManagedResourceNamespace: "crossplane-system",
		}))
...
```
With the above configuration, generated example manifests for any namespace-scoped resources (and the secret references they have) will have the `crossplane-system` namespace.

Some further refactoring is needed in the example generation pipeline. We are planning to do so in follow-up PRs.

This is a backwards-compatible change meaning that if the provider authors do not override the default namespace, they will continue to use `upbound-system`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against `crossplane/upjet-provider-template` & `crossplane-contrib/provider-upjet-azure`.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
