### PR TITLE
Skip synthetic TF state creation when external identifier is empty

### DIFF
--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -242,7 +242,10 @@ func (fp *FileProducer) EnsureTFState(_ context.Context, tfID string) error { //
 	// This is especially useful for resources whose deletion are scheduled for
 	// a long period of time, where if we fill the ID, the queries would actually
 	// succeed, i.e. GCP KMS KeyRing.
-	if !empty || meta.WasDeleted(fp.Resource) {
+	// Skip synthetic state creation when: state already exists, resource is
+	// being deleted, or there is no external identifier yet (new resource).
+	// Without an ID, Refresh would fail on providers that require it for Read.
+	if !empty || meta.WasDeleted(fp.Resource) || tfID == "" {
 		return nil
 	}
 	base := make(map[string]any)


### PR DESCRIPTION
When a managed resource uses IdentifierFromProvider and has no external-name yet (a new resource that needs to be created), EnsureTFState creates a synthetic Terraform state populated with all forProvider parameters but no    
  valid resource ID. This synthetic state causes Refresh (tofu apply -refresh-only) to attempt a Read against the cloud API using those parameters, which fails on Terraform Plugin Framework providers because the Read function   
  strictly requires the resource ID to construct the API call.
                                                                                                                                                                                                                                    
  The result is that Observe returns an error before it can determine that the resource does not exist, so the managed reconciler never reaches the Create path. The resource gets stuck in a permanent observe failed: cannot run  
  refresh loop.
                                                                                                                                                                                                                                    
  Root cause: EnsureTFState unconditionally creates a synthetic state when the state file is empty, regardless of whether the resource has an external identifier. For Terraform Plugin SDK providers this was silently tolerated   
  because their Read functions handle missing IDs gracefully (returning "not found"). Terraform Plugin Framework providers are stricter — they require the ID to build the API request and fail with errors like missing required 
  <resource>_id parameter.                                                                                                                                                                                                          
                                                                                                                                                                                                                                  
  Fix: Add tfID == "" to the early-return guard in EnsureTFState. When there is no external identifier, the state file is left empty. This allows Refresh to return Exists: false, which correctly triggers the Create flow in the  
  managed reconciler.
                                                                                                                                                                                                                                    
  Flow before fix (new resource, no external-name):                                                                                                                                                                                 
  1. EnsureTFState("") → creates synthetic state with parameters, no ID
  2. Refresh → TF provider attempts Read with no ID → fails                                                                                                                                                                         
  3. Observe returns error → Create never called                                                                                                                                                                                  
  4. Resource stuck in error loop                                                                                                                                                                                                   
                                                                                                                                                                                                                                    
  Flow after fix:
  1. EnsureTFState("") → tfID == "" → returns nil, state stays empty                                                                                                                                                                
  2. Refresh → empty state → Exists: false                                                                                                                                                                                          
  3. Observe returns ResourceExists: false → Create is called
  4. Resource created successfully                                                                                                                                                                                                  
                                                                                                                                                                                                                                    
  This affects all upjet-based providers that wrap Terraform Plugin Framework providers using IdentifierFromProvider external-name configuration. We encountered this with provider-upjet-cloudflare (wrapping Cloudflare TF        
  provider v5 which uses Plugin Framework), specifically when creating cloudflare_ruleset and cloudflare_dns_record resources from scratch.                                                                                         
                                                                                                                                                                                                                                  
  I have:                                                                                                                                                                                                                           
                                                                                                                                                                                                                                  
  - Read and followed Upjet's https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md.                                                                                                                                        
  - Run make reviewable to ensure this PR is ready for review.
  - Added backport release-x.y labels to auto-backport this PR if necessary.                                                                                                                                                        
                                                                                                                                                                                                                                  
  How has this code been tested                                                                                                                                                                                                     
   
  Tested end-to-end with https://github.com/wildbitca/provider-upjet-cloudflare (wrapping cloudflare/cloudflare TF provider v5.18.0, Plugin Framework-based) on a Crossplane v2.2.0 cluster:                                        
                                                                                                                                                                                                                                  
  - Before fix: cloudflare_ruleset resources without external-name failed with observe failed: cannot run refresh: refresh failed: missing required ruleset_id parameter. Resources never created.                                  
  - After fix: Same resources reach Create flow, are successfully created in Cloudflare, and reconcile to SYNCED=True, READY=True.                                                                                                
  - Existing resources with external-name: No regression — resources with crossplane.io/external-name set continue to be imported and observed correctly via the existing Refresh path (the tfID == "" guard is not triggered).     
  - Deletion: No regression — meta.WasDeleted guard remains unchanged.                                                                                                                                                              
                                                                                                                                                                                                                                    
  The fix was validated using a go.mod replace directive pointing to the fork branch, with 6 Crossplane claims managing 20 rulesets and 61 DNS records across 13 Cloudflare zones — all reaching SYNCED=True, READY=True.