### PR TITLE
Fix async observe masking unresolved operation failures

### DIFF
--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -157,9 +157,13 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 			// so, we hackily return "late-initialized" to true.
 			// This might not work if the late initialization management policy
 			// is disabled.
+			//
+			// We intentionally keep ResourceUpToDate=false in this branch: the
+			// previous async create is still in failed state and must not be
+			// observed as synced/healthy before a successful retry.
 			return managed.ExternalObservation{
 				ResourceExists:          true,
-				ResourceUpToDate:        true,
+				ResourceUpToDate:        false,
 				ResourceLateInitialized: true,
 			}, nil
 		}
@@ -167,13 +171,15 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 	n.opTracker.LastOperation.Clear(true)
 
 	o, err := n.terraformPluginFrameworkExternalClient.Observe(ctx, mg)
-	// clear any previously reported LastAsyncOperation error condition here,
-	// because there are no pending updates on the existing resource and it's
-	// not scheduled to be deleted.
+	// Only clear previously reported LastAsyncOperation failures if there is no
+	// unresolved async error cached in the operation tracker. Otherwise, an
+	// observe-only success can mask a terminal async failure.
 	if err == nil && o.ResourceExists && o.ResourceUpToDate && !meta.WasDeleted(mg) {
-		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
-		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
-		n.opTracker.LastOperation.Clear(false)
+		if lastErr := n.opTracker.LastOperation.Error(); lastErr == nil {
+			mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
+			mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
+			n.opTracker.LastOperation.Clear(false)
+		}
 	}
 	return o, err
 }

