### PR TITLE
Fix the race on the registered conversion paths in conversion.Convert

### DIFF
--- a/pkg/config/conversion/list_conversion.go
+++ b/pkg/config/conversion/list_conversion.go
@@ -90,7 +90,9 @@ type ConvertOptions struct {
 // an embedded object will be converted into a singleton list or a singleton
 // list will be converted into an embedded object) is determined by the mode
 // parameter.
-func Convert(params map[string]any, paths []string, mode ListConversionMode, opts *ConvertOptions) (map[string]any, error) { //nolint:gocyclo // easier to follow as a unit
+func Convert(params map[string]any, p []string, mode ListConversionMode, opts *ConvertOptions) (map[string]any, error) { //nolint:gocyclo // easier to follow as a unit
+	// make a copy of p to prevent races on the configured conversion paths.
+	paths := append([]string(nil), p...)
 	switch mode {
 	case ToSingletonList:
 		slices.Sort(paths)

--- a/pkg/controller/conversion/functions.go
+++ b/pkg/controller/conversion/functions.go
@@ -45,6 +45,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	}
 
 	// first PrioritizedManagedConversions are run in their registration order
+	r.logger.Debug("Running the registered PrioritizedManagedConversions.")
 	for _, c := range r.GetConversions(dst) {
 		if pc, ok := c.(conversion.PrioritizedManagedConversion); ok {
 			if _, err := pc.ConvertManaged(src, dst); err != nil {
@@ -65,6 +66,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	srcPaved := fieldpath.Pave(srcMap)
 	dstPaved := fieldpath.Pave(dstMap)
 	// then run the PavedConversions
+	r.logger.Debug("Running the registered PavedConversions.")
 	for _, c := range r.GetConversions(dst) {
 		if pc, ok := c.(conversion.PavedConversion); ok {
 			if _, err := pc.ConvertPaved(srcPaved, dstPaved); err != nil {
@@ -79,6 +81,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	}
 
 	// finally at the third stage, run the ManagedConverters
+	r.logger.Debug("Running the registered ManagedConverters.")
 	for _, c := range r.GetConversions(dst) {
 		if tc, ok := c.(conversion.ManagedConversion); ok {
 			if _, ok := tc.(conversion.PrioritizedManagedConversion); ok {

--- a/pkg/controller/conversion/functions_test.go
+++ b/pkg/controller/conversion/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
@@ -169,6 +170,7 @@ func TestRoundTrip(t *testing.T) {
 			}
 			r := &registry{
 				scheme: s,
+				logger: logging.NewNopLogger(),
 			}
 			if err := r.RegisterConversions(p, nil); err != nil {
 				t.Fatalf("\n%s\nRegisterConversions(p): Failed to register the conversions with the registry.\n", tc.reason)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Multiple Go routines can race on the registered conversion paths when in-place sorts are performed in `conversion.Convert`. Although we could not reproduce these issues like the one reported in https://github.com/crossplane-contrib/provider-upjet-aws/issues/1714, observations done by @jonathan-innis [here](https://github.com/crossplane-contrib/provider-upjet-aws/issues/1714#issuecomment-3408035762) using a provider package with the fix proposed in this PR suggest that this data race could be the underlying reason behind similar failures.

This PR fixes the data race by making a copy of the list of the registered conversion paths before they are sorted in-place.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
We have tested the data race fix using the provider package `xpkg.upbound.io/upbound/provider-aws-lambda:v1.20.5-1.gf4470285b`. There are logging differences between that implementation and the one proposed here. The test image has more verbose logging, which is not suggested with this PR due to concerns with PII.


[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
