### PR TITLE
fix(tfpluginsdk): fix ignore changes path for converted singleton lists

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -348,7 +348,7 @@ func filterInitExclusiveDiffs(config *config.Resource, tr resource.Terraformed, 
 			if strings.HasPrefix(key, matchPrefix) {
 				initProviderExclusiveParamKeysConverted = append(initProviderExclusiveParamKeysConverted, strings.Replace(key, matchPrefix, fmt.Sprintf("%s0.", matchPrefix), 1))
 				matched = true
-				continue
+				break
 			}
 		}
 		if !matched {

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -323,7 +323,7 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 	}, nil
 }
 
-func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.InstanceDiff) error { //nolint:gocyclo
+func filterInitExclusiveDiffs(config *config.Resource, tr resource.Terraformed, instanceDiff *tf.InstanceDiff) error { //nolint:gocyclo
 	if instanceDiff == nil || instanceDiff.Empty() {
 		return nil
 	}
@@ -338,6 +338,25 @@ func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.Instance
 	}
 
 	initProviderExclusiveParamKeys := getTerraformIgnoreChanges(paramsForProvider, paramsInitProvider)
+
+	/* process singleton list expansions */
+	initProviderExclusiveParamKeysConverted := []string{}
+	for _, key := range initProviderExclusiveParamKeys {
+		matched := false
+		for _, p := range config.TFListConversionPaths() {
+			matchPrefix := fmt.Sprintf("%s.", p)
+			if strings.HasPrefix(key, matchPrefix) {
+				initProviderExclusiveParamKeysConverted = append(initProviderExclusiveParamKeysConverted, strings.Replace(key, matchPrefix, fmt.Sprintf("%s0.", matchPrefix), 1))
+				matched = true
+				continue
+			}
+		}
+		if !matched {
+			initProviderExclusiveParamKeysConverted = append(initProviderExclusiveParamKeysConverted, key)
+		}
+	}
+	initProviderExclusiveParamKeys = initProviderExclusiveParamKeysConverted
+
 	for _, keyToIgnore := range initProviderExclusiveParamKeys {
 		for attributeKey := range instanceDiff.Attributes {
 			keyToIgnoreAsPrefix := fmt.Sprintf("%s.", keyToIgnore)
@@ -451,7 +470,7 @@ func (n *terraformPluginSDKExternal) getResourceDataDiff(tr resource.Terraformed
 	}
 
 	if resourceExists {
-		if err := filterInitExclusiveDiffs(tr, instanceDiff); err != nil {
+		if err := filterInitExclusiveDiffs(n.config, tr, instanceDiff); err != nil {
 			return nil, errors.Wrap(err, "failed to filter the diffs exclusive to spec.initProvider in the terraform.InstanceDiff")
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/2044
Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1907

This PR updates the process of `ignore_changes` paths computation which did not handle converted singleton lists properly. Resources represented as objects in CRDs and blocks/lists were added improperly to the `ignore_changes` list. Example (and apparently the most usual use case) for `eks.aws.m.upbound.io/v1beta1/NodeGroup`:
* `scaling_config.0.desired_size` is the **expected output and correct value**,
* `scaling_config.desired_size` is the **invalid output  produced by the plugin**.

Here we have added the missing `.0` path segment to circumvent this issue.
Fixing this should resolve the underlying issue for all resource types but primarily fixing issue preventing use of automated scaling (eg. `cluster-autoscaler`) for EKS clusters.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Steps to reproduce the issue are detailed in my original issue https://github.com/crossplane-contrib/provider-upjet-aws/issues/2044. Here's a guideline for testing:
1. Create `eks.aws.m.upbound.io/v1beta1/Cluster`,
2. Create `eks.aws.m.upbound.io/v1beta1/NodeGroup` with the following options:
```
apiVersion: eks.aws.m.upbound.io/v1beta1
kind: NodeGroup
metadata:
  [...]
spec:
  managementPolicies:
    - Create
    - Update
    - Delete
    - Observe
  initProvider:
    scalingConfig:
      desiredSize: 5
  forProvider:
    scalingConfig:
      maxSize: 10
      minSize: 3
  [...]
```
3. Using AWS console or CLI update the desired cluster size to different value,
4. Provider should not touch the provisioned node group resource - in the original codebase it would as invalid path was present in `ignore_changes` (`scaling_config.desired_size` vs `scaling_config.0.desired_size`).

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
