### PR TITLE
feat: add resource identity support to TF Plugin Framework integration

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -483,6 +483,25 @@ func (n *terraformPluginFrameworkExternalClient) hasResourceNotFoundDiagnostic(d
 	}
 	return n.config.ExternalName.IsNotFoundDiagnosticFn(diags)
 }
+
+// diagSummaryMissingResourceIdentity is the diagnostic summary returned by
+// terraform-plugin-framework when a resource with an IdentitySchema has its
+// state set to null (resource deleted externally or not yet created) but the
+// provider's identity interceptor skips populating identity for null states.
+const diagSummaryMissingResourceIdentity = "Missing Resource Identity After Read"
+
+// hasMissingResourceIdentityDiagnostic checks whether the diagnostics contain
+// the "Missing Resource Identity After Read" error. We treat this as a
+// resource-not-found condition.
+func hasMissingResourceIdentityDiagnostic(diags []*tfprotov6.Diagnostic) bool {
+	for _, d := range diags {
+		if d.Severity == tfprotov6.DiagnosticSeverityError && d.Summary == diagSummaryMissingResourceIdentity {
+			return true
+		}
+	}
+	return false
+}
+
 func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg xpresource.Managed) (managed.ExternalObservation, error) { //nolint:gocyclo
 	n.logger.Debug("Observing the external resource")
 
@@ -508,11 +527,18 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 	// suppress them if the resource has such configuration.
 	isResourceNotFoundDiags := n.hasResourceNotFoundDiagnostic(readResponse.Diagnostics)
 	if fatalDiags := getFatalDiagnostics(readResponse.Diagnostics); fatalDiags != nil {
-		if !isResourceNotFoundDiags {
+		isMissingIdentityDiags := hasMissingResourceIdentityDiagnostic(readResponse.Diagnostics)
+		if !isResourceNotFoundDiags && !isMissingIdentityDiags {
 			n.opTracker.ResetReconstructedFrameworkTFState()
 			return managed.ExternalObservation{}, errors.Wrap(fatalDiags, "read resource request failed")
 		}
-		n.logger.Debug("TF ReadResource returned error diagnostics, but XP resource was configured to treat them as `Resource not exists`. Skipping", "skippedDiags", fatalDiags)
+		if isResourceNotFoundDiags {
+			n.logger.Debug("TF ReadResource returned error diagnostics, but XP resource was configured to treat them as `Resource not exists`. Skipping", "skippedDiags", fatalDiags)
+		}
+		if isMissingIdentityDiags {
+			n.logger.Debug("TF ReadResource returned Missing Resource Identity diagnostic, treating as resource not found", "skippedDiags", fatalDiags)
+			isResourceNotFoundDiags = true
+		}
 	}
 
 	var tfStateValue tftypes.Value

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -110,6 +110,14 @@ type terraformPluginFrameworkExternalClient struct {
 	resourceTerraformConfigValue tftypes.Value
 }
 
+// supportsIdentity reports whether the underlying TF resource implements
+// fwresource.ResourceWithIdentity and therefore participates in identity
+// propagation through Read/Plan/Apply cycles.
+func (n *terraformPluginFrameworkExternalClient) supportsIdentity() bool {
+	_, ok := n.resource.(fwresource.ResourceWithIdentity)
+	return ok
+}
+
 func getFrameworkExtendedParameters(ctx context.Context, tr resource.Terraformed, externalName string, cfg *config.Resource, ts terraform.Setup, initParamsMerged bool, kube client.Client, fwResSchema rschema.Schema) (map[string]any, error) { //nolint:gocyclo // easier to follow as a unit
 	var err error
 	var params map[string]any                          // Assigned by both branches; functions return non-nil on success
@@ -381,7 +389,9 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 		PriorState:       n.opTracker.GetFrameworkTFState(),
 		Config:           &tfConfigDynamicVal,
 		ProposedNewState: &tfProposedStateDynamicVal,
-		PriorIdentity:    n.opTracker.GetFrameworkIdentity(),
+	}
+	if n.supportsIdentity() {
+		prcReq.PriorIdentity = n.opTracker.GetFrameworkIdentity()
 	}
 	planResponse, err := n.server.PlanResourceChange(ctx, prcReq)
 	if err != nil {
@@ -404,7 +414,9 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 	if err := n.filterRequiresReplace(ctx, planResponse, tfStateValue, plannedStateValue); err != nil {
 		return nil, false, errors.Wrap(err, "failed to check for required replacement fields")
 	}
-	n.plannedIdentity = planResponse.PlannedIdentity
+	if n.supportsIdentity() {
+		n.plannedIdentity = planResponse.PlannedIdentity
+	}
 
 	return planResponse, n.filteredDiffExists(rawDiff), nil
 }
@@ -512,9 +524,11 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 	}
 
 	readRequest := &tfprotov6.ReadResourceRequest{
-		TypeName:        n.config.Name,
-		CurrentState:    n.opTracker.GetFrameworkTFState(),
-		CurrentIdentity: n.opTracker.GetFrameworkIdentity(),
+		TypeName:     n.config.Name,
+		CurrentState: n.opTracker.GetFrameworkTFState(),
+	}
+	if n.supportsIdentity() {
+		readRequest.CurrentIdentity = n.opTracker.GetFrameworkIdentity()
 	}
 	readResponse, err := n.server.ReadResource(ctx, readRequest)
 	if err != nil {
@@ -527,7 +541,7 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 	// suppress them if the resource has such configuration.
 	isResourceNotFoundDiags := n.hasResourceNotFoundDiagnostic(readResponse.Diagnostics)
 	if fatalDiags := getFatalDiagnostics(readResponse.Diagnostics); fatalDiags != nil {
-		isMissingIdentityDiags := hasMissingResourceIdentityDiagnostic(readResponse.Diagnostics)
+		isMissingIdentityDiags := n.supportsIdentity() && hasMissingResourceIdentityDiagnostic(readResponse.Diagnostics)
 		if !isResourceNotFoundDiags && !isMissingIdentityDiags {
 			n.opTracker.ResetReconstructedFrameworkTFState()
 			return managed.ExternalObservation{}, errors.Wrap(fatalDiags, "read resource request failed")
@@ -552,14 +566,18 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot create nil dynamic value")
 		}
 		n.opTracker.SetFrameworkTFState(&nildynamicValue)
-		n.opTracker.SetFrameworkIdentity(nil)
+		if n.supportsIdentity() {
+			n.opTracker.SetFrameworkIdentity(nil)
+		}
 	} else {
 		tfStateValue, err = readResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 		if err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot unmarshal state value")
 		}
 		n.opTracker.SetFrameworkTFState(readResponse.NewState)
-		n.opTracker.SetFrameworkIdentity(readResponse.NewIdentity)
+		if n.supportsIdentity() {
+			n.opTracker.SetFrameworkIdentity(readResponse.NewIdentity)
+		}
 	}
 
 	// Determine if the resource exists based on Terraform state
@@ -586,7 +604,9 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 					return managed.ExternalObservation{}, errors.Wrap(err, "cannot create nil dynamic value")
 				}
 				n.opTracker.SetFrameworkTFState(&nildynamicValue)
