### PR TITLE
Rename examples/conversion.ConvertSingletonListToEmbeddedObject as ApplyAPIConverters

### DIFF
--- a/pkg/examples/conversion/example_conversions.go
+++ b/pkg/examples/conversion/example_conversions.go
@@ -23,12 +23,12 @@ import (
 	"github.com/crossplane/upjet/v2/pkg/config/conversion"
 )
 
-// ConvertSingletonListToEmbeddedObject generates the example manifests for
-// the APIs with converted singleton lists in their new API versions with the
-// embedded objects. All manifests under `startPath` are scanned and the
+// ApplyAPIConverters applies the registered converters to generated
+// example manifests under the given root directory.
+// All (generated) manifests under the `startPath` are scanned and the
 // header at the specified path `licenseHeaderPath` is used for the converted
 // example manifests.
-func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licenseHeaderPath string) error {
+func ApplyAPIConverters(pc *config.Provider, startPath, licenseHeaderPath string) error {
 	resourceRegistry := prepareResourceRegistry(pc)
 
 	var license string
@@ -64,15 +64,15 @@ func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licens
 				return nil
 			}
 
-			newPath := strings.ReplaceAll(path, examples[0].GroupVersionKind().Version, rootResource.Version)
-			if path == newPath {
-				return nil
-			}
 			annotationValue := strings.ToLower(fmt.Sprintf("%s/%s/%s", rootResource.ShortGroup, rootResource.Version, rootResource.Kind))
 			for _, e := range examples {
 				if resource, ok := resourceRegistry[fmt.Sprintf("%s/%s", e.GroupVersionKind().Kind, e.GroupVersionKind().Group)]; ok {
 					conversionPaths := resource.CRDListConversionPaths()
-					if conversionPaths != nil && e.GroupVersionKind().Version != resource.Version {
+					// if the latest version has conversions, run the conversions on the
+					// example manifest.
+					// Please note that only the version being generated (latest version)
+					// is processed.
+					if conversionPaths != nil && e.GroupVersionKind().Version == resource.Version {
 						for i, cp := range conversionPaths {
 							// Here, for the manifests to be converted, only `forProvider
 							// is converted, assuming the `initProvider` field is empty in the
@@ -100,7 +100,7 @@ func ConvertSingletonListToEmbeddedObject(pc *config.Provider, startPath, licens
 				}
 			}
 			convertedFileContent = license + "\n\n"
-			if err := writeExampleContent(path, convertedFileContent, examples, newPath); err != nil {
+			if err := writeExampleContent(path, convertedFileContent, examples, path); err != nil {
 				return errors.Wrap(err, "failed to write example content")
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This PR changes the existing `examples/conversion.ConvertSingletonListToEmbeddedObject` in the following ways:
- Renames it as `ApplyAPIConverters` because it applies all the registered API converters, not just the singleton-list-to-embedded-object converter.
- `ConvertSingletonListToEmbeddedObject` used to convert the `v1beta1` versions into the new versions. However, we should already be generating the new version from the hopefully updated registry examples corresponding to that new version. So instead of a direct conversion from the old API, we had better have it generated from the new registry examples corresponding to that version and apply the registered converters on them.

Please note that this only applies the API converters on the latest generated version. Any old versions are kept intact. This is meant to be run in a post processing step for the generated manifests.

A provider's code and example manifest generation pipeline could run this as follows (in a post-processing phase):
```go
kingpin.FatalIfError(conversion.ConvertSingletonListToEmbeddedObject(pc, "../examples-generated/cluster", "../hack/boilerplate.yaml.txt"), "Cannot convert singleton lists to embedded objects in example cluster-scoped resource manifests.")
```
, where `pc` is the `config.Provider` which happens to hold the API converters registered for the resources. The `../examples-generated/cluster` is the root path under which the generated example manifests are to be processed. `../hack/boilerplate.yaml.txt` is the license header to be appended to the processed documents.

As a future work, we could turn what we currently have in `ApplyAPIConverters` into a chain of post processors run for the generated manifests and probably decouple the license header adder from the API converter applier.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested against `crossplane-contrib/provider-upjet-{aws,azuread}`:
- https://github.com/crossplane-contrib/provider-upjet-azuread/pull/264
- https://github.com/crossplane-contrib/provider-upjet-aws/pull/1888
- https://github.com/crossplane-contrib/provider-upjet-azure/pull/1084
- https://github.com/crossplane-contrib/provider-upjet-gcp/pull/854

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