--- a/pkg/controller/external_async_tfpluginfw_test.go
+++ b/pkg/controller/external_async_tfpluginfw_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+
+	upjetresource "github.com/crossplane/upjet/v2/pkg/resource"
+	"github.com/crossplane/upjet/v2/pkg/resource/fake"
+	tjerrors "github.com/crossplane/upjet/v2/pkg/terraform/errors"
+)
+
+func TestAsyncTerraformPluginFrameworkObserve(t *testing.T) {
+	type args struct {
+		testConfig testConfiguration
+		prepare    func(e *terraformPluginFrameworkAsyncExternalClient, obj *fake.Terraformed) error
+	}
+	type want struct {
+		obs              managed.ExternalObservation
+		err              error
+		lastCondition    *xpv1.Condition
+		lastOperationErr error
+		externalName     string
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"UpToDateWithUnresolvedAsyncFailure": {
+			args: args{
+				testConfig: testConfiguration{
+					r:   newMockBaseTPFResource(),
+					cfg: newBaseUpjetConfig(),
+					obj: newBaseObject(),
+					params: map[string]any{
+						"id":   "example-id",
+						"name": "example",
+					},
+					currentStateMap: map[string]any{
+						"id":   "example-id",
+						"name": "example",
+					},
+					plannedStateMap: map[string]any{
+						"id":   "example-id",
+						"name": "example",
+					},
+				},
+				prepare: func(e *terraformPluginFrameworkAsyncExternalClient, obj *fake.Terraformed) error {
+					lastErr := tjerrors.NewAsyncCreateFailed(errBoom)
+					e.opTracker.LastOperation.MarkStart("create")
+					e.opTracker.LastOperation.SetError(lastErr)
+					e.opTracker.LastOperation.MarkEnd()
+					obj.SetConditions(upjetresource.LastAsyncOperationCondition(lastErr))
+					return nil
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: true,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+				lastCondition: &xpv1.Condition{
+					Type:    upjetresource.TypeLastAsyncOperation,
+					Status:  corev1.ConditionFalse,
+					Reason:  upjetresource.ReasonAsyncCreateFailure,
+					Message: tjerrors.NewAsyncCreateFailed(errBoom).Error(),
+				},
+				lastOperationErr: tjerrors.NewAsyncCreateFailed(errBoom),
+			},
+		},
+		"RecoverExternalNameAfterFailedCreateNotUpToDate": {
+			args: args{
+				testConfig: testConfiguration{
+					r:   newMockBaseTPFResource(),
+					cfg: newBaseUpjetConfig(),
+					obj: newBaseObject(),
+					params: map[string]any{
+						"name": "example",
+					},
+					currentStateMap: map[string]any{
+						"name": "example",
+					},
+					plannedStateMap: map[string]any{
+						"name": "example",
+					},
+				},
+				prepare: func(e *terraformPluginFrameworkAsyncExternalClient, obj *fake.Terraformed) error {
+					state, err := protov6DynamicValueFromMap(map[string]any{
+						"id":   "example-id",
+						"name": "example",
+					}, e.resourceValueTerraformType)
+					if err != nil {
+						return err
+					}
+					lastErr := tjerrors.NewAsyncCreateFailed(errBoom)
+					e.opTracker.SetFrameworkTFState(state)
+					e.opTracker.LastOperation.MarkStart("create")
+					e.opTracker.LastOperation.SetError(lastErr)
+					e.opTracker.LastOperation.MarkEnd()
+					obj.SetConditions(upjetresource.LastAsyncOperationCondition(lastErr))
+					return nil
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: true,
+				},
+				lastCondition: &xpv1.Condition{
+					Type:    upjetresource.TypeLastAsyncOperation,
+					Status:  corev1.ConditionFalse,
+					Reason:  upjetresource.ReasonAsyncCreateFailure,
+					Message: tjerrors.NewAsyncCreateFailed(errBoom).Error(),
+				},
+				lastOperationErr: tjerrors.NewAsyncCreateFailed(errBoom),
+				externalName:     "example-id",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			baseExternal := prepareTPFExternalWithTestConfig(tc.args.testConfig)
+			asyncExternal := &terraformPluginFrameworkAsyncExternalClient{
+				terraformPluginFrameworkExternalClient: baseExternal,
+			}
+			obj := tc.args.testConfig.obj
+			if tc.args.prepare != nil {
+				if err := tc.args.prepare(asyncExternal, &obj); err != nil {
+					t.Fatalf("prepare(...): %v", err)
+				}
+			}
+			observation, err := asyncExternal.Observe(context.TODO(), &obj)
+			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
+				t.Errorf("\nObserve(...): -want observation, +got observation:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\nObserve(...): -want error, +got error:\n%s", diff)
+			}
+			if tc.want.lastCondition != nil {
+				got := obj.GetCondition(tc.want.lastCondition.Type)
+				if diff := cmp.Diff(*tc.want.lastCondition, got, cmpopts.IgnoreFields(xpv1.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("\nObserve(...): -want condition, +got condition:\n%s", diff)
+				}
+			}
+			if tc.want.lastOperationErr != nil {
+				if diff := cmp.Diff(tc.want.lastOperationErr, asyncExternal.opTracker.LastOperation.Error(), test.EquateErrors()); diff != "" {
+					t.Errorf("\nObserve(...): -want last operation error, +got last operation error:\n%s", diff)
+				}
+			}
+			if tc.want.externalName != "" {
+				if diff := cmp.Diff(tc.want.externalName, meta.GetExternalName(&obj)); diff != "" {
+					t.Errorf("\nObserve(...): -want external-name, +got external-name:\n%s", diff)
+				}
+			}
+		})
+	}
+}
+

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -126,13 +126,15 @@ func (n *terraformPluginSDKAsyncExternal) Observe(ctx context.Context, mg xpreso
 	n.opTracker.LastOperation.Clear(true)
 
 	o, err := n.terraformPluginSDKExternal.Observe(ctx, mg)
-	// clear any previously reported LastAsyncOperation error condition here,
-	// because there are no pending updates on the existing resource and it's
-	// not scheduled to be deleted.
+	// Only clear previously reported LastAsyncOperation failures if there is no
+	// unresolved async error cached in the operation tracker. Otherwise, an
+	// observe-only success can mask a terminal async failure.
 	if err == nil && o.ResourceExists && o.ResourceUpToDate && !meta.WasDeleted(mg) {
-		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
-		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
-		n.opTracker.LastOperation.Clear(false)
+		if lastErr := n.opTracker.LastOperation.Error(); lastErr == nil {
+			mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
+			mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
+			n.opTracker.LastOperation.Clear(false)
+		}
 	}
 	return o, err
 }

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -8,19 +8,24 @@ import (
 	"context"
 	"testing"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tf "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/resource/fake"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	tjerrors "github.com/crossplane/upjet/v2/pkg/terraform/errors"
 )
 
 var (
@@ -137,9 +142,12 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 
 func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 	type args struct {
-		r   Resource
-		cfg *config.Resource
-		obj xpresource.Managed
+		r             Resource
+		cfg           *config.Resource
+		obj           xpresource.Managed
+		prepare       func(*terraformPluginSDKAsyncExternal, xpresource.Managed)
+		wantCondition *xpv1.Condition
+		wantLastOpErr error
 	}
 	type want struct {
 		obs managed.ExternalObservation
@@ -189,16 +197,64 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 				},
 			},
 		},