-				n.opTracker.SetFrameworkIdentity(nil)
+				if n.supportsIdentity() {
+					n.opTracker.SetFrameworkIdentity(nil)
+				}
 			}
 		}
 	}
@@ -700,11 +720,13 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:        n.config.Name,
-		PriorState:      n.opTracker.GetFrameworkTFState(),
-		PlannedState:    n.planResponse.PlannedState,
-		Config:          &tfConfigDynamicVal,
-		PlannedIdentity: n.plannedIdentity,
+		TypeName:     n.config.Name,
+		PriorState:   n.opTracker.GetFrameworkTFState(),
+		PlannedState: n.planResponse.PlannedState,
+		Config:       &tfConfigDynamicVal,
+	}
+	if n.supportsIdentity() {
+		applyRequest.PlannedIdentity = n.plannedIdentity
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -720,7 +742,9 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 		// In the following reconciles, this helps to track the external
 		// resource, rather than try to recreate that might cause leaking.
 		n.opTracker.SetFrameworkTFState(applyResponse.NewState)
-		n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+		if n.supportsIdentity() {
+			n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+		}
 		return managed.ExternalCreation{}, errors.Wrap(fatalDiags, "resource creation call returned error diags")
 	}
 
@@ -741,7 +765,9 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 	}
 
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
-	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	if n.supportsIdentity() {
+		n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	}
 
 	if _, err := n.setExternalName(mg, stateValueMap); err != nil {
 		return managed.ExternalCreation{}, errors.Wrapf(err, "failed to set the external-name of the managed resource during create")
@@ -805,11 +831,13 @@ func (n *terraformPluginFrameworkExternalClient) Update(ctx context.Context, mg 
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:        n.config.Name,
-		PriorState:      n.opTracker.GetFrameworkTFState(),
-		PlannedState:    n.planResponse.PlannedState,
-		Config:          &tfConfigDynamicVal,
-		PlannedIdentity: n.plannedIdentity,
+		TypeName:     n.config.Name,
+		PriorState:   n.opTracker.GetFrameworkTFState(),
+		PlannedState: n.planResponse.PlannedState,
+		Config:       &tfConfigDynamicVal,
+	}
+	if n.supportsIdentity() {
+		applyRequest.PlannedIdentity = n.plannedIdentity
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -821,7 +849,9 @@ func (n *terraformPluginFrameworkExternalClient) Update(ctx context.Context, mg 
 		return managed.ExternalUpdate{}, errors.Wrap(fatalDiags, "resource update call returned error diags")
 	}
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
-	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	if n.supportsIdentity() {
+		n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	}
 
 	newStateAfterApplyVal, err := applyResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 	if err != nil {
@@ -877,11 +907,14 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:        n.config.Name,
-		PriorState:      n.opTracker.GetFrameworkTFState(),
-		PlannedState:    &plannedState,
-		Config:          &tfConfigDynamicVal,
-		PlannedIdentity: n.plannedIdentity,
+		TypeName:     n.config.Name,
+		PriorState:   n.opTracker.GetFrameworkTFState(),
+		PlannedState: &plannedState,
+		Config:       &tfConfigDynamicVal,
+		// PlannedIdentity is intentionally nil for delete: the planned state is
+		// null (resource is going away) so there is no planned identity. Passing
+		// the update-plan identity stored in n.plannedIdentity would be stale
+		// and semantically incorrect.
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -893,7 +926,9 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 		return managed.ExternalDelete{}, errors.Wrap(fatalDiags, "resource deletion call returned error diags")
 	}
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
-	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	if n.supportsIdentity() {
+		n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
+	}
 
 	newStateAfterApplyVal, err := applyResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 	if err != nil {

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -93,16 +93,17 @@ func NewTerraformPluginFrameworkConnector(kube client.Client, sf terraform.Setup
 }
 
 type terraformPluginFrameworkExternalClient struct {
-	ts             terraform.Setup
-	config         *config.Resource
-	logger         logging.Logger
-	metricRecorder *metrics.MetricRecorder
-	opTracker      *AsyncTracker
-	resource       fwresource.Resource
-	server         tfprotov6.ProviderServer
-	params         map[string]any
-	planResponse   *tfprotov6.PlanResourceChangeResponse
-	resourceSchema rschema.Schema
+	ts              terraform.Setup
+	config          *config.Resource
+	logger          logging.Logger
+	metricRecorder  *metrics.MetricRecorder
+	opTracker       *AsyncTracker
+	resource        fwresource.Resource
+	server          tfprotov6.ProviderServer
+	params          map[string]any
+	planResponse    *tfprotov6.PlanResourceChangeResponse
+	plannedIdentity *tfprotov6.ResourceIdentityData
+	resourceSchema  rschema.Schema
 	// the terraform value type associated with the resource schema
 	resourceValueTerraformType tftypes.Type
 	// configured value for the resource in terraform type system
@@ -380,6 +381,7 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 		PriorState:       n.opTracker.GetFrameworkTFState(),
 		Config:           &tfConfigDynamicVal,
 		ProposedNewState: &tfProposedStateDynamicVal,
+		PriorIdentity:    n.opTracker.GetFrameworkIdentity(),
 	}
 	planResponse, err := n.server.PlanResourceChange(ctx, prcReq)
 	if err != nil {
@@ -402,6 +404,7 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 	if err := n.filterRequiresReplace(ctx, planResponse, tfStateValue, plannedStateValue); err != nil {
 		return nil, false, errors.Wrap(err, "failed to check for required replacement fields")
 	}
+	n.plannedIdentity = planResponse.PlannedIdentity
 
 	return planResponse, n.filteredDiffExists(rawDiff), nil
 }
@@ -490,8 +493,9 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 	}
 
 	readRequest := &tfprotov6.ReadResourceRequest{
-		TypeName:     n.config.Name,
-		CurrentState: n.opTracker.GetFrameworkTFState(),
+		TypeName:        n.config.Name,
+		CurrentState:    n.opTracker.GetFrameworkTFState(),
+		CurrentIdentity: n.opTracker.GetFrameworkIdentity(),
 	}
 	readResponse, err := n.server.ReadResource(ctx, readRequest)
 	if err != nil {
@@ -522,12 +526,14 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot create nil dynamic value")
 		}
 		n.opTracker.SetFrameworkTFState(&nildynamicValue)
+		n.opTracker.SetFrameworkIdentity(nil)
 	} else {
 		tfStateValue, err = readResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 		if err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot unmarshal state value")
 		}
 		n.opTracker.SetFrameworkTFState(readResponse.NewState)
+		n.opTracker.SetFrameworkIdentity(readResponse.NewIdentity)
 	}
 
 	// Determine if the resource exists based on Terraform state
