### PR TITLE
linter: suppress linter false positives on switch-case

### DIFF
--- a/pkg/controller/proposed_state.go
+++ b/pkg/controller/proposed_state.go
@@ -165,7 +165,7 @@ func emptyValue(sc rschema.Schema) tftypes.Value {
 func emptyAttribute(attr rschema.Attribute) tftypes.Value {
 	switch attr := attr.(type) {
 	case rschema.NestedAttribute:
-		switch attr.GetNestingMode() {
+		switch attr.GetNestingMode() { //nolint:exhaustive // already exhaustive
 		case NestingModeSingle:
 			vals := make(map[string]tftypes.Value)
 			for key, na := range attr.GetNestedObject().GetAttributes() {
@@ -188,7 +188,7 @@ func emptyAttribute(attr rschema.Attribute) tftypes.Value {
 }
 
 func emptyBlock(blockS rschema.Block) tftypes.Value {
-	switch blockS.GetNestingMode() {
+	switch blockS.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case BlockNestingModeList:
 		return tftypes.NewValue(blockS.Type().TerraformType(context.TODO()), []tftypes.Value{})
 	case BlockNestingModeSet:
@@ -249,7 +249,7 @@ func proposedNewNestedBlock(schema rschema.Block, prior, config tftypes.Value) t
 		Blocks:     resBlocks,
 	}
 
-	switch schema.GetNestingMode() {
+	switch schema.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case BlockNestingModeSingle:
 		// A NestingSingle configuration block value can be null, and since it
 		// cannot be computed we can always take the configuration value.
@@ -277,7 +277,7 @@ func proposedNewNestedType(schema rschema.NestedAttribute, prior, config tftypes
 
 	// Even if the config is null or empty, we will be using this default value.
 	newV := config
-	switch schema.GetNestingMode() {
+	switch schema.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case NestingModeSingle:
 		// If the config is null, we already have our value. If the attribute
 		// is optional+computed, we won't reach this branch with a null value


### PR DESCRIPTION
### Description of your changes

Suppress linter false positives on switch-case statements. The cases are already exhaustive. These case value constants were at an internal lib in TF, so they are redefined at https://github.com/crossplane/upjet/blob/631ac596eea1bd79beb88e72933dd437de3f413d/pkg/controller/proposed_state.go#L21-L66 already and covers all cases.


I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
no code changes, tested with `make lint`

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
