### PR TITLE
set observedGeneration for status conditions

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -124,7 +124,7 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform
 		// status condition but we need changes in the managed reconciler
 		// to do so. So we keep the `LastAsyncOperation` condition.
 		// TODO: move this to the `Synced` condition.
-		tr.SetConditions(resource.LastAsyncOperationCondition(err))
+		tr.SetConditions(resource.LastAsyncOperationCondition(err).WithObservedGeneration(tr.GetGeneration()))
 		if err != nil {
 			wrapMsg := ""
 			switch op {
@@ -135,12 +135,12 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform
 			case "destroy":
 				wrapMsg = errXPReconcileDelete
 			}
-			tr.SetConditions(xpv1.ReconcileError(errors.Wrap(err, wrapMsg)))
+			tr.SetConditions(xpv1.ReconcileError(errors.Wrap(err, wrapMsg)).WithObservedGeneration(tr.GetGeneration()))
 		} else {
-			tr.SetConditions(xpv1.ReconcileSuccess())
+			tr.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(tr.GetGeneration()))
 		}
 		if ac.enableStatusUpdates {
-			tr.SetConditions(resource.AsyncOperationFinishedCondition())
+			tr.SetConditions(resource.AsyncOperationFinishedCondition().WithObservedGeneration(tr.GetGeneration()))
 		}
 		uErr := errors.Wrapf(ac.kube.Status().Update(ctx, tr), errUpdateStatusFmt, tr.GetObjectKind().GroupVersionKind().String(), nn, op)
 		if ac.eventHandler != nil {

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -472,7 +472,7 @@ func (e *external) Import(ctx context.Context, tr resource.Terraformed) (managed
 	// in progress. In that case, we want to wait for the operation to finish
 	// before we start observing.
 	if res.ASyncInProgress {
-		tr.SetConditions(resource.AsyncOperationOngoingCondition())
+		tr.SetConditions(resource.AsyncOperationOngoingCondition().WithObservedGeneration(tr.GetGeneration()))
 		return managed.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: true,
@@ -502,7 +502,7 @@ func (e *external) Import(ctx context.Context, tr resource.Terraformed) (managed
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot get connection details")
 	}
 
-	tr.SetConditions(xpv1.Available())
+	tr.SetConditions(xpv1.Available().WithObservedGeneration(tr.GetGeneration()))
 	return managed.ExternalObservation{
 		ResourceExists:    true,
 		ResourceUpToDate:  true,

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -171,8 +171,8 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 	// because there are no pending updates on the existing resource and it's
 	// not scheduled to be deleted.
 	if err == nil && o.ResourceExists && o.ResourceUpToDate && !meta.WasDeleted(mg) {
-		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
-		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
+		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil).WithObservedGeneration(mg.GetGeneration()))
+		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(mg.GetGeneration()))
 		n.opTracker.LastOperation.Clear(false)
 	}
 	return o, err

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -130,8 +130,8 @@ func (n *terraformPluginSDKAsyncExternal) Observe(ctx context.Context, mg xpreso
 	// because there are no pending updates on the existing resource and it's
 	// not scheduled to be deleted.
 	if err == nil && o.ResourceExists && o.ResourceUpToDate && !meta.WasDeleted(mg) {
-		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil))
-		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess())
+		mg.(resource.Terraformed).SetConditions(resource.LastAsyncOperationCondition(nil).WithObservedGeneration(mg.GetGeneration()))
+		mg.(resource.Terraformed).SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(mg.GetGeneration()))
 		n.opTracker.LastOperation.Clear(false)
 	}
 	return o, err

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -589,7 +589,7 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 			mg.GetCondition(xpv1.TypeReady).Status == corev1.ConditionFalse {
 			addTTR(mg)
 		}
-		mg.SetConditions(xpv1.Available())
+		mg.SetConditions(xpv1.Available().WithObservedGeneration(mg.GetGeneration()))
 
 		// we get the connection details from the observed state before
 		// the conversion because the sensitive paths assume the native Terraform

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -546,7 +546,7 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 			mg.GetCondition(xpv1.TypeReady).Status == corev1.ConditionFalse {
 			addTTR(mg)
 		}
-		mg.SetConditions(xpv1.Available())
+		mg.SetConditions(xpv1.Available().WithObservedGeneration(mg.GetGeneration()))
 
 		// we get the connection details from the observed state before
 		// the conversion because the sensitive paths assume the native Terraform

--- a/pkg/resource/conditions.go
+++ b/pkg/resource/conditions.go
@@ -130,6 +130,6 @@ func SetUpToDateCondition(mg xpresource.Managed, upToDate bool) {
 	// After running refresh, if the resource is up-to-date and a test resource
 	// we can set the UpToDate condition
 	if upToDate && IsTest(mg) {
-		mg.SetConditions(UpToDateCondition())
+		mg.SetConditions(UpToDateCondition().WithObservedGeneration(mg.GetGeneration()))
 	}
 }


### PR DESCRIPTION
### Description of your changes

Set `observedGeneration` on all status conditions set by upjet controllers.

Fixes #591
Note: https://github.com/crossplane/crossplane-runtime/pull/906 already fixes the issue of unnecessarily updating `lastTransitionTime`. This change is to conform with the crossplane-runtime setting `observedGeneration` fields

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