@@ -554,6 +560,7 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 					return managed.ExternalObservation{}, errors.Wrap(err, "cannot create nil dynamic value")
 				}
 				n.opTracker.SetFrameworkTFState(&nildynamicValue)
+				n.opTracker.SetFrameworkIdentity(nil)
 			}
 		}
 	}
@@ -667,10 +674,11 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:     n.config.Name,
-		PriorState:   n.opTracker.GetFrameworkTFState(),
-		PlannedState: n.planResponse.PlannedState,
-		Config:       &tfConfigDynamicVal,
+		TypeName:        n.config.Name,
+		PriorState:      n.opTracker.GetFrameworkTFState(),
+		PlannedState:    n.planResponse.PlannedState,
+		Config:          &tfConfigDynamicVal,
+		PlannedIdentity: n.plannedIdentity,
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -686,6 +694,7 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 		// In the following reconciles, this helps to track the external
 		// resource, rather than try to recreate that might cause leaking.
 		n.opTracker.SetFrameworkTFState(applyResponse.NewState)
+		n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
 		return managed.ExternalCreation{}, errors.Wrap(fatalDiags, "resource creation call returned error diags")
 	}
 
@@ -706,6 +715,7 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 	}
 
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
+	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
 
 	if _, err := n.setExternalName(mg, stateValueMap); err != nil {
 		return managed.ExternalCreation{}, errors.Wrapf(err, "failed to set the external-name of the managed resource during create")
@@ -769,10 +779,11 @@ func (n *terraformPluginFrameworkExternalClient) Update(ctx context.Context, mg 
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:     n.config.Name,
-		PriorState:   n.opTracker.GetFrameworkTFState(),
-		PlannedState: n.planResponse.PlannedState,
-		Config:       &tfConfigDynamicVal,
+		TypeName:        n.config.Name,
+		PriorState:      n.opTracker.GetFrameworkTFState(),
+		PlannedState:    n.planResponse.PlannedState,
+		Config:          &tfConfigDynamicVal,
+		PlannedIdentity: n.plannedIdentity,
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -784,6 +795,7 @@ func (n *terraformPluginFrameworkExternalClient) Update(ctx context.Context, mg 
 		return managed.ExternalUpdate{}, errors.Wrap(fatalDiags, "resource update call returned error diags")
 	}
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
+	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
 
 	newStateAfterApplyVal, err := applyResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 	if err != nil {
@@ -839,10 +851,11 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 	}
 
 	applyRequest := &tfprotov6.ApplyResourceChangeRequest{
-		TypeName:     n.config.Name,
-		PriorState:   n.opTracker.GetFrameworkTFState(),
-		PlannedState: &plannedState,
-		Config:       &tfConfigDynamicVal,
+		TypeName:        n.config.Name,
+		PriorState:      n.opTracker.GetFrameworkTFState(),
+		PlannedState:    &plannedState,
+		Config:          &tfConfigDynamicVal,
+		PlannedIdentity: n.plannedIdentity,
 	}
 	start := time.Now()
 	applyResponse, err := n.server.ApplyResourceChange(ctx, applyRequest)
@@ -854,6 +867,7 @@ func (n *terraformPluginFrameworkExternalClient) Delete(ctx context.Context, _ x
 		return managed.ExternalDelete{}, errors.Wrap(fatalDiags, "resource deletion call returned error diags")
 	}
 	n.opTracker.SetFrameworkTFState(applyResponse.NewState)
+	n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
 
 	newStateAfterApplyVal, err := applyResponse.NewState.Unmarshal(n.resourceValueTerraformType)
 	if err != nil {

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -558,7 +558,7 @@ func TestTPFObserveIdentityPropagation(t *testing.T) {
 
 		var capturedReadReq *tfprotov6.ReadResourceRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			params: map[string]any{
@@ -601,7 +601,7 @@ func TestTPFObserveIdentityPropagation(t *testing.T) {
 	t.Run("ObserveHandlesNilIdentity", func(t *testing.T) {
 		var capturedReadReq *tfprotov6.ReadResourceRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			params: map[string]any{
@@ -643,7 +643,7 @@ func TestTPFCreateIdentityPropagation(t *testing.T) {
 
 		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
 		tc := testConfiguration{
-			r:               newMockBaseTPFResource(),
+			r:               newMockTPFResourceWithIdentity(),
 			cfg:             newBaseUpjetConfig(),
 			obj:             obj,
 			currentStateMap: nil,
@@ -685,7 +685,7 @@ func TestTPFCreateIdentityPropagation(t *testing.T) {
 		newIdentity := newTestIdentityData("partial-id")
 
 		tc := testConfiguration{
-			r:               newMockBaseTPFResource(),
+			r:               newMockTPFResourceWithIdentity(),
 			cfg:             newBaseUpjetConfig(),
 			obj:             obj,
 			currentStateMap: nil,
@@ -726,7 +726,7 @@ func TestTPFUpdateIdentityPropagation(t *testing.T) {
 
 		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			currentStateMap: map[string]any{
@@ -770,12 +770,12 @@ func TestTPFUpdateIdentityPropagation(t *testing.T) {
 }
 
 func TestTPFDeleteIdentityPropagation(t *testing.T) {
-	t.Run("DeletePassesPlannedIdentityAndStoresNewIdentity", func(t *testing.T) {
+	t.Run("DeleteSendsNilPlannedIdentityAndStoresNewIdentity", func(t *testing.T) {
 		plannedIdentity := newTestIdentityData("planned-id")
 
 		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			currentStateMap: map[string]any{
@@ -787,12 +787,12 @@ func TestTPFDeleteIdentityPropagation(t *testing.T) {
 				"name": "example",
 			},
 			newStateMap:          nil,
-			planPlannedIdentity:  plannedIdentity,
 			applyNewIdentity:     nil,
 			capturedApplyRequest: &capturedApplyReq,
 		}
 		tpfExternal := prepareTPFExternalWithTestConfig(tc)
-		// Pre-set plannedIdentity as it would be after a Plan call
+		// Pre-set plannedIdentity to simulate state after a prior Observe/Plan
+		// call. Delete should NOT forward this stale update-plan identity.
 		tpfExternal.plannedIdentity = plannedIdentity
 
 		_, err := tpfExternal.Delete(context.TODO(), &tc.obj)
@@ -802,8 +802,10 @@ func TestTPFDeleteIdentityPropagation(t *testing.T) {
 		if capturedApplyReq == nil {
 			t.Fatal("ApplyResourceChange was not called")
 		}
-		if capturedApplyReq.PlannedIdentity != plannedIdentity {
-			t.Error("ApplyResourceChangeRequest.PlannedIdentity was not set to the planned identity")
+		// PlannedIdentity must be nil for delete: the planned state is null
+		// (resource is going away) so there is no meaningful planned identity.
+		if capturedApplyReq.PlannedIdentity != nil {
+			t.Error("ApplyResourceChangeRequest.PlannedIdentity should be nil for delete operations")
 		}
 		// After delete, identity from response (nil) should be stored
 		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
@@ -864,7 +866,7 @@ func TestHasMissingResourceIdentityDiagnostic(t *testing.T) {
 
 func TestTPFObserveMissingIdentityTreatedAsNotFound(t *testing.T) {
 	tc := testConfiguration{
-		r:   newMockBaseTPFResource(),
+		r:   newMockTPFResourceWithIdentity(),
 		cfg: newBaseUpjetConfig(),
 		obj: newBaseObject(),
 		params: map[string]any{
@@ -906,7 +908,7 @@ func TestTPFPlanIdentityPropagation(t *testing.T) {
 		var capturedReadReq *tfprotov6.ReadResourceRequest
 		var capturedPlanReq *tfprotov6.PlanResourceChangeRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			params: map[string]any{
@@ -953,7 +955,7 @@ func TestTPFPlanIdentityPropagation(t *testing.T) {
 
 		var capturedPlanReq *tfprotov6.PlanResourceChangeRequest
 		tc := testConfiguration{
-			r:   newMockBaseTPFResource(),
+			r:   newMockTPFResourceWithIdentity(),
 			cfg: newBaseUpjetConfig(),
 			obj: newBaseObject(),
 			params: map[string]any{
@@ -1242,4 +1244,31 @@ func (r *mockTPFResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	r.UpdateMethod(ctx, req, resp)
+}
+
+// mockTPFResourceWithIdentity extends mockTPFResource by also implementing
+// resource.ResourceWithIdentity, so supportsIdentity() returns true.
+type mockTPFResourceWithIdentity struct {
+	mockTPFResource
+}
+
+var _ resource.ResourceWithIdentity = &mockTPFResourceWithIdentity{}
+
+func (r *mockTPFResourceWithIdentity) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, _ *resource.IdentitySchemaResponse) {
+}
+
+func newMockTPFResourceWithIdentity() *mockTPFResourceWithIdentity {
+	return &mockTPFResourceWithIdentity{
+		mockTPFResource: mockTPFResource{
+			SchemaMethod: func(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+				response.Schema = newBaseSchema()
+			},
+			ReadMethod: func(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+				response.State = tfsdk.State{
+					Raw:    tftypes.Value{},
+					Schema: nil,
+				}
+			},
+		},
+	}
 }

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -813,6 +813,89 @@ func TestTPFDeleteIdentityPropagation(t *testing.T) {
 	})
 }
 
+func TestHasMissingResourceIdentityDiagnostic(t *testing.T) {
+	cases := map[string]struct {
+		diags []*tfprotov6.Diagnostic
+		want  bool
+	}{
+		"NilDiags": {
+			diags: nil,
+			want:  false,
+		},
+		"EmptyDiags": {
+			diags: []*tfprotov6.Diagnostic{},
+			want:  false,
+		},
+		"UnrelatedError": {
+			diags: []*tfprotov6.Diagnostic{
+				{Severity: tfprotov6.DiagnosticSeverityError, Summary: "Some other error"},
+			},
+			want: false,
+		},
+		"WarningNotError": {
+			diags: []*tfprotov6.Diagnostic{
+				{Severity: tfprotov6.DiagnosticSeverityWarning, Summary: diagSummaryMissingResourceIdentity},
+			},
+			want: false,
+		},
+		"MatchingDiagnostic": {
+			diags: []*tfprotov6.Diagnostic{
+				{Severity: tfprotov6.DiagnosticSeverityError, Summary: diagSummaryMissingResourceIdentity},
+			},
+			want: true,
+		},
+		"MatchingAmongMultiple": {
+			diags: []*tfprotov6.Diagnostic{
+				{Severity: tfprotov6.DiagnosticSeverityWarning, Summary: "some warning"},
+				{Severity: tfprotov6.DiagnosticSeverityError, Summary: diagSummaryMissingResourceIdentity},
+			},
+			want: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasMissingResourceIdentityDiagnostic(tc.diags)
+			if got != tc.want {
+				t.Errorf("hasMissingResourceIdentityDiagnostic() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTPFObserveMissingIdentityTreatedAsNotFound(t *testing.T) {
+	tc := testConfiguration{
+		r:   newMockBaseTPFResource(),
+		cfg: newBaseUpjetConfig(),
+		obj: newBaseObject(),
+		params: map[string]any{
+			"name": "example",
+		},
+		currentStateMap: map[string]any{
+			"id":   "example-id",
+			"name": "example",
+		},
+		plannedStateMap: map[string]any{
+			"name": "example",
+		},
+		readDiags: []*tfprotov6.Diagnostic{
+			{Severity: tfprotov6.DiagnosticSeverityError, Summary: diagSummaryMissingResourceIdentity},
+		},
+	}
+
+	tpfExternal := prepareTPFExternalWithTestConfig(tc)
+	obs, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+	if err != nil {
+		t.Fatalf("Observe returned unexpected error: %v", err)
+	}
+	if obs.ResourceExists {
+		t.Error("Expected ResourceExists to be false when Missing Resource Identity diagnostic is returned")
+	}
+	storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+	if storedIdentity != nil {
+		t.Error("Expected tracker identity to be nil after Missing Resource Identity diagnostic")
+	}
+}
+
 // TestTPFPlanIdentityPropagation tests identity propagation through
 // getDiffPlanResponse, which is unexported and invoked internally by Observe.
 func TestTPFPlanIdentityPropagation(t *testing.T) {

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -115,6 +115,16 @@ type testConfiguration struct {
 
 	planErr   error
 	planDiags []*tfprotov6.Diagnostic
+
+	// Identity fields for response mocking
+	readNewIdentity     *tfprotov6.ResourceIdentityData
+	planPlannedIdentity *tfprotov6.ResourceIdentityData
+	applyNewIdentity    *tfprotov6.ResourceIdentityData
+
+	// Capture fields for verifying identity in requests
+	capturedReadRequest  **tfprotov6.ReadResourceRequest
+	capturedPlanRequest  **tfprotov6.PlanResourceChangeRequest
+	capturedApplyRequest **tfprotov6.ApplyResourceChangeRequest
 }
 
 func prepareTPFExternalWithTestConfig(testConfig testConfiguration) *terraformPluginFrameworkExternalClient {
@@ -139,27 +149,39 @@ func prepareTPFExternalWithTestConfig(testConfig testConfiguration) *terraformPl
 		ts: terraform.Setup{
 			FrameworkProvider: &mockTPFProvider{},
 		},
-		config: cfg,
+		config: testConfig.cfg,
 		logger: logTest,
 		// metricRecorder:             nil,
 		opTracker: NewAsyncTracker(),
 		resource:  testConfig.r,
 		server: &mockTPFProviderServer{
 			ReadResourceFn: func(ctx context.Context, request *tfprotov6.ReadResourceRequest) (*tfprotov6.ReadResourceResponse, error) {
+				if testConfig.capturedReadRequest != nil {
+					*testConfig.capturedReadRequest = request
+				}
 				return &tfprotov6.ReadResourceResponse{
 					NewState:    currentStateVal,
+					NewIdentity: testConfig.readNewIdentity,
 					Diagnostics: testConfig.readDiags,
 				}, testConfig.readErr
 			},
 			PlanResourceChangeFn: func(ctx context.Context, request *tfprotov6.PlanResourceChangeRequest) (*tfprotov6.PlanResourceChangeResponse, error) {
+				if testConfig.capturedPlanRequest != nil {
+					*testConfig.capturedPlanRequest = request
+				}
 				return &tfprotov6.PlanResourceChangeResponse{
-					PlannedState: plannedStateVal,
-					Diagnostics:  testConfig.planDiags,
+					PlannedState:    plannedStateVal,
+					PlannedIdentity: testConfig.planPlannedIdentity,
+					Diagnostics:     testConfig.planDiags,
 				}, testConfig.planErr
 			},
 			ApplyResourceChangeFn: func(ctx context.Context, request *tfprotov6.ApplyResourceChangeRequest) (*tfprotov6.ApplyResourceChangeResponse, error) {
+				if testConfig.capturedApplyRequest != nil {
+					*testConfig.capturedApplyRequest = request
+				}
 				return &tfprotov6.ApplyResourceChangeResponse{
 					NewState:    newStateAfterApplyVal,
+					NewIdentity: testConfig.applyNewIdentity,
 					Diagnostics: testConfig.applyDiags,
 				}, testConfig.applyErr
 			},
@@ -508,6 +530,385 @@ func TestTPFDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestIdentityData creates a *tfprotov6.ResourceIdentityData for testing.
+func newTestIdentityData(id string) *tfprotov6.ResourceIdentityData {
+	identityType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id": tftypes.String,
+		},
+	}
+	identityVal := tftypes.NewValue(identityType, map[string]tftypes.Value{
+		"id": tftypes.NewValue(tftypes.String, id),
+	})
+	dv, err := tfprotov6.NewDynamicValue(identityType, identityVal)
+	if err != nil {
+		panic("cannot create test identity data: " + err.Error())
+	}
+	return &tfprotov6.ResourceIdentityData{
+		IdentityData: &dv,
+	}
+}
+
+func TestTPFObserveIdentityPropagation(t *testing.T) {
+	t.Run("ObservePassesCurrentIdentityAndStoresNewIdentity", func(t *testing.T) {
+		existingIdentity := newTestIdentityData("existing-id")
+		newIdentity := newTestIdentityData("refreshed-id")
+
+		var capturedReadReq *tfprotov6.ReadResourceRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			params: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			currentStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			plannedStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			readNewIdentity:     newIdentity,
+			capturedReadRequest: &capturedReadReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set identity on the tracker to verify it's passed in the request
+		tpfExternal.opTracker.SetFrameworkIdentity(existingIdentity)
+
+		_, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Observe returned unexpected error: %v", err)
+		}
+		// Verify CurrentIdentity was passed in the read request
+		if capturedReadReq == nil {
+			t.Fatal("ReadResource was not called")
+		}
+		if capturedReadReq.CurrentIdentity != existingIdentity {
+			t.Error("ReadResourceRequest.CurrentIdentity was not set to the tracker's identity")
+		}
+		// Verify NewIdentity from response was stored in the tracker
+		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+		if storedIdentity != newIdentity {
+			t.Error("NewIdentity from ReadResourceResponse was not stored in the tracker")
+		}
+	})
+
+	t.Run("ObserveHandlesNilIdentity", func(t *testing.T) {
+		var capturedReadReq *tfprotov6.ReadResourceRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			params: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			currentStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			plannedStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			readNewIdentity:     nil,
+			capturedReadRequest: &capturedReadReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+
+		_, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Observe returned unexpected error: %v", err)
+		}
+		// With no pre-set identity, request should have nil CurrentIdentity
+		if capturedReadReq.CurrentIdentity != nil {
+			t.Error("ReadResourceRequest.CurrentIdentity should be nil when tracker has no identity")
+		}
+		// With nil identity in response, tracker should store nil
+		if tpfExternal.opTracker.GetFrameworkIdentity() != nil {
+			t.Error("Tracker identity should be nil when response has no identity")
+		}
+	})
+}
+
+func TestTPFCreateIdentityPropagation(t *testing.T) {
+	t.Run("CreatePassesPlannedIdentityAndStoresNewIdentity", func(t *testing.T) {
+		plannedIdentity := newTestIdentityData("planned-id")
+		newIdentity := newTestIdentityData("created-id")
+
+		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
+		tc := testConfiguration{
+			r:               newMockBaseTPFResource(),
+			cfg:             newBaseUpjetConfig(),
+			obj:             obj,
+			currentStateMap: nil,
+			plannedStateMap: map[string]any{
+				"name": "example",
+			},
+			params: map[string]any{
+				"name": "example",
+			},
+			newStateMap: map[string]any{
+				"name": "example",
+				"id":   "example-id",
+			},
+			planPlannedIdentity:  plannedIdentity,
+			applyNewIdentity:     newIdentity,
+			capturedApplyRequest: &capturedApplyReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set plannedIdentity as it would be after a Plan call
+		tpfExternal.plannedIdentity = plannedIdentity
+
+		_, err := tpfExternal.Create(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Create returned unexpected error: %v", err)
+		}
+		if capturedApplyReq == nil {
+			t.Fatal("ApplyResourceChange was not called")
+		}
+		if capturedApplyReq.PlannedIdentity != plannedIdentity {
+			t.Error("ApplyResourceChangeRequest.PlannedIdentity was not set to the planned identity")
+		}
+		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+		if storedIdentity != newIdentity {
+			t.Error("NewIdentity from ApplyResourceChangeResponse was not stored in the tracker")
+		}
+	})
+
+	t.Run("CreateStoresIdentityEvenOnDiagError", func(t *testing.T) {
+		newIdentity := newTestIdentityData("partial-id")
+
+		tc := testConfiguration{
+			r:               newMockBaseTPFResource(),
+			cfg:             newBaseUpjetConfig(),
+			obj:             obj,
+			currentStateMap: nil,
+			plannedStateMap: map[string]any{
+				"name": "example",
+			},
+			params: map[string]any{
+				"name": "example",
+			},
+			newStateMap: nil,
+			applyDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "partial failure",
+					Detail:   "resource partially created",
+				},
+			},
+			applyNewIdentity: newIdentity,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+
+		_, err := tpfExternal.Create(context.TODO(), &tc.obj)
+		if err == nil {
+			t.Fatal("Create should have returned an error on diag error")
+		}
+		// Identity should still be stored even on error (like state is)
+		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+		if storedIdentity != newIdentity {
+			t.Error("NewIdentity should be stored in tracker even when apply returns error diags")
+		}
+	})
+}
+
+func TestTPFUpdateIdentityPropagation(t *testing.T) {
+	t.Run("UpdatePassesPlannedIdentityAndStoresNewIdentity", func(t *testing.T) {
+		plannedIdentity := newTestIdentityData("planned-id")
+		newIdentity := newTestIdentityData("updated-id")
+
+		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			currentStateMap: map[string]any{
+				"name": "example",
+				"id":   "example-id",
+			},
+			plannedStateMap: map[string]any{
+				"name": "example-updated",
+				"id":   "example-id",
+			},
+			params: map[string]any{
+				"name": "example-updated",
+			},
+			newStateMap: map[string]any{
+				"name": "example-updated",
+				"id":   "example-id",
+			},
+			planPlannedIdentity:  plannedIdentity,
+			applyNewIdentity:     newIdentity,
+			capturedApplyRequest: &capturedApplyReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set plannedIdentity as it would be after a Plan call
+		tpfExternal.plannedIdentity = plannedIdentity
+
+		_, err := tpfExternal.Update(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Update returned unexpected error: %v", err)
+		}
+		if capturedApplyReq == nil {
+			t.Fatal("ApplyResourceChange was not called")
+		}
+		if capturedApplyReq.PlannedIdentity != plannedIdentity {
+			t.Error("ApplyResourceChangeRequest.PlannedIdentity was not set to the planned identity")
+		}
+		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+		if storedIdentity != newIdentity {
+			t.Error("NewIdentity from ApplyResourceChangeResponse was not stored in the tracker")
+		}
+	})
+}
+
+func TestTPFDeleteIdentityPropagation(t *testing.T) {
+	t.Run("DeletePassesPlannedIdentityAndStoresNewIdentity", func(t *testing.T) {
+		plannedIdentity := newTestIdentityData("planned-id")
+
+		var capturedApplyReq *tfprotov6.ApplyResourceChangeRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			currentStateMap: map[string]any{
+				"name": "example",
+				"id":   "example-id",
+			},
+			plannedStateMap: nil,
+			params: map[string]any{
+				"name": "example",
+			},
+			newStateMap:          nil,
+			planPlannedIdentity:  plannedIdentity,
+			applyNewIdentity:     nil,
+			capturedApplyRequest: &capturedApplyReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set plannedIdentity as it would be after a Plan call
+		tpfExternal.plannedIdentity = plannedIdentity
+
+		_, err := tpfExternal.Delete(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Delete returned unexpected error: %v", err)
+		}
+		if capturedApplyReq == nil {
+			t.Fatal("ApplyResourceChange was not called")
+		}
+		if capturedApplyReq.PlannedIdentity != plannedIdentity {
+			t.Error("ApplyResourceChangeRequest.PlannedIdentity was not set to the planned identity")
+		}
+		// After delete, identity from response (nil) should be stored
+		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
+		if storedIdentity != nil {
+			t.Error("Tracker identity should be nil after delete with nil response identity")
+		}
+	})
+}
+
+// TestTPFPlanIdentityPropagation tests identity propagation through
+// getDiffPlanResponse, which is unexported and invoked internally by Observe.
+func TestTPFPlanIdentityPropagation(t *testing.T) {
+	t.Run("ObserveRehydratesIdentityBeforePlan", func(t *testing.T) {
+		refreshedIdentity := newTestIdentityData("refreshed-id")
+		plannedIdentity := newTestIdentityData("planned-id")
+
+		var capturedReadReq *tfprotov6.ReadResourceRequest
+		var capturedPlanReq *tfprotov6.PlanResourceChangeRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			params: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			currentStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			plannedStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			readNewIdentity:     refreshedIdentity,
+			planPlannedIdentity: plannedIdentity,
+			capturedReadRequest: &capturedReadReq,
+			capturedPlanRequest: &capturedPlanReq,
+		}
+
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Do NOT pre-set identity on the tracker — simulates a restart
+		_, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Observe returned unexpected error: %v", err)
+		}
+		if capturedReadReq == nil {
+			t.Fatal("ReadResource was not called")
+		}
+		if capturedReadReq.CurrentIdentity != nil {
+			t.Fatal("ReadResourceRequest.CurrentIdentity should be nil during rehydration")
+		}
+		if capturedPlanReq == nil {
+			t.Fatal("PlanResourceChange was not called")
+		}
+		if diff := cmp.Diff(refreshedIdentity, capturedPlanReq.PriorIdentity); diff != "" {
+			t.Fatalf("PlanResourceChangeRequest.PriorIdentity mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("PlanPassesPriorIdentityAndCapturesPlannedIdentity", func(t *testing.T) {
+		existingIdentity := newTestIdentityData("existing-id")
+		plannedIdentity := newTestIdentityData("planned-id")
+
+		var capturedPlanReq *tfprotov6.PlanResourceChangeRequest
+		tc := testConfiguration{
+			r:   newMockBaseTPFResource(),
+			cfg: newBaseUpjetConfig(),
+			obj: newBaseObject(),
+			params: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			currentStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			plannedStateMap: map[string]any{
+				"id":   "example-id",
+				"name": "example",
+			},
+			readNewIdentity:     existingIdentity,
+			planPlannedIdentity: plannedIdentity,
+			capturedPlanRequest: &capturedPlanReq,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set identity on the tracker to verify it's passed as PriorIdentity
+		tpfExternal.opTracker.SetFrameworkIdentity(existingIdentity)
+
+		// Observe triggers getDiffPlanResponse internally
+		_, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Observe returned unexpected error: %v", err)
+		}
+		if capturedPlanReq == nil {
+			t.Fatal("PlanResourceChange was not called")
+		}
+		if capturedPlanReq.PriorIdentity != existingIdentity {
+			t.Error("PlanResourceChangeRequest.PriorIdentity was not set to the tracker's identity")
+		}
+		// Verify planned identity was captured on the client
+		if tpfExternal.plannedIdentity != plannedIdentity {
+			t.Error("PlannedIdentity from PlanResourceChangeResponse was not stored on the client")
+		}
+	})
 }
 
 // Mocks

--- a/pkg/controller/nofork_store.go
+++ b/pkg/controller/nofork_store.go
@@ -55,6 +55,13 @@ type AsyncTracker struct {
 	tfState *tfsdk.InstanceState
 	// TF Plugin Framework instance state for TF Plugin Framework-based resources
 	fwState *tfprotov6.DynamicValue
+	// TF Plugin Framework resource identity for TF Plugin Framework-based resources.
+	// Unlike fwState, fwIdentity is not persisted or reconstructed across restarts.
+	// This is safe because CurrentIdentity is optional in ReadResourceRequest —
+	// after a restart, the first Observe sends nil CurrentIdentity, and the
+	// provider's identity interceptor populates NewIdentity from state/client
+	// data in the ReadResourceResponse, rehydrating the tracker.
+	fwIdentity *tfprotov6.ResourceIdentityData
 	// stateMark holds meta-information about the state
 	stateMark stateMark
 	// lifecycle of certain external resources are bound to a parent resource's
@@ -212,6 +219,24 @@ func (a *AsyncTracker) ResetReconstructedFrameworkTFState() {
 		a.fwState = nil
 		a.stateMark = defaultState
 	}
+}
+
+// GetFrameworkIdentity returns the stored Terraform Plugin Framework resource
+// identity in this AsyncTracker as *tfprotov6.ResourceIdentityData.
+// MUST be used only for Terraform Plugin Framework resources.
+func (a *AsyncTracker) GetFrameworkIdentity() *tfprotov6.ResourceIdentityData {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.fwIdentity
+}
+
+// SetFrameworkIdentity stores the given *tfprotov6.ResourceIdentityData
+// Terraform Plugin Framework resource identity into this AsyncTracker.
+// MUST be used only for Terraform Plugin Framework resources.
+func (a *AsyncTracker) SetFrameworkIdentity(id *tfprotov6.ResourceIdentityData) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.fwIdentity = id
 }
 
 // OperationTrackerStore stores the AsyncTracker instances associated with the

--- a/pkg/controller/nofork_store_test.go
+++ b/pkg/controller/nofork_store_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+)
+
+// newTestIdentityData is defined in external_tfpluginfw_test.go
+
+func TestAsyncTrackerFrameworkIdentity(t *testing.T) {
+	t.Run("GetFrameworkIdentityReturnsNilByDefault", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		if tracker.GetFrameworkIdentity() != nil {
+			t.Error("expected nil identity for new tracker")
+		}
+	})
+
+	t.Run("SetAndGetFrameworkIdentity", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		identity := newTestIdentityData("test-id")
+		tracker.SetFrameworkIdentity(identity)
+
+		got := tracker.GetFrameworkIdentity()
+		if got != identity {
+			t.Error("GetFrameworkIdentity did not return the identity that was set")
+		}
+	})
+
+	t.Run("SetFrameworkIdentityToNil", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		identity := newTestIdentityData("test-id")
+		tracker.SetFrameworkIdentity(identity)
+		tracker.SetFrameworkIdentity(nil)
+
+		if tracker.GetFrameworkIdentity() != nil {
+			t.Error("expected nil identity after setting to nil")
+		}
+	})
+
+	t.Run("SetFrameworkIdentityOverwrite", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		id1 := newTestIdentityData("id-1")
+		id2 := newTestIdentityData("id-2")
+
+		tracker.SetFrameworkIdentity(id1)
+		tracker.SetFrameworkIdentity(id2)
+
+		got := tracker.GetFrameworkIdentity()
+		if got != id2 {
+			t.Error("GetFrameworkIdentity should return the most recently set identity")
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

Pass resource identity data through all protov6 request/response cycles (ReadResource, PlanResourceChange, ApplyResourceChange) so that resources declaring an IdentitySchema in terraform-plugin-framework v1.17.0+ receive the required identity data and no longer fail with "Missing Resource Identity After Read".

Fixes crossplane-contrib/provider-upjet-aws#2003

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
