### PR TITLE
Fix panic while diffing tf framework resources with nested attributes collection types

### DIFF
--- a/pkg/controller/proposed_state.go
+++ b/pkg/controller/proposed_state.go
@@ -478,7 +478,7 @@ func proposedNewObjectAttributes(schema rschema.NestedAttribute, prior, config t
 		rs[k] = rat
 	}
 
-	return tftypes.NewValue(schema.GetType().TerraformType(context.TODO()), proposedNewAttributes(rs, prior, config))
+	return tftypes.NewValue(schema.GetNestedObject().Type().TerraformType(context.TODO()), proposedNewAttributes(rs, prior, config))
 }
 
 func proposedNewAttributes(attrs map[string]rschema.Attribute, prior, config tftypes.Value) map[string]tftypes.Value {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

 @sergenyalcin @erhancagirici PTAL 🙏 

For Terraform plugin framework resources with nested attributes collection(list/map/set) types https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes#nested-attribute-types, the external Observe() runs into panic `"tftypes.NewValue can't use map[string]tftypes.Value as a tftypes.List; expected types are: []tftypes.Value"` in getDiffPlanResponse().

Fixes the panic by referencing the right schema type for the tf value.

below stack trace was for github.com/crossplane/upjet/v2 `v2.2.1-0.20251217201857-cf84e7188f60` mod dependency:

```
2026-03-04T23:55:44Z	ERROR	Observed a panic	{"controller": "managed/iam.cloud.ex.com/v1beta1, kind=accountrole", "namespace": "", "name": "test-role", "reconcileID": "869a1929-4ffe-42ae-9f74-2112bd10fc7c", "panic": "tftypes.NewValue can't use map[string]tftypes.Value as a tftypes.List; expected types are: []tftypes.Value", "panicGoValue": "&errors.errorString{s:\"tftypes.NewValue can't use map[string]tftypes.Value as a tftypes.List; expected types are: []tftypes.Value\"}", "stacktrace": "goroutine 428 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x303bed0, 0x2c9c2c505590}, {0x28b7d80, 0x2c9c294ec580})\n\tk8s.io/apimachinery@v0.35.0/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:198 +0x103\npanic({0x28b7d80?, 0x2c9c294ec580?})\n\truntime/panic.go:860 +0x13a\ngithub.com/hashicorp/terraform-plugin-go/tftypes.NewValue(...)\n\tgithub.com/hashicorp/terraform-plugin-go@v0.29.0/tftypes/value.go:278\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNewObjectAttributes({0x7f298a164008, 0x2c9c246be9a0}, {{0x304ce10?, 0x2c9c3c0a98f0?}, {0x295d700?, 0x2c9c3c0a95c0?}}, {{0x304ce10, 0x2c9c3c0aa450}, {0x295d700, 0x2c9c3c0aa120}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:481 +0x2e5\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNewBlockOrObject({0x7f298a164098?, 0x2c9c246be9a0}, {{0x304ce10?, 0x2c9c3c0a98f0?}, {0x295d700?, 0x2c9c3c0a95c0?}}, {{0x304ce10, 0x2c9c3c0aa450}, {0x295d700, 0x2c9c3c0aa120}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:215 +0x2c6\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNewNestingList({0x7f298a164098, 0x2c9c246be9a0}, {{0x304cdb8?, 0x2c9c3c0a9b00?}, {0x2743400?, 0x2c9c3c09af60?}}, {{0x304cdb8, 0x2c9c3c0aa660}, {0x2743400, 0x2c9c3c09aff0}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:317 +0x3cb\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNewNestedType({0x7f298a164008, 0x2c9c246be9a0}, {{0x304cdb8?, 0x2c9c3c0a9b00?}, {0x2743400?, 0x2c9c3c09af60?}}, {{0x304cdb8, 0x2c9c3c0aa660}, {0x2743400, 0x2c9c3c09aff0}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:281 +0x3fc\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNewAttributes(0x2c9c2e05eae0, {{0x304ce10?, 0x2c9c3c0aa060?}, {0x295d700?, 0x2c9c3c0a9590?}}, {{0x304ce10?, 0x2c9c3c0aa900?}, {0x295d700?, 0x2c9c3c0aa090?}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:520 +0x4a5\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedNew({0x2c9c2e05eae0, 0x0, {0x2e2b425, 0x34}, {0x0, 0x0}, {0x0, 0x0}, 0x0}, {{0x304ce10, ...}, ...}, ...)\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:127 +0x2ef\ngithub.com/crossplane/upjet/v2/pkg/controller.proposedState({0x2c9c2e05eae0, 0x0, {0x2e2b425, 0x34}, {0x0, 0x0}, {0x0, 0x0}, 0x0}, {{0x304ce10, ...}, ...}, ...)\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:68 +0x188\ngithub.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkExternalClient).getDiffPlanResponse(0x2c9c32da91e0, {0x303bf78, 0x2c9c24768b60}, {{0x304ce10?, 0x2c9c3c0a46c0?}, {0x295d700?, 0x2c9c3c0a2d80?}})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_tfpluginfw.go:359 +0x2dc\ngithub.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkExternalClient).Observe(0x2c9c32da91e0, {0x303bf78, 0x2c9c24768b60}, {0x307e2b0, 0x2c9c2baef408})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_tfpluginfw.go:560 +0xa70\ngithub.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkAsyncExternalClient).Observe(0x2c9c31fd28a0, {0x303bf78, 0x2c9c24768b60}, {0x307e2b0, 0x2c9c2baef408})\n\tgithub.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_async_tfpluginfw.go:169 +0x1ec\ngithub.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed.(*Reconciler).Reconcile(0x2c9c2ae98140, {0x303bed0, 0x2c9c2c505590}, {{{0x0, 0x0}, {0x2c9c2d611bc5, 0x9}}})\n\tgithub.com/crossplane/crossplane-runtime/v2@v2.1.0/pkg/reconciler/managed/reconciler.go:1118 +0x2322\ngithub.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter.(*Reconciler).Reconcile(0x2c9c2c58c0f0, {0x303bed0, 0x2c9c2c505590}, {{{0x0?, 0x2c9c2c505590?}, {0x2c9c2d611bc5?, 0x0?}}})\n\tgithub.com/crossplane/crossplane-runtime/v2@v2.1.0/pkg/ratelimiter/reconciler.go:62 +0x139\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0x2c9c2c505500?, {0x303bed0?, 0x2c9c2c505590}, {{{0x0, 0x0?}, {0x2c9c2d611bc5?, 0x0?}}})\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:216 +0x165\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x3079f40, {0x303bf08, 0x2c9c24b1d180}, {{{0x0, 0x0}, {0x2c9c2d611bc5, 0x9}}}, 0x0)\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:461 +0x3ac\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x3079f40, {0x303bf08, 0x2c9c24b1d180})\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421 +0x1f8\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 420\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:292 +0x26b\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
	k8s.io/apimachinery@v0.35.0/pkg/util/runtime/runtime.go:142
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
	sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:198
runtime.gopanic
	runtime/panic.go:860
github.com/hashicorp/terraform-plugin-go/tftypes.NewValue
	github.com/hashicorp/terraform-plugin-go@v0.29.0/tftypes/value.go:278
github.com/crossplane/upjet/v2/pkg/controller.proposedNewObjectAttributes
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:481
github.com/crossplane/upjet/v2/pkg/controller.proposedNewBlockOrObject
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:215
github.com/crossplane/upjet/v2/pkg/controller.proposedNewNestingList
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:317
github.com/crossplane/upjet/v2/pkg/controller.proposedNewNestedType
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:281
github.com/crossplane/upjet/v2/pkg/controller.proposedNewAttributes
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:520
github.com/crossplane/upjet/v2/pkg/controller.proposedNew
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:127
github.com/crossplane/upjet/v2/pkg/controller.proposedState
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/proposed_state.go:68
github.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkExternalClient).getDiffPlanResponse
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_tfpluginfw.go:359
github.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkExternalClient).Observe
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_tfpluginfw.go:560
github.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginFrameworkAsyncExternalClient).Observe
	github.com/crossplane/upjet/v2@v2.2.1-0.20251217201857-cf84e7188f60/pkg/controller/external_async_tfpluginfw.go:169
github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed.(*Reconciler).Reconcile
	github.com/crossplane/crossplane-runtime/v2@v2.1.0/pkg/reconciler/managed/reconciler.go:1118
github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter.(*Reconciler).Reconcile
	github.com/crossplane/crossplane-runtime/v2@v2.1.0/pkg/ratelimiter/reconciler.go:62
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:216
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:461
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
	sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296
```

the terraform'ed resource being reconciled had this ListNestedAttribute in its resource schema:

```
			keys.Policies: schema.ListNestedAttribute{
				MarkdownDescription: "Policies for the custom account role where policy name is required to be unique in the list to identify each element.",
				NestedObject: schema.NestedAttributeObject{
					Attributes: map[string]schema.Attribute{
						keys.Actions: schema.ListAttribute{
							MarkdownDescription: "Actions belonging to the service name for which this policy is being defined.",
							ElementType:         basetypes.StringType{},
							Optional:            true,
							PlanModifiers:       []planmodifier.List{},
							Validators:          []validator.List{},
						},
						keys.Condition: schema.SingleNestedAttribute{
							MarkdownDescription: "Condition for tags if applicable",
							Attributes: map[string]schema.Attribute{
								keys.ForAllValuesStringEquals: schema.SingleNestedAttribute{
									MarkdownDescription: "The condition forAllValuesStringEquals for the tag.",
									Attributes: map[string]schema.Attribute{
										keys.ResourceTags: schema.ListNestedAttribute{
											MarkdownDescription: "The resource tags for the condition",
											NestedObject: schema.NestedAttributeObject{
												Attributes: map[string]schema.Attribute{
													keys.Key: schema.StringAttribute{
														MarkdownDescription: "The key for the tag.",
														Optional:            true,
														PlanModifiers:       []planmodifier.String{},
														Validators:          []validator.String{},
													},
													keys.Value: schema.StringAttribute{
														MarkdownDescription: "The value for the tag.",
														Optional:            true,
														PlanModifiers:       []planmodifier.String{},
														Validators:          []validator.String{},
													},
												},
											},
											Optional:      true,
											PlanModifiers: []planmodifier.List{},
											Validators:    []validator.List{},
										},
									},
									Optional:      true,
									PlanModifiers: []planmodifier.Object{},
									Validators:    []validator.Object{},
								},
								keys.ForAnyValueStringEquals: schema.SingleNestedAttribute{
									MarkdownDescription: "The condition forAnyValueStringEquals for the tag.",
									Attributes: map[string]schema.Attribute{
										keys.ResourceTags: schema.ListNestedAttribute{
											MarkdownDescription: "The resource tags for the condition",
											NestedObject: schema.NestedAttributeObject{
												Attributes: map[string]schema.Attribute{
													keys.Key: schema.StringAttribute{
														MarkdownDescription: "The key for the tag.",
														Optional:            true,
														PlanModifiers:       []planmodifier.String{},
														Validators:          []validator.String{},
													},
													keys.Value: schema.StringAttribute{
														MarkdownDescription: "The value for the tag.",
														Optional:            true,
														PlanModifiers:       []planmodifier.String{},
														Validators:          []validator.String{},
													},
												},
											},
											Optional:      true,
											PlanModifiers: []planmodifier.List{},
											Validators:    []validator.List{},
										},
									},
									Optional:      true,
									PlanModifiers: []planmodifier.Object{},
									Validators:    []validator.Object{},
								},
							},
							Optional:      true,
							PlanModifiers: []planmodifier.Object{},
							Validators:    []validator.Object{},
						},
					},
				},
				Optional:      true,
				PlanModifiers: []planmodifier.List{},
				Validators:    []validator.List{},
			}, 
```



I have:

- [X] Read and followed Upjet's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Tested manually that the reconcile loop/Observe runs successfully for the impacted tf framework MR resource with listnested attributes, after the fix.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
