### PR TITLE
Fix sensitive TF path injection when list wildcards ([*]) are present

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -243,8 +243,6 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 
 				for key, value := range data {
 					fp := fmt.Sprintf("%s.%s", expandedTFPath, key)
-					fmt.Printf("DEBUG upjet local: concreteTFPath=%s expandedJSONPath=%s\n", expandedTFPath, expandedJSONPath)
-
 					if err = pavedTF.SetValue(fp, string(value)); err != nil {
 						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fp)
 					}

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -238,9 +238,15 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 				if resource.IgnoreNotFound(err) != nil {
 					return errors.Wrapf(err, errFmtCannotGetSecretValue, ref)
 				}
+
+				expandedTFPath, _ := expandWildcardTFPath(tfPath, expandedJSONPath)
+
 				for key, value := range data {
-					if err = pavedTF.SetValue(fmt.Sprintf("%s.%s", tfPath, key), string(value)); err != nil {
-						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s.%s", tfPath, key))
+					fp := fmt.Sprintf("%s.%s", expandedTFPath, key)
+					fmt.Printf("DEBUG upjet local: concreteTFPath=%s expandedJSONPath=%s\n", expandedTFPath, expandedJSONPath)
+
+					if err = pavedTF.SetValue(fp, string(value)); err != nil {
+						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fp)
 					}
 				}
 				continue
@@ -296,6 +302,39 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 		}
 	}
 	return nil
+}
+
+// expandWildcardTFPath replaces segments like "options[*]" with the concrete index
+// found in expandedJSONPath (e.g. "...options[0]....").
+// Example:
+// tfPath: "options[*].configuration"
+// expandedJSONPath: "spec.forProvider.options[0].configurationSecretRef"
+// => "options[0].configuration"
+func expandWildcardTFPath(tfPath, expandedJSONPath string) (string, error) {
+	segs := strings.Split(tfPath, ".")
+	// match "options[*]"
+	reWildcard := regexp.MustCompile(`^([A-Za-z0-9_-]+)\[\*\]$`)
+	// match "options[0]" in expandedJSONPath
+	// we build this per-field: fmt.Sprintf(`\b%s\[(\d+)\]`, field)
+	out := make([]string, 0, len(segs))
+
+	for _, s := range segs {
+		m := reWildcard.FindStringSubmatch(s)
+		if len(m) == 0 {
+			out = append(out, s)
+			continue
+		}
+		field := m[1]
+		reIndex := regexp.MustCompile(fmt.Sprintf(`\b%v\[(\d+)\]`, regexp.QuoteMeta(field)))
+		mi := reIndex.FindStringSubmatch(expandedJSONPath)
+		if len(mi) < 2 {
+			// if we cannot find an index, keep as-is (fallback)
+			out = append(out, s)
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s[%s]", field, mi[1]))
+	}
+	return strings.Join(out, "."), nil
 }
 
 // GetSensitiveObservation will return sensitive information as terraform state


### PR DESCRIPTION

### Description of your changes

This PR fixes a failure in sensitive parameter injection when the Terraform
field path includes list wildcards (e.g. `options[*].configuration`).

#### Issue #[589](https://github.com/crossplane/upjet/issues/589)

### Root cause

Upjet injects sensitive values into a Terraform-shaped object using
`fieldpath.Paved.SetValue`. When the TF path contains `[*]`, the segment before
the wildcard (e.g. `options`) is a list (`[]any`), not an object/map. Writing
to a path like `options[*].configuration.<key>` therefore fails with errors like:

`cannot set string as terraform attribute for fieldpath "options[*].configuration.<key>": options is not an object`

At the same time, Upjet already has the concrete list index available after it
expands the corresponding Crossplane JSON path (e.g. `...options[0]...`).

### Fix

Introduce a helper `expandWildcardTFPath(tfPath, expandedJSONPath)` that replaces
wildcard list segments (e.g. `options[*]`) with the concrete index extracted
from the expanded JSON path (e.g. `options[0]`). This enables writing sensitive
values at the correct Terraform location, for example:
`options[0].configuration.<key>`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### How has this code been tested

- Reproduced the failure in a local Crossplane + Upjet-based provider setup with
  a resource that injects sensitive values into a list field path containing `[*]`.
- Verified reconciliation proceeds and values are injected at the expected
  concrete index (e.g. `options[0]...`) without the "options is not an object" error.


[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
