### PR TITLE
fix: set dotted map keys with correct nesting

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -221,9 +221,14 @@ func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, p
 			}
 		}
 	case schema.TypeString:
+		paramStr, ok := param.(string)
+		if !ok {
+			c.logger.Debug("expected parameter value to be string", "parameterType", fmt.Sprintf("%T", param))
+			return param
+		}
 		// For String types check if it is an HCL string and process
-		if isHCLSnippetPattern.MatchString(param.(string)) {
-			hclProccessedParam, err := processHCLParam(param.(string))
+		if isHCLSnippetPattern.MatchString(paramStr) {
+			hclProccessedParam, err := processHCLParam(paramStr)
 			if err != nil {
 				c.logger.Debug("could not process param, returning original", "param", sc.GoString())
 			} else {

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -239,8 +239,8 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 					return errors.Wrapf(err, errFmtCannotGetSecretValue, ref)
 				}
 				for key, value := range data {
-					if err = pavedTF.SetValue(fmt.Sprintf("%s.%s", tfPath, key), string(value)); err != nil {
-						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s.%s", tfPath, key))
+					if err = pavedTF.SetValue(fmt.Sprintf("%s[%s]", tfPath, key), string(value)); err != nil {
+						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s[%s]", tfPath, key))
 					}
 				}
 				continue

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -1449,6 +1449,132 @@ func TestGetSensitiveParameters(t *testing.T) {
 				},
 			},
 		},
+		// Test for the bug where secret keys containing dots were
+		// incorrectly split by dot notation when building the TF attribute
+		// path, producing a wrong nested structure instead of a dotted map key.
+		// e.g. SetValue("tls_config.tls.crt", v) → {"tls_config":{"tls":{"crt":v}}} (wrong)
+		//      SetValue("tls_config[tls.crt]", v) → {"tls_config":{"tls.crt":v}} (correct)
+		"SecretReferenceWithDottedKeys": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &fakeManaged{
+					Unstructured: &unstructured.Unstructured{
+						Object: map[string]any{
+							"spec": map[string]any{
+								"forProvider": map[string]any{
+									"tlsSecretRef": map[string]any{
+										"name":      "tls-secret",
+										"namespace": "crossplane-system",
+									},
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
+		"SecretReferenceWithDottedKeysInitProvider": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &fakeManaged{
+					Unstructured: &unstructured.Unstructured{
+						Object: map[string]any{
+							"spec": map[string]any{
+								"initProvider": map[string]any{
+									"tlsSecretRef": map[string]any{
+										"name":      "tls-secret",
+										"namespace": "crossplane-system",
+									},
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
+		"SecretReferenceWithDottedKeys_NamespacedMR": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "foo-ns",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &fakeManaged{
+					Unstructured: &unstructured.Unstructured{
+						Object: map[string]any{
+							"metadata": map[string]any{
+								"name":      "some-mr",
+								"namespace": "foo-ns",
+							},
+							"spec": map[string]any{
+								"forProvider": map[string]any{
+									"tlsSecretRef": map[string]any{
+										// no namespace — should be filled from MR namespace
+										"name": "tls-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
### Description of your changes

When a `SecretReference` is used to populate an MR attribute of `map[string]string` type, keys of secret data become the map keys. When the key have dots, `fieldpath` splits the key at every dot, producing a wronly-nested object, instead of a flat string to string map entry.

The fix switches to bracket notation (`foo_attribute[bar.with.dot]`), which preserves the full key string as a single path segment.

Addresses https://github.com/crossplane-contrib/provider-upjet-aws/issues/1946

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Consuming upjet from this PR in `provider-upjet-aws` with the reproducer at https://github.com/crossplane-contrib/provider-upjet-aws/issues/1946

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