+		"UpToDateWithUnresolvedAsyncFailure": {
+			args: args{
+				r: mockResource{
+					RefreshWithoutUpgradeFn: func(ctx context.Context, s *tf.InstanceState, meta interface{}) (*tf.InstanceState, diag.Diagnostics) {
+						return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+					},
+				},
+				cfg: cfgAsync,
+				obj: objAsync.DeepCopyObject().(xpresource.Managed),
+				prepare: func(e *terraformPluginSDKAsyncExternal, mg xpresource.Managed) {
+					lastErr := tjerrors.NewAsyncCreateFailed(errBoom)
+					e.opTracker.LastOperation.MarkStart("create")
+					e.opTracker.LastOperation.SetError(lastErr)
+					e.opTracker.LastOperation.MarkEnd()
+					mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(lastErr))
+				},
+				wantCondition: &xpv1.Condition{
+					Type:    resource.TypeLastAsyncOperation,
+					Status:  corev1.ConditionFalse,
+					Reason:  resource.ReasonAsyncCreateFailure,
+					Message: tjerrors.NewAsyncCreateFailed(errBoom).Error(),
+				},
+				wantLastOpErr: tjerrors.NewAsyncCreateFailed(errBoom),
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: true,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, CallbackFns{})
+			if tc.args.prepare != nil {
+				tc.args.prepare(terraformPluginSDKAsyncExternal, tc.args.obj)
+			}
 			observation, err := terraformPluginSDKAsyncExternal.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+			if tc.args.wantCondition != nil {
+				got := tc.args.obj.(resource.Terraformed).GetCondition(tc.args.wantCondition.Type)
+				if diff := cmp.Diff(*tc.args.wantCondition, got, cmpopts.IgnoreFields(xpv1.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("\nObserve(...): -want condition, +got condition:\n%s", diff)
+				}
+			}
+			if tc.args.wantLastOpErr != nil {
+				if diff := cmp.Diff(tc.args.wantLastOpErr, terraformPluginSDKAsyncExternal.opTracker.LastOperation.Error(), test.EquateErrors()); diff != "" {
+					t.Errorf("\nObserve(...): -want last operation error, +got last operation error:\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Problem statement

In asynchronous reconciliation flows, a terminal failure from the last async create/update operation can be unintentionally masked by a later successful observe pass.

In practice, this can make a managed resource look healthy (`Synced=True` / reconcile success) even though the most recent async operation actually failed and has not yet been resolved by a successful retry.

## Failure pattern (generic)

A representative sequence:

1. Controller starts async create/update.
2. Provider/API returns a terminal error for that async operation (for example, transient `5xx`, dependency not ready, or backend operation failure).
3. Callback path records failure (`LastAsyncOperation=False`, reconcile error).
4. Next reconcile runs `Observe`.
5. `Observe` returns `ResourceExists=true` and `ResourceUpToDate=true` (resource object may exist and desired diff is empty from Terraform perspective).
6. Previous code path unconditionally cleared async failure condition and set reconcile success.

Result: failure signal from step 3 could be overwritten before a genuinely successful apply cycle occurs.

## Concrete generic example

- Async create returns a terminal provider error (e.g. `InternalServerError` or equivalent).
- Immediately after, `Observe` reports resource as existing and up-to-date.
- Status transitions could show success while the prior async operation remained unresolved.

This is a status/condition precedence issue, not a provider-specific business logic issue.

## Root cause

The async observe code paths were clearing failure-related conditions based only on observe success (`err == nil && exists && upToDate`) without verifying whether the operation tracker still contained an unresolved async error.

Additionally, in the framework `recoverExternalName` branch (failed create + partial state), observe returned `ResourceUpToDate=true`, which could also contribute to a false healthy signal during recovery.

## What this PR changes

### 1) Guard condition clearing with operation error state

For both async clients:

- `pkg/controller/external_async_tfpluginsdk.go`
- `pkg/controller/external_async_tfpluginfw.go`

Condition-clearing logic now executes only when:

- observe is successful **and**
- `LastOperation.Error()` is `nil`

So unresolved async failures are preserved until a true successful cycle clears them.

### 2) Harden framework recovery branch

In:

- `pkg/controller/external_async_tfpluginfw.go`

When recovering external name after a failed async create, observe now returns:

- `ResourceExists=true`
- `ResourceLateInitialized=true`
- `ResourceUpToDate=false`  <-- changed from true

This keeps reconcile state conservative while a failed async operation remains unresolved.

## Behavior after fix

If an async create/update fails:

- failure condition is retained,
- observe-only success does not prematurely clear failure,
- resource is not presented as fully healthy/synced until a successful apply/update resolves the error.

## Regression coverage added

### SDK async client

File:

- `pkg/controller/external_async_tfpluginsdk_test.go`

New case validates:

- prior async create failure + observe up-to-date
- `LastAsyncOperation` remains failed
- operation tracker error remains set

### Framework async client

New file:

- `pkg/controller/external_async_tfpluginfw_test.go`

Cases validate:

1. prior async failure is not masked by observe up-to-date
2. failed-create `recoverExternalName` path does not report `ResourceUpToDate=true` and preserves failure signaling

## Why this is safe

- No API surface changes.
- No CRD/schema changes.
- Changes are limited to async reconcile condition handling and test coverage.
- Logic is stricter/conservative: success is only reported when there is no unresolved async error state.

## Test plan

- [x] `go test ./pkg/controller/...`
- [x] Validate unresolved async error is preserved in SDK async observe flow
- [x] Validate unresolved async error is preserved in framework async observe flow
- [x] Validate framework failed-create recovery path stays not-up-to-date until resolution