### PR TITLE
Handle nested attributes inside blocks

### DIFF
--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -187,7 +187,11 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 	res := &schemav2.Resource{}
 	res.Schema = make(map[string]*schemav2.Schema, len(nb.Block.Attributes)+len(nb.Block.NestedBlocks))
 	for key, attr := range nb.Block.Attributes {
-		res.Schema[key] = tfJSONAttributeToV2Schema(attr)
+		if attr.AttributeNestedType != nil {
+			res.Schema[key] = tfJSONNestedAttributeTypeToV2Schema(attr)
+		} else {
+			res.Schema[key] = tfJSONAttributeToV2Schema(attr)
+		}
 	}
 	for key, block := range nb.Block.NestedBlocks {
 		// Please note that unlike the resource-level CRUD timeout configuration


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

Handle nested attributes also when they are nested inside a block. (e.g. [dhcp_routes_configuration](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/network#dhcp_routes_configuration-1) attribute inside [ip_network](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/network#ip_network-1) block of `upcloud_network` resource)

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Generated crossplane-provider-upcloud (see https://github.com/UpCloudLtd/crossplane-provider-upcloud/pull/23)

Without this change, the generating failed with:

```txt
panic: cannot generate crd for resource upcloud_network: cannot build types for Network: cannot build the Types for resource "upcloud_network": cannot infer type from schema of field ip_network: cannot infer type from resource schema of element type of Network.IPNetwork: cannot infer type from schema of field dhcp_routes_configuration: invalid schema type TypeInvalid

goroutine 1 [running]:
github.com/crossplane/upjet/v2/pkg/pipeline.(*PipelineRunner).Run(0x14000c97d58, 0x14000a504e0)
        /Users/kangasta/go/pkg/mod/github.com/crossplane/upjet/v2@v2.2.0/pkg/pipeline/run.go:190 +0x2248
github.com/crossplane/upjet/v2/pkg/pipeline.Run(0x14000a504e0, 0x14000b4f520, {0x140001d26e0, 0x3c})
        /Users/kangasta/go/pkg/mod/github.com/crossplane/upjet/v2@v2.2.0/pkg/pipeline/run.go:83 +0x628
main.main()
        /Users/kangasta/Documents/GitHub/crossplane-provider-upcloud/cmd/generator/main.go:26 +0x6c
exit status 2
```

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
