### PR TITLE
tfsdk external client: Flush reconstructed states for recalculation after Observation failures

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -307,7 +307,7 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 			}
 			s.Meta[schema.TimeoutKey] = timeouts
 		}
-		opTracker.SetTfState(s)
+		opTracker.SetReconstructedTfState(s)
 	}
 
 	return &terraformPluginSDKExternal{
@@ -496,6 +496,7 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 	newState, diag := n.resourceSchema.RefreshWithoutUpgrade(ctx, n.opTracker.GetTfState(), n.ts.Meta)
 	metrics.ExternalAPITime.WithLabelValues("read").Observe(time.Since(start).Seconds())
 	if diag != nil && diag.HasError() {
+		n.opTracker.ResetReconstructedTfState()
 		return managed.ExternalObservation{}, errors.Errorf("failed to observe the resource: %v", diag)
 	}
 	diffState := n.opTracker.GetTfState()

--- a/pkg/controller/nofork_store.go
+++ b/pkg/controller/nofork_store.go
@@ -115,6 +115,29 @@ func (a *AsyncTracker) SetTfState(state *tfsdk.InstanceState) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.tfState = state
+	a.stateMark = defaultState
+}
+
+// SetReconstructedTfState stores the given SDKv2 Terraform InstanceState into
+// the AsyncTracker and marks the state as reconstructed.
+// MUST be only used for SDKv2 resources.
+func (a *AsyncTracker) SetReconstructedTfState(state *tfsdk.InstanceState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.tfState = state
+	a.stateMark = reconstructedState
+}
+
+// ResetReconstructedTfState clears the TF Plugin SDKv2 InstanceState
+// if it is a reconstructed state. No-op otherwise.
+// MUST be only used for SDKv2 resources.
+func (a *AsyncTracker) ResetReconstructedTfState() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.stateMark == reconstructedState {
+		a.tfState = nil
+		a.stateMark = defaultState
+	}
 }
 
 // GetTfID returns the Terraform ID of the external resource currently


### PR DESCRIPTION
### Description of your changes

Continuation of https://github.com/crossplane/upjet/pull/555 for TF SDKv2 external client. #555 was covering TF plugin framework external client.

Quoting the description of #555

Background:
In the initial reconciliation of the MRs just after a provider pod restart OR they get created in the k8s apiserver, the very first `Connect()` constructs a (partial) TF prior state using the current status values (`status.atProvider`), and saves it to the opTracker state cache. This reconstructed state contains enough information to identify the external resource, and facilitates the TF resource read operation in the subsequent `Observe()` call. 
- After the successful initial observation, this state is immediately updated with the latest full state data from the resource read (empty state for a non-existent external resource). Subsequent reconciles do not reconstruct the state anymore.
- If the resource read fails, an error is returned without touching the constructed prior state and the reconcile is requeued.

This causes an issue for the following scenario:
- An MR manifest is applied with some invalid parameter values
- in the initial `Connect()` a prior state is constructed with those values and saved to state cache.
- the initial observation fails and returns an error. The state cache is not modified.
- State cache has still the "invalid" value.
- MR manifest is updated with the correct value.
- In the next reconciliation, the state is not reconstructed, because a prior state already exists.
- The observation/resource read fails again because the invalid prior state.
- Resource is stuck, until a provider pod restart.

In this change:
- while recording the TF states into the cache, attach a meta-information regarding whether this state is a "reconstructed" state or a regular one (that comes from a TF resource CRUD operation).
- After observation failures, flush reconstructed states, so that they are rebuilt, with new configuration values if any.

Addresses https://github.com/crossplane-contrib/provider-upjet-azuread/issues/287
I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested manually,
thanks to @jonasz-lasut for the clear test steps and testing, see https://github.com/crossplane/upjet/pull/564#issuecomment-3710554788

I conducted the same test with slightly different order and it was successful too.
- install provider-azuread v1.8.0
- apply MRs, observe synced and ready ✅ 
- upgrade provider-azuread to modified version: v2.2.0+this fix consumed
- observe that `Principal` MR is failing now, Synced: false
- update the external name to the new format
- `Principal` MR recovers without a pod restart

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
