### PR TITLE
feat(terraform): add LocalName field to ProviderRequirement

### DIFF
--- a/pkg/terraform/files_test.go
+++ b/pkg/terraform/files_test.go
@@ -463,6 +463,39 @@ func TestWriteMainTF(t *testing.T) {
 				maintf: `{"provider":{"provider-test":null},"resource":{"":{"":{"lifecycle":{"prevent_destroy":true},"name":"some-id","param":"paramval"}}},"terraform":{"required_providers":{"provider-test":{"source":"my-company/namespace/provider-test","version":"1.2.3"}}}}`,
 			},
 		},
+		"LocalNameOverride": {
+			reason: "When LocalName is set, it should be used instead of deriving from the source path (fixes issue #565)",
+			args: args{
+				tr: &fake.LegacyTerraformed{
+					LegacyManaged: xpfake.LegacyManaged{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								resource.AnnotationKeyPrivateRawAttribute: "privateraw",
+								meta.AnnotationKeyExternalName:            "some-id",
+							},
+						},
+					},
+					Parameterizable: fake.Parameterizable{Parameters: map[string]any{
+						"param": "paramval",
+					}},
+					Observable: fake.Observable{Observation: map[string]any{
+						"obs": "obsval",
+					}},
+				},
+				cfg: config.DefaultResource("upjet_resource", nil, nil, nil),
+				s: Setup{
+					Requirement: ProviderRequirement{
+						Source:    "port-labs/port-labs",
+						Version:   "1.0.0",
+						LocalName: "port",
+					},
+					Configuration: nil,
+				},
+			},
+			want: want{
+				maintf: `{"provider":{"port":null},"resource":{"":{"":{"lifecycle":{"prevent_destroy":true},"name":"some-id","param":"paramval"}}},"terraform":{"required_providers":{"port":{"source":"port-labs/port-labs","version":"1.0.0"}}}}`,
+			},
+		},
 		"SuccessManagementPolicies": {
 			reason: "Management policies enabled with ignore changes resources and merging initProvider should be able to write everything it has into maintf file",
 			args: args{

--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -50,6 +50,12 @@ type ProviderRequirement struct {
 
 	// Registry of the provider. An example value is `provider["registry.terraform.io/%s"]`
 	Registry string
+
+	// LocalName is the local name used for the provider in the Terraform
+	// configuration. If not set, it defaults to the last segment of Source.
+	// This is useful for providers where the resource prefix doesn't match
+	// the provider source name (e.g., port-labs/port-labs uses port_ prefix).
+	LocalName string
 }
 
 // ProviderConfiguration holds the setup configuration body


### PR DESCRIPTION
### Description of your changes

  Adds an optional `LocalName` field to `ProviderRequirement` to override the derived provider local name in Terraform configuration.

  Currently, Upjet derives provider names from the source path (`port-labs/port-labs` → `port-labs`). This breaks providers like Port Labs where the resource prefix (`port_*`) doesn't match the derived name—Terraform expects a provider called `port`, not `port-labs`.

  This change lets providers set `LocalName: "port"` to fix the mismatch. When `LocalName` is empty, existing behavior is unchanged.

  Fixes #565

  I have:

  - [x] Read and followed Upjet's [contribution process].
  - [x] Run `make reviewable` to ensure this PR is ready for review.
  - [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

  Added a unit test (`LocalNameOverride`) that verifies the fix works for `port-labs/port-labs` with `LocalName: "port"`. Also confirmed existing tests still pass (backward compatible) and tested end-to-end in a downstream provider against Port.io.


[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
