### PR TITLE
feat(issue-559): allow sensitive values to be passable as plaintext

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -244,6 +244,12 @@ type Sensitive struct {
 	// fieldPaths keeps the mapping of sensitive fields in Terraform schema with
 	// terraform field path as key and xp field path as value.
 	fieldPaths map[string]string
+
+	// AllowPlaintextValue allows sensitive fields to be passed as plaintext
+	// in addition to secret references. When true, sensitive fields will be
+	// generated as both a regular field and a secret reference field, giving
+	// users the option to provide values directly or via secrets.
+	AllowPlaintextValue bool
 }
 
 // LateInitializer represents configurations that control

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -182,6 +182,14 @@ func GetSensitiveParameters(ctx context.Context, client SecretClient, from resou
 			prefixes = []string{""}
 		}
 
+		// Check if plaintext value already exists in Terraform state
+		// This happens when AllowPlaintextValue is enabled and user provided plaintext
+		existingValue, err := pavedTF.GetValue(tfPath)
+		if err == nil && existingValue != nil {
+			// Plaintext value exists, skip secret reference handling
+			continue
+		}
+
 		// spec.forProvider secret references override the spec.initProvider
 		// references.
 		for _, p := range prefixes {

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -165,6 +165,16 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 			if drop {
 				continue
 			}
+			// If AllowPlaintextValue is enabled, also generate the regular field
+			if cfg.Sensitive.AllowPlaintextValue && !IsObservation(res.Schema[snakeFieldName]) {
+				regularField, err := NewField(g, cfg, r, res.Schema[snakeFieldName], snakeFieldName, tfPath, xpPath, names, asBlocksMode)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				// Track that these fields are alternatives for validation
+				regularField.AlternateFieldName = f.TransformedName
+				regularField.AddToResource(g, r, typeNames, ptr.Deref(cfg.SchemaElementOptions[cPath], config.SchemaElementOption{}))
+			}
 		case reference != nil:
 			f, err = NewReferenceField(g, cfg, r, res.Schema[snakeFieldName], reference, snakeFieldName, tfPath, xpPath, names, asBlocksMode)
 			if err != nil {
@@ -204,7 +214,16 @@ func (g *Builder) AddToBuilder(typeNames *TypeNames, r *resource) (*types.Named,
 	for _, p := range r.topLevelRequiredParams {
 		g.validationRules += "\n"
 		sp := sanitizePath(p.path)
-		if p.includeInit {
+		if p.alternateFieldPath != "" {
+			// When there's an alternate field path (e.g., AllowPlaintextValue),
+			// create an OR condition requiring at least one of the two fields
+			asp := sanitizePath(p.alternateFieldPath)
+			if p.includeInit {
+				g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || has(self.forProvider.%s) || (has(self.initProvider) && (has(self.initProvider.%s) || has(self.initProvider.%s)))",message="spec.forProvider.%s or spec.forProvider.%s is a required parameter"`, sp, asp, sp, asp, p.path, p.alternateFieldPath)
+			} else {
+				g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || has(self.forProvider.%s)",message="spec.forProvider.%s or spec.forProvider.%s is a required parameter"`, sp, asp, p.path, p.alternateFieldPath)
+			}
+		} else if p.includeInit {
 			g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || (has(self.initProvider) && has(self.initProvider.%s))",message="spec.forProvider.%s is a required parameter"`, sp, sp, p.path)
 		} else {
 			g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s)",message="spec.forProvider.%s is a required parameter"`, sp, p.path)
@@ -374,12 +393,17 @@ type resource struct {
 }
 
 type topLevelRequiredParam struct {
-	path        string
-	includeInit bool
+	path          string
+	includeInit   bool
+	alternateFieldPath string // Alternative field path (e.g., for AllowPlaintextValue)
 }
 
 func newTopLevelRequiredParam(path string, includeInit bool) *topLevelRequiredParam {
 	return &topLevelRequiredParam{path: path, includeInit: includeInit}
+}
+
+func newTopLevelRequiredParamWithAlternate(path string, includeInit bool, alternatePath string) *topLevelRequiredParam {
+	return &topLevelRequiredParam{path: path, includeInit: includeInit, alternateFieldPath: alternatePath}
 }
 
 func (r *resource) addParameterField(f *Field, field *types.Var) {
@@ -401,7 +425,12 @@ func (r *resource) addParameterField(f *Field, field *types.Var) {
 		requiredBySchema = false
 		// If the field is not a terraform field, we should not require it in init,
 		// as it is not an initProvider field.
-		r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParam(f.TransformedName, !f.TFTag.AlwaysOmitted()))
+		if f.AlternateFieldName != "" {
+			// This field has an alternate (e.g., AllowPlaintextValue scenario)
+			r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParamWithAlternate(f.TransformedName, !f.TFTag.AlwaysOmitted(), f.AlternateFieldName))
+		} else {
+			r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParam(f.TransformedName, !f.TFTag.AlwaysOmitted()))
+		}
 	}
 
 	// Note(lsviben): Only fields which are not also initProvider fields should have a required kubebuilder comment.

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -169,6 +169,16 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 			if drop {
 				continue
 			}
+			// If AllowPlaintextValue is enabled, also generate the regular field
+			if cfg.Sensitive.AllowPlaintextValue && !IsObservation(res.Schema[snakeFieldName]) {
+				regularField, err := NewField(g, cfg, r, res.Schema[snakeFieldName], snakeFieldName, tfPath, xpPath, names, asBlocksMode)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				// Track that these fields are alternatives for validation
+				regularField.AlternateFieldName = f.TransformedName
+				regularField.AddToResource(g, r, typeNames, ptr.Deref(cfg.SchemaElementOptions[cPath], config.SchemaElementOption{}))
+			}
 		case reference != nil:
 			f, err = NewReferenceField(g, cfg, r, res.Schema[snakeFieldName], reference, snakeFieldName, tfPath, xpPath, names, asBlocksMode)
 			if err != nil {
@@ -208,7 +218,16 @@ func (g *Builder) AddToBuilder(typeNames *TypeNames, r *resource) (*types.Named,
 	for _, p := range r.topLevelRequiredParams {
 		g.validationRules += "\n"
 		sp := sanitizePath(p.path)
-		if p.includeInit {
+		if p.alternateFieldPath != "" {
+			// When there's an alternate field path (e.g., AllowPlaintextValue),
+			// create an OR condition requiring at least one of the two fields
+			asp := sanitizePath(p.alternateFieldPath)
+			if p.includeInit {
+				g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || has(self.forProvider.%s) || (has(self.initProvider) && (has(self.initProvider.%s) || has(self.initProvider.%s)))",message="spec.forProvider.%s or spec.forProvider.%s is a required parameter"`, sp, asp, sp, asp, p.path, p.alternateFieldPath)
+			} else {
+				g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || has(self.forProvider.%s)",message="spec.forProvider.%s or spec.forProvider.%s is a required parameter"`, sp, asp, p.path, p.alternateFieldPath)
+			}
+		} else if p.includeInit {
 			g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s) || (has(self.initProvider) && has(self.initProvider.%s))",message="spec.forProvider.%s is a required parameter"`, sp, sp, p.path)
 		} else {
 			g.validationRules += fmt.Sprintf(`// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.%s)",message="spec.forProvider.%s is a required parameter"`, sp, p.path)
@@ -378,12 +397,17 @@ type resource struct {
 }
 
 type topLevelRequiredParam struct {
-	path        string
-	includeInit bool
+	path          string
+	includeInit   bool
+	alternateFieldPath string // Alternative field path (e.g., for AllowPlaintextValue)
 }
 
 func newTopLevelRequiredParam(path string, includeInit bool) *topLevelRequiredParam {
 	return &topLevelRequiredParam{path: path, includeInit: includeInit}
+}
+
+func newTopLevelRequiredParamWithAlternate(path string, includeInit bool, alternatePath string) *topLevelRequiredParam {
+	return &topLevelRequiredParam{path: path, includeInit: includeInit, alternateFieldPath: alternatePath}
 }
 
 func (r *resource) addParameterField(f *Field, field *types.Var) {
@@ -405,7 +429,12 @@ func (r *resource) addParameterField(f *Field, field *types.Var) {
 		requiredBySchema = false
 		// If the field is not a terraform field, we should not require it in init,
 		// as it is not an initProvider field.
-		r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParam(f.TransformedName, !f.TFTag.AlwaysOmitted()))
+		if f.AlternateFieldName != "" {
+			// This field has an alternate (e.g., AllowPlaintextValue scenario)
+			r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParamWithAlternate(f.TransformedName, !f.TFTag.AlwaysOmitted(), f.AlternateFieldName))
+		} else {
+			r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParam(f.TransformedName, !f.TFTag.AlwaysOmitted()))
+		}
 	}
 
 	// Note(lsviben): Only fields which are not also initProvider fields should have a required kubebuilder comment.

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -56,6 +56,9 @@ type Field struct {
 	// Sensitive is set if this Field holds sensitive data and is thus
 	// generated as a secret reference.
 	Sensitive bool
+	// AlternateFieldName is set when this field has an alternative field
+	// (e.g., clientId and clientIdSecretRef when AllowPlaintextValue is true)
+	AlternateFieldName string
 }
 
 // getDocString tries to extract the documentation string for the specified
@@ -288,6 +291,19 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 		// Data will be stored in connection details secret
 		return nil, true, nil
 	}
+	
+	// When AllowPlaintextValue is true, the secret ref field is not required
+	// by itself since the plaintext field can be used instead.
+	// We need to mark the schema as optional to prevent it from being added
+	// to topLevelRequiredParams.
+	if cfg.Sensitive.AllowPlaintextValue {
+		f.Required = false
+		// Create a copy of the schema and mark it as optional
+		schemaCopy := *f.Schema
+		schemaCopy.Optional = true
+		f.Schema = &schemaCopy
+	}
+	
 	sfx := "SecretRef"
 	switch f.FieldType.(type) {
 	case *types.Slice:


### PR DESCRIPTION
# allow sensitive values to be passable as plaintext

Draft for #559 to have a base for discussion.  This shall give you an idea of the requirement i have.
This was the easiest implementation approach I found that is fully backwards compatible. 
However, it does add some complexity to the builder logic and generated code, so I'm open to suggestions on how to make it cleaner or if we want to take a different approach.
In general i need some more flexibility with what i can pass in as secret and what i can pass in as plaintext for the provider-keycloak, as OIDC / SAML clients and tools vary alot in what they support and need.


## Problem

Sensitive fields currently only support secret references. Users must create a Kubernetes Secret even if they just want to pass a value directly. This is inflexible and doesn't match how the underlying Terraform providers work (which accept plaintext).

## Potential Solution

I Added a `AllowPlaintextValue` config flag. When enabled, generates both the regular field AND the secret reference field for sensitive parameters. Users pick which one to use via OR validation (provide one or the other, not both).

Runtime checks the plaintext field first, falls back to secret reference if not set. Its Backwards compatible so existing secret-only resources work unchanged.

## Usage

Provider configuration:
```go
p.AddResourceConfigurator("keycloak_oidc_identity_provider", func(r *config.Resource) {
    r.ShortGroup = "oidc"
    
    // Mark fields as sensitive in Terraform schema
    if s, ok := r.TerraformResource.Schema["client_id"]; ok {
        s.Sensitive = true
    }
    if s, ok := r.TerraformResource.Schema["client_secret"]; ok {
        s.Sensitive = true
    }
    
    // Enable plaintext AND secret reference support
    r.Sensitive.AllowPlaintextValue = true
})
```
See https://github.com/crossplane-contrib/provider-keycloak/blob/feat/upjet-test/config/oidc/config.go#L30

Generated CRD types will then look like this:
```go
type IdentityProviderParameters struct {
    // [...more stuff...]
    // Plaintext field (new!)
    ClientID *string `json:"clientId,omitempty"`
    
    // Secret reference field (existing)
    ClientIDSecretRef v1.SecretKeySelector `json:"clientIdSecretRef,omitempty"`
    
    ClientSecret *string `json:"clientSecret,omitempty"`
    ClientSecretSecretRef *v1.SecretKeySelector `json:"clientSecretSecretRef,omitempty"`
   // [...more stuff...]
}
```
see https://github.com/crossplane-contrib/provider-keycloak/blob/feat/upjet-test/apis/cluster/oidc/v1alpha1/zz_identityprovider_types.go#L43


## Example

After enabling `AllowPlaintextValue`, users can choose:
```yaml
# Option 1: Plaintext (new)
spec:
  forProvider:
    clientId: "my-client-id"
    clientSecret: "my-secret"

# Option 2: Secret references 
spec:
  forProvider:
    clientIdSecretRef:
      name: my-secret
      key: client_id
    clientSecretSecretRef:
      name: my-secret
      key: client_secret
      [... other fields ...]
```

## Testing

I Tested in provider-keycloak with both plaintext and secret reference patterns.
Both resources successfully created and synced in a dev cluster. 

