### PR TITLE
Add config.FrameworkResourceWithComputedIdentifier external-name configuration

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -181,6 +181,20 @@ type ExternalName struct {
 	// "ignore" the supplied diagnostics, i.e. they
 	// correspond to "resource not found".
 	IsNotFoundDiagnosticFn func(diags []*tfprotov6.Diagnostic) bool
+
+	// TFPluginFrameworkOptions represents options related to Terraform plugin
+	// framework resources.
+	TFPluginFrameworkOptions TFPluginFrameworkOptions
+}
+
+// TFPluginFrameworkOptions are external-name configuration options that
+// are specific to Terraform plugin framework resources.
+type TFPluginFrameworkOptions struct {
+	// ComputedIdentifierAttributes is the list of computed Terraform identifier
+	// attribute names for a framework resource. When set,
+	// these computed identifier attributes will be ignored from the desired
+	// state when calculating the drifts between the desired and actual states.
+	ComputedIdentifierAttributes []string
 }
 
 // References represents reference resolver configurations for the fields of a

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 	"strings"
@@ -313,9 +314,14 @@ func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(rawDiff []tf
 // If plan response contains non-empty RequiresReplace (i.e. the resource needs
 // to be recreated) an error is returned as Crossplane Resource Model (XRM)
 // prohibits resource re-creations and rejects this plan.
-func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context.Context,
-	tfStateValue tftypes.Value) (*tfprotov6.PlanResourceChangeResponse, bool, error) {
-	tfConfigDynamicVal, err := protov6DynamicValueFromMap(n.params, n.resourceValueTerraformType)
+func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context.Context, tfStateValue tftypes.Value) (*tfprotov6.PlanResourceChangeResponse, bool, error) {
+	params := maps.Clone(n.params)
+	// if some computed identifiers have been configured,
+	// remove them from config.
+	for _, id := range n.config.ExternalName.TFPluginFrameworkOptions.ComputedIdentifierAttributes {
+		delete(params, id)
+	}
+	tfConfigDynamicVal, err := protov6DynamicValueFromMap(params, n.resourceValueTerraformType)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "cannot construct dynamic value for TF Config")
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
Relevant PR: https://github.com/crossplane-contrib/provider-upjet-aws/pull/1900

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR adds a new external-name configuration `config.FrameworkResourceWithComputedIdentifier` to be used with the Terraform plugin framework resources with a computed identifier field. It also introduces `config.ExternalName.TFPluginFrameworkOptions` struct type for logically grouping framework resource related external-name configuration options. `TFPluginFrameworkOptions.ComputedIdentifierAttributes` can be used to exclude the configured computed identifier fields while calculating drifts between the desired and actual states.

This PR also fixes an existing bug in `config.ExternalNameFrom` so that it now properly exhibits the parent configuration's behavior.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested against `crossplane-contrib/provider-upjet-aws`.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
