### PR TITLE
Move mergenci to emeritus maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,4 +22,4 @@
 pkg/migrations/*			@sergenyalcin
 
 # Fallback owners
-*			                @ulucinar @sergenyalcin @erhancagirici @mergenci
+*			                @ulucinar @sergenyalcin @erhancagirici

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -16,6 +16,9 @@ repository maintainers in their own `OWNERS.md` file.
 * Sergen Yalcin <sergen@upbound.io> ([sergenyalcin](https://github.com/sergenyalcin))
 * Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis))
 * Erhan Cagirici <erhan@upbound.io> ([erhancagirici](https://github.com/erhancagirici))
+
+## Emeritus Maintainers
+
 * Cem Mergenci <cem@upbound.io> ([mergenci](https://github.com/mergenci))
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
### Description of your changes

This PR moves @mergenci to the Emeritus Maintainers section in OWNERS.md.

His contributions, guidance, and long-standing support for the project have been widely appreciated and remain an important part of its history. We thank @mergenci for the solid foundation they helped build and warmly acknowledge their lasting impact on the upjet.

Thank you, @mergenci, for everything you’ve done.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
