### PR TITLE
feat: API roundtrip testing library 

### DIFF
--- a/docs/api-roundtrip-testing.md
+++ b/docs/api-roundtrip-testing.md
@@ -1,0 +1,200 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# API roundtrip testing
+
+A testing utility library for verifying that Crossplane provider managed resources
+correctly survive two kinds of round trips:
+
+| Test | What it checks |
+|---|---|
+| **Serialization** | Every registered type can be JSON-encoded and decoded back to an identical object. |
+| **Conversion** | Every multi-version type survives spoke→hub→spoke and hub→spoke→hub conversion with no data loss. |
+
+The library builds on `k8s.io/apimachinery`'s fuzzing/round-trip infrastructure and
+`sigs.k8s.io/randfill` to generate random objects, then exercises the conversion
+functions registered by `pkg/controller/conversion.RegisterConversions`.
+
+---
+
+## How it works
+
+### Serialization round-trip
+
+`TestSerializationRoundtrip` delegates to the upstream
+`roundtrip.RoundTripExternalTypesWithoutProtobuf` helper. For every type in the
+scheme it:
+
+1. Creates a randomly filled instance using the fuzzer.
+2. Marshals it to JSON.
+3. Unmarshals back to a new instance.
+4. Asserts the two instances are equal.
+
+### Conversion round-trip
+
+`TestConversionRoundtrip` discovers every API group in the scheme, finds the hub
+version and all spoke versions for each `GroupKind`, then runs two sub-tests per
+(hub, spoke) pair:
+
+- **spoke → hub → spoke**: fill a spoke, convert to hub, convert back to a new spoke, compare.
+- **hub → spoke → hub**: fill a hub, convert to spoke, convert back to a new hub, compare.
+
+Each sub-test repeats the cycle `defaultFuzzIterations` (5) times with fresh random data.
+Sub-tests are run in parallel per group to keep the suite fast.
+
+---
+
+## Usage
+
+### Minimal setup
+
+```go
+// e2e/roundtrip/roundtrip_test.go
+package roundtrip
+
+import (
+    "testing"
+
+    "github.com/crossplane/upjet/v2/pkg/apitesting/roundtrip"
+    "k8s.io/apimachinery/pkg/runtime"
+
+    clusterapis    "github.com/upbound/provider-foo/apis/cluster"
+    namespacedapis "github.com/upbound/provider-foo/apis/namespaced"
+    "github.com/upbound/provider-foo/config"
+    "github.com/upbound/provider-foo/xpprovider"
+)
+
+func TestRoundTrip(t *testing.T) {
+    schema, err := xpprovider.GetProviderSchema(t.Context())
+    if err != nil {
+        t.Fatalf("GetProviderSchema: %s", err)
+    }
+
+    provider, err := config.GetProvider(t.Context(), schema, false)
+    if err != nil {
+        t.Fatalf("GetProvider: %s", err)
+    }
+
+    providerNamespaced, err := config.GetNamespacedProvider(t.Context(), schema, false)
+    if err != nil {
+        t.Fatalf("GetNamespacedProvider: %s", err)
+    }
+
+    testScheme := runtime.NewScheme()
+    if err := clusterapis.AddToScheme(testScheme); err != nil {
+        t.Fatalf("cluster-scoped apis AddToScheme: %s", err)
+    }
+    if err := namespacedapis.AddToScheme(testScheme); err != nil {
+        t.Fatalf("namespaced apis AddToScheme: %s", err)
+    }
+
+    rt, err := roundtrip.NewRoundTripTest(provider, providerNamespaced, testScheme)
+    if err != nil {
+        t.Fatalf("NewRoundTripTest: %s", err)
+    }
+
+    t.Run("TestSerializationRoundtrip", rt.TestSerializationRoundtrip)
+    t.Run("TestConversionRoundtrip",    rt.TestConversionRoundtrip)
+}
+```
+
+Pass `nil` for `providerNamespaced` if the provider only exposes cluster-scoped resources.
+
+---
+
+## Options
+
+All options are passed to `NewRoundTripTest` as variadic `TestOption` arguments.
+
+### Codec
+
+| Option | Description |
+|---|---|
+| `WithCodecFactory(c)` | Override the codec factory derived from the scheme. |
+
+### Filtering which kinds to test
+
+| Option | Description |
+|---|---|
+| `WithIncludeGroups(groups...)` | Only test these API groups. |
+| `WithIncludeGroupKinds(gks...)` | Only test these GroupKinds. |
+| `WithExcludeGroups(groups...)` | Skip these API groups. |
+| `WithExcludeGroupKinds(gks...)` | Skip these GroupKinds. |
+
+When no include filter is set, all groups registered in the scheme are tested
+(minus `defaultIgnoredKinds` and the empty/core group).
+
+### Fuzzer configuration
+
+`WithFuzzerConfig(opts ...FuzzerOption)` adds a fuzzer configuration.  Each
+registered configuration is run in sequence for every (kind, version-pair),
+accumulating coverage across different fuzz parameters.  When no
+`WithFuzzerConfig` call is made a single default configuration is used
+(NilChance≈0.2, NumElements 0–3, 10 iterations).
+
+Multiple calls each add a **distinct** configuration:
+
+```go
+rt, _ := roundtrip.NewRoundTripTest(provider, nil,
+    roundtrip.WithScheme(testScheme),
+    // First pass: no nil pointers, 20 iterations
+    roundtrip.WithFuzzerConfig(
+        roundtrip.FuzzerNilChance(0),
+        roundtrip.FuzzerIterations(20),
+    ),
+    // Second pass: sparse data, 5 iterations
+    roundtrip.WithFuzzerConfig(
+        roundtrip.FuzzerNilChance(0.8),
+        roundtrip.FuzzerNumElements(0, 1),
+        roundtrip.FuzzerIterations(5),
+    ),
+)
+```
+
+Available `FuzzerOption` constructors:
+
+| Constructor | Description |
+|---|---|
+| `FuzzerIterations(n)` | Number of fuzz-fill + round-trip cycles for this config. Default: 10. |
+| `FuzzerNilChance(p)` | Probability [0,1] that pointer fields are left nil. Default: ~0.2. |
+| `FuzzerNumElements(min, max)` | Min/max elements for maps and slices. Default: 0–3. |
+| `FuzzerMaxDepth(d)` | Maximum recursion depth for nested structs. |
+| `FuzzerRandSource(src)` | Deterministic random source (e.g. `rand.NewSource(42)`). |
+| `FuzzerSkipPatterns(patterns...)` | Skip fields whose names match any regexp. |
+| `FuzzerAllowUnexportedFields(bool)` | Whether to fill unexported struct fields. |
+
+`WithExtraFuzzFuncs(fns...)` adds `func(*T, randfill.Continue)` functions that
+are applied globally to **every** fuzzer configuration.
+
+### Comparison options
+
+| Option | Description |
+|---|---|
+| `WithComparisonOptions(opts...)` | Append `cmp.Option` values used when comparing objects after round trip. |
+
+---
+
+## Exported fuzzer helpers
+
+These can be passed to `WithExtraFuzzFuncs`:
+
+| Helper | Description |
+|---|---|
+| `ASCIIStringFuzzer` | Fills strings with random lowercase-alphanumeric characters (included by default). |
+
+
+Example:
+
+```go
+rt, err := roundtrip.NewRoundTripTest(provider, nil,
+    roundtrip.WithScheme(testScheme),
+    roundtrip.WithExtraFuzzFuncs(
+        roundtrip.NoNilElementsInPointerSlices(codecFactory)...),
+    roundtrip.WithComparisonOptions(roundtrip.EquateNilPtr()),
+)
+```
+
+---

--- a/docs/api-roundtrip-testing.md
+++ b/docs/api-roundtrip-testing.md
@@ -174,7 +174,7 @@ Available `FuzzerOption` constructors:
 > When max element is >=2 , singleton lists can be filled with multiple elements.
 > This expectedly fails the conversions, and the test.
 
-### Comparison options
+ø### Comparison options
 
 | Option                           | Description                                                              |
 |----------------------------------|--------------------------------------------------------------------------|
@@ -182,9 +182,10 @@ Available `FuzzerOption` constructors:
 
 Exported helper comparison options:
 
-| Helper                          | Description                                                                  |
-|---------------------------------|------------------------------------------------------------------------------|
-| `EquateEmptyAndSingleZeroSlice` | Considers empty slices and slices of length 1 with zero-value elements equal |
+| Helper                          | Description                                                                                            |
+|---------------------------------|--------------------------------------------------------------------------------------------------------|
+| `EquateEmptyAndSingleZeroSlice` | Considers empty slices and slices of length 1 with zero-value elements equal (recursively)             |
+| `EquateNilAndZeroValuePtr`      | Considers a nil struct pointer equal to a pointer to an effectively-zero struct (e.g. `nil == &Foo{}`) |
 
 
 You can also use ones at [cmpopts package](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts) and/or define your custom
@@ -215,7 +216,6 @@ a custom fuzzer for a particular type.
 Example:
 
 ```go
-
 type State string
 
 const (

--- a/docs/api-roundtrip-testing.md
+++ b/docs/api-roundtrip-testing.md
@@ -133,13 +133,12 @@ When no include filter is set, all groups registered in the scheme are tested
 registered configuration is run in sequence for every (kind, version-pair),
 accumulating coverage across different fuzz parameters.  When no
 `WithFuzzerConfig` call is made a single default configuration is used
-(NilChance≈0.2, NumElements 0–3, 10 iterations).
+(NilChance≈0.2, NumElements 0–1, 5 iterations).
 
 Multiple calls each add a **distinct** configuration:
 
 ```go
-rt, _ := roundtrip.NewRoundTripTest(provider, nil,
-    roundtrip.WithScheme(testScheme),
+rt, _ := roundtrip.NewRoundTripTest(provider, nil, testScheme,
     // First pass: no nil pointers, 20 iterations
     roundtrip.WithFuzzerConfig(
         roundtrip.FuzzerNilChance(0),
@@ -158,16 +157,21 @@ Available `FuzzerOption` constructors:
 
 | Constructor | Description |
 |---|---|
-| `FuzzerIterations(n)` | Number of fuzz-fill + round-trip cycles for this config. Default: 10. |
+| `FuzzerIterations(n)` | Number of fuzz-fill + round-trip cycles for this config. Default: 5. |
 | `FuzzerNilChance(p)` | Probability [0,1] that pointer fields are left nil. Default: ~0.2. |
-| `FuzzerNumElements(min, max)` | Min/max elements for maps and slices. Default: 0–3. |
+| `FuzzerNumElements(min, max)` | Min/max elements for maps and slices. Default: 0–1. |
 | `FuzzerMaxDepth(d)` | Maximum recursion depth for nested structs. |
 | `FuzzerRandSource(src)` | Deterministic random source (e.g. `rand.NewSource(42)`). |
 | `FuzzerSkipPatterns(patterns...)` | Skip fields whose names match any regexp. |
 | `FuzzerAllowUnexportedFields(bool)` | Whether to fill unexported struct fields. |
 
-`WithExtraFuzzFuncs(fns...)` adds `func(*T, randfill.Continue)` functions that
-are applied globally to **every** fuzzer configuration.
+> [!WARNING]
+> Providers that utilize singleton list/embedded object conversions
+> should not set `FuzzerNumElements` option.
+> By default, fuzzer cannot determine whether a given slice field corresponds 
+> to a singleton list or a regular list. 
+> When max element is >=2 , singleton lists can be filled with multiple elements.
+> This expectedly fails the conversions, and the test.
 
 ### Comparison options
 
@@ -175,25 +179,71 @@ are applied globally to **every** fuzzer configuration.
 |---|---|
 | `WithComparisonOptions(opts...)` | Append `cmp.Option` values used when comparing objects after round trip. |
 
+Exported helper comparison options:
+
+| Helper | Description |
+|---|---|
+| `EquateEmptyAndSingleZeroSlice` | Considers empty slices and slices of length 1 with zero-value elements equal |
 ---
 
-## Exported fuzzer helpers
+You can also use ones at [cmpopts package](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts) and/or define your custom
+own [cmp.Option](https://pkg.go.dev/github.com/google/go-cmp/cmp#Option)
 
-These can be passed to `WithExtraFuzzFuncs`:
+## Optional Custom Fuzzer functions
+
+`WithExtraFuzzFuncs(fns...)` adds `func(*T, randfill.Continue)` functions that
+are applied globally to **every** fuzzer configuration.
+
+
+| Option | Description |
+|---|---|
+| `WithExtraFuzzFuncs(fns...)` | adds `func(*T, randfill.Continue)` functions that are applied globally to **every** fuzzer configuration |
+
+
+Exported built-in fuzzers
 
 | Helper | Description |
 |---|---|
 | `ASCIIStringFuzzer` | Fills strings with random lowercase-alphanumeric characters (included by default). |
 
 
+When you need more control on the fuzzed values, you can define
+a custom fuzzer for a particular type.
+
 Example:
 
 ```go
-rt, err := roundtrip.NewRoundTripTest(provider, nil,
-    roundtrip.WithScheme(testScheme),
+
+type State string
+
+const (
+	StatePending   State = "PENDING"
+	StateRunning   State = "RUNNING"
+	StateCompleted State = "COMPLETED"
+)
+
+var validStates = []State{ StatePending, StateRunning, StateCompleted }
+
+type MyWorkload struct {
+	Name string
+	State State // enum-like field with restricted set of valid values
+	PendingJobCount int 
+}
+
+// define a custom fuzzer for MyWorkload type
+func myCustomWorkloadFuzzer(f *MyWorkload, c randfill.Continue) {
+	c.FillNoCustom() // run default fillers first
+	randIndex := c.Rand.Intn(len(validStates)) 
+	f.State = validStates[randIndex] // set a random valid state value
+	if f.State ==  StateCompleted {
+		f.PendingJobCount = 0 // should be zero for completed workloads 
+	}
+}
+
+rt, err := roundtrip.NewRoundTripTest(provider, nil, testScheme,
     roundtrip.WithExtraFuzzFuncs(
-        roundtrip.NoNilElementsInPointerSlices(codecFactory)...),
-    roundtrip.WithComparisonOptions(roundtrip.EquateNilPtr()),
+        myCustomWorkloadFuzzer),
+    roundtrip.WithComparisonOptions(roundtrip.EquateEmptyAndSingleZeroSlice()),
 )
 ```
 

--- a/docs/api-roundtrip-testing.md
+++ b/docs/api-roundtrip-testing.md
@@ -6,13 +6,13 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # API roundtrip testing
 
-A testing utility library for verifying that Crossplane provider managed resources
+A testing utility library for verifying that managed resources of a Crossplane provider
 correctly survive two kinds of round trips:
 
-| Test | What it checks |
-|---|---|
-| **Serialization** | Every registered type can be JSON-encoded and decoded back to an identical object. |
-| **Conversion** | Every multi-version type survives spoke→hub→spoke and hub→spoke→hub conversion with no data loss. |
+| Test              | What it checks                                                                                    |
+|-------------------|---------------------------------------------------------------------------------------------------|
+| **Serialization** | Every registered type can be JSON-encoded and decoded back to an identical object.                |
+| **Conversion**    | Every multi-version type survives spoke→hub→spoke and hub→spoke→hub conversion with no data loss. |
 
 The library builds on `k8s.io/apimachinery`'s fuzzing/round-trip infrastructure and
 `sigs.k8s.io/randfill` to generate random objects, then exercises the conversion
@@ -111,18 +111,18 @@ All options are passed to `NewRoundTripTest` as variadic `TestOption` arguments.
 
 ### Codec
 
-| Option | Description |
-|---|---|
+| Option                | Description                                         |
+|-----------------------|-----------------------------------------------------|
 | `WithCodecFactory(c)` | Override the codec factory derived from the scheme. |
 
 ### Filtering which kinds to test
 
-| Option | Description |
-|---|---|
-| `WithIncludeGroups(groups...)` | Only test these API groups. |
+| Option                          | Description                 |
+|---------------------------------|-----------------------------|
+| `WithIncludeGroups(groups...)`  | Only test these API groups. |
 | `WithIncludeGroupKinds(gks...)` | Only test these GroupKinds. |
-| `WithExcludeGroups(groups...)` | Skip these API groups. |
-| `WithExcludeGroupKinds(gks...)` | Skip these GroupKinds. |
+| `WithExcludeGroups(groups...)`  | Skip these API groups.      |
+| `WithExcludeGroupKinds(gks...)` | Skip these GroupKinds.      |
 
 When no include filter is set, all groups registered in the scheme are tested
 (minus `defaultIgnoredKinds` and the empty/core group).
@@ -155,15 +155,16 @@ rt, _ := roundtrip.NewRoundTripTest(provider, nil, testScheme,
 
 Available `FuzzerOption` constructors:
 
-| Constructor | Description |
-|---|---|
-| `FuzzerIterations(n)` | Number of fuzz-fill + round-trip cycles for this config. Default: 5. |
-| `FuzzerNilChance(p)` | Probability [0,1] that pointer fields are left nil. Default: ~0.2. |
-| `FuzzerNumElements(min, max)` | Min/max elements for maps and slices. Default: 0–1. |
-| `FuzzerMaxDepth(d)` | Maximum recursion depth for nested structs. |
-| `FuzzerRandSource(src)` | Deterministic random source (e.g. `rand.NewSource(42)`). |
-| `FuzzerSkipPatterns(patterns...)` | Skip fields whose names match any regexp. |
-| `FuzzerAllowUnexportedFields(bool)` | Whether to fill unexported struct fields. |
+| Constructor                         | Description                                                          |
+|-------------------------------------|----------------------------------------------------------------------|
+| `FuzzerIterations(n)`               | Number of fuzz-fill + round-trip cycles for this config. Default: 5. |
+| `FuzzerNilChance(p)`                | Probability [0,1] that pointer fields are left nil. Default: ~0.2.   |
+| `FuzzerNumElements(min, max)`       | Min/max elements for maps and slices. Default: 0–1.                  |
+| `FuzzerMaxDepth(d)`                 | Maximum recursion depth for nested structs.                          |
+| `FuzzerRandSource(src)`             | Deterministic random source (e.g. `rand.NewSource(42)`).             |
+| `FuzzerSkipPatterns(patterns...)`   | Skip fields whose names match any regexp.                            |
+| `FuzzerAllowUnexportedFields(bool)` | Whether to fill unexported struct fields.                            |
+
 
 > [!WARNING]
 > Providers that utilize singleton list/embedded object conversions
@@ -175,35 +176,36 @@ Available `FuzzerOption` constructors:
 
 ### Comparison options
 
-| Option | Description |
-|---|---|
+| Option                           | Description                                                              |
+|----------------------------------|--------------------------------------------------------------------------|
 | `WithComparisonOptions(opts...)` | Append `cmp.Option` values used when comparing objects after round trip. |
 
 Exported helper comparison options:
 
-| Helper | Description |
-|---|---|
+| Helper                          | Description                                                                  |
+|---------------------------------|------------------------------------------------------------------------------|
 | `EquateEmptyAndSingleZeroSlice` | Considers empty slices and slices of length 1 with zero-value elements equal |
----
+
 
 You can also use ones at [cmpopts package](https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts) and/or define your custom
 own [cmp.Option](https://pkg.go.dev/github.com/google/go-cmp/cmp#Option)
 
 ## Optional Custom Fuzzer functions
 
-`WithExtraFuzzFuncs(fns...)` adds `func(*T, randfill.Continue)` functions that
-are applied globally to **every** fuzzer configuration.
+By default, k8s runtime objects are fuzzed using the generic fuzzer at
+[k8s.io/apimachinery](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/fuzzer) module  
+Fuzzing behavior can be further controlled via extra fuzzer functions.
 
 
-| Option | Description |
-|---|---|
+| Option                       | Description                                                                                              |
+|------------------------------|----------------------------------------------------------------------------------------------------------|
 | `WithExtraFuzzFuncs(fns...)` | adds `func(*T, randfill.Continue)` functions that are applied globally to **every** fuzzer configuration |
 
 
 Exported built-in fuzzers
 
-| Helper | Description |
-|---|---|
+| Helper              | Description                                                                        |
+|---------------------|------------------------------------------------------------------------------------|
 | `ASCIIStringFuzzer` | Fills strings with random lowercase-alphanumeric characters (included by default). |
 
 
@@ -232,7 +234,7 @@ type MyWorkload struct {
 
 // define a custom fuzzer for MyWorkload type
 func myCustomWorkloadFuzzer(f *MyWorkload, c randfill.Continue) {
-	c.FillNoCustom() // run default fillers first
+	c.FillNoCustom(f) // run default fillers first
 	randIndex := c.Rand.Intn(len(validStates)) 
 	f.State = validStates[randIndex] // set a random valid state value
 	if f.State ==  StateCompleted {
@@ -246,5 +248,3 @@ rt, err := roundtrip.NewRoundTripTest(provider, nil, testScheme,
     roundtrip.WithComparisonOptions(roundtrip.EquateEmptyAndSingleZeroSlice()),
 )
 ```
-
----

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	k8s.io/client-go v0.35.3
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -143,6 +144,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	sigs.k8s.io/controller-tools v0.20.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/pkg/apitesting/roundtrip/cmp.go
+++ b/pkg/apitesting/roundtrip/cmp.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+package roundtrip
+
+import (
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// normalizeMeta strips volatile metadata fields from obj so that round-trip
+// comparisons focus on the API fields that are part of the provider contract.
+// Fields like ResourceVersion, UID, Generation, and ManagedFields are set by
+// the API server and vary across encode/decode cycles.
+func normalizeMeta(obj metav1.Object) {
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetUID("")
+	obj.SetManagedFields(nil)
+	obj.SetCreationTimestamp(metav1.Time{})
+}
+
+// EquateEmptyAndSingleZeroSlice returns a cmp.Option that treats an empty (or
+// nil) slice as equal to a slice containing exactly one zero-value element:
+//
+//   - pointer slices:  []*T{}  ≡  []*T{nil}
+//   - value slices:    []T{}   ≡  []T{zero}  (zero is the zero value of T)
+//
+// This handles conversions that produce []T{zero} where the source had []T{}.
+//
+// Conflict avoidance: cmpopts.EquateEmpty (already in the default options)
+// registers its own Comparer for the case where both sides have Len==0.
+// This option requires at least one side to have Len==1, so the two
+// Comparers are mutually exclusive and go-cmp never sees an ambiguous pair.
+//
+// Multi-element slices and slices whose single element is non-zero fall
+// through to go-cmp's normal element-by-element comparison.
+//
+// Use with WithComparisonOptions:
+//
+//	rt, _ := roundtrip.NewRoundTripTest(provider, nil,
+//	    roundtrip.WithComparisonOptions(roundtrip.EquateEmptyAndSingleZeroSlice()))
+func EquateEmptyAndSingleZeroSlice() cmp.Option { //nolint:gocyclo // easier to follow as a unit
+	// isEffectivelyZero recursively checks whether v is "effectively zero"
+	// under the same equate-empty-or-single-zero semantics:
+	//   - slice/array: nil, len==0, or len==1 with an effectively-zero element
+	//   - struct: every exported and unexported field is effectively zero
+	//   - ptr/interface: nil or the pointed-to value is effectively zero
+	//   - map: nil or len==0
+	//   - everything else: reflect.Value.IsZero()
+	var isEffectivelyZero func(v reflect.Value) bool
+	isEffectivelyZero = func(v reflect.Value) bool {
+		switch v.Kind() { //nolint:exhaustive // default covers remaining kinds
+		case reflect.Slice, reflect.Array:
+			return v.Len() == 0 || (v.Len() == 1 && isEffectivelyZero(v.Index(0)))
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				if !isEffectivelyZero(v.Field(i)) {
+					return false
+				}
+			}
+			return true
+		case reflect.Ptr, reflect.Interface:
+			return v.IsNil() || isEffectivelyZero(v.Elem())
+		case reflect.Map:
+			return v.IsNil() || v.Len() == 0
+		default:
+			return v.IsZero()
+		}
+	}
+
+	// isSingleZero reports whether v is a slice with exactly one element that
+	// is effectively zero (nil for pointers, "" for strings, recursively zero
+	// for structs containing nested slices, etc.).
+	isSingleZero := func(v reflect.Value) bool {
+		return v.Len() == 1 && isEffectivelyZero(v.Index(0))
+	}
+	isEmptyOrSingleZero := func(v reflect.Value) bool {
+		return v.Len() == 0 || isSingleZero(v)
+	}
+	return cmp.FilterValues(
+		func(x, y interface{}) bool {
+			vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+			if !vx.IsValid() || !vy.IsValid() {
+				return false
+			}
+			if vx.Kind() != reflect.Slice || vy.Kind() != reflect.Slice {
+				return false
+			}
+			// Both sides must be empty-or-single-zero AND at least one must be
+			// exactly the single-zero case (Len==1, zero element).
+			//
+			// Using || instead would intercept e.g. []T{non_zero} vs []T{zero},
+			// preventing go-cmp from recursing into the elements where
+			// cmpopts.EquateEmpty could equate sub-fields.  Requiring both
+			// sides to qualify ensures we only short-circuit truly equivalent
+			// pairs and let everything else fall through to element comparison.
+			//
+			// cmpopts.EquateEmpty covers both-Len==0; requiring Len==1 on at
+			// least one side keeps the two Comparers mutually exclusive.
+			return (isSingleZero(vx) || isSingleZero(vy)) &&
+				isEmptyOrSingleZero(vx) && isEmptyOrSingleZero(vy)
+		},
+		cmp.Comparer(func(x, y interface{}) bool {
+			vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+			return isEmptyOrSingleZero(vx) && isEmptyOrSingleZero(vy)
+		}),
+	)
+}

--- a/pkg/apitesting/roundtrip/cmp.go
+++ b/pkg/apitesting/roundtrip/cmp.go
@@ -22,6 +22,33 @@ func normalizeMeta(obj metav1.Object) {
 	obj.SetCreationTimestamp(metav1.Time{})
 }
 
+// isEffectivelyZero recursively reports whether v is "effectively zero" under
+// the equate-empty-or-single-zero semantics used by this package:
+//   - slice/array: nil, len==0, or len==1 with an effectively-zero element
+//   - struct: every field is effectively zero
+//   - ptr/interface: nil or the pointed-to value is effectively zero
+//   - map: nil or len==0
+//   - everything else: reflect.Value.IsZero()
+func isEffectivelyZero(v reflect.Value) bool { //nolint:gocyclo // easier to follow as a unit
+	switch v.Kind() { //nolint:exhaustive // default covers remaining kinds
+	case reflect.Slice, reflect.Array:
+		return v.Len() == 0 || (v.Len() == 1 && isEffectivelyZero(v.Index(0)))
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !isEffectivelyZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Pointer, reflect.Interface:
+		return v.IsNil() || isEffectivelyZero(v.Elem())
+	case reflect.Map:
+		return v.IsNil() || v.Len() == 0
+	default:
+		return v.IsZero()
+	}
+}
+
 // EquateEmptyAndSingleZeroSlice returns a cmp.Option that treats an empty (or
 // nil) slice as equal to a slice containing exactly one zero-value element:
 //
@@ -43,34 +70,6 @@ func normalizeMeta(obj metav1.Object) {
 //	rt, _ := roundtrip.NewRoundTripTest(provider, nil,
 //	    roundtrip.WithComparisonOptions(roundtrip.EquateEmptyAndSingleZeroSlice()))
 func EquateEmptyAndSingleZeroSlice() cmp.Option { //nolint:gocyclo // easier to follow as a unit
-	// isEffectivelyZero recursively checks whether v is "effectively zero"
-	// under the same equate-empty-or-single-zero semantics:
-	//   - slice/array: nil, len==0, or len==1 with an effectively-zero element
-	//   - struct: every exported and unexported field is effectively zero
-	//   - ptr/interface: nil or the pointed-to value is effectively zero
-	//   - map: nil or len==0
-	//   - everything else: reflect.Value.IsZero()
-	var isEffectivelyZero func(v reflect.Value) bool
-	isEffectivelyZero = func(v reflect.Value) bool {
-		switch v.Kind() { //nolint:exhaustive // default covers remaining kinds
-		case reflect.Slice, reflect.Array:
-			return v.Len() == 0 || (v.Len() == 1 && isEffectivelyZero(v.Index(0)))
-		case reflect.Struct:
-			for i := 0; i < v.NumField(); i++ {
-				if !isEffectivelyZero(v.Field(i)) {
-					return false
-				}
-			}
-			return true
-		case reflect.Ptr, reflect.Interface:
-			return v.IsNil() || isEffectivelyZero(v.Elem())
-		case reflect.Map:
-			return v.IsNil() || v.Len() == 0
-		default:
-			return v.IsZero()
-		}
-	}
-
 	// isSingleZero reports whether v is a slice with exactly one element that
 	// is effectively zero (nil for pointers, "" for strings, recursively zero
 	// for structs containing nested slices, etc.).
@@ -81,7 +80,7 @@ func EquateEmptyAndSingleZeroSlice() cmp.Option { //nolint:gocyclo // easier to 
 		return v.Len() == 0 || isSingleZero(v)
 	}
 	return cmp.FilterValues(
-		func(x, y interface{}) bool {
+		func(x, y any) bool {
 			vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
 			if !vx.IsValid() || !vy.IsValid() {
 				return false
@@ -103,9 +102,56 @@ func EquateEmptyAndSingleZeroSlice() cmp.Option { //nolint:gocyclo // easier to 
 			return (isSingleZero(vx) || isSingleZero(vy)) &&
 				isEmptyOrSingleZero(vx) && isEmptyOrSingleZero(vy)
 		},
-		cmp.Comparer(func(x, y interface{}) bool {
+		cmp.Comparer(func(x, y any) bool {
 			vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
 			return isEmptyOrSingleZero(vx) && isEmptyOrSingleZero(vy)
+		}),
+	)
+}
+
+// EquateNilAndZeroValuePtr returns a cmp.Option that treats a nil pointer as
+// equal to a pointer to an effectively-zero struct value:
+//
+//	(*Foo)(nil)  ≡  &Foo{}
+//	(*Foo)(nil)  ≡  &Foo{Nested: []Bar{{}}}   // nested slices also effectively zero
+//
+// Only struct pointer types are intercepted; pointers to scalars, maps, or
+// other non-struct types fall through to go-cmp's default comparison.
+//
+// Use with WithComparisonOptions:
+//
+//	rt, _ := roundtrip.NewRoundTripTest(provider, nil,
+//	    roundtrip.WithComparisonOptions(roundtrip.EquateNilAndZeroValuePtr()))
+func EquateNilAndZeroValuePtr() cmp.Option {
+	// nonNilPointsToEffectivelyZeroStruct returns the non-nil value when
+	// exactly one of the two is nil and the non-nil one points to an
+	// effectively-zero struct, otherwise returns the zero reflect.Value.
+	shouldEquate := func(vx, vy reflect.Value) bool {
+		if vx.Kind() != reflect.Pointer || vy.Kind() != reflect.Pointer {
+			return false
+		}
+		xNil, yNil := vx.IsNil(), vy.IsNil()
+		if xNil == yNil {
+			// both nil or both non-nil: don't intercept
+			return false
+		}
+		nonNil := vy
+		if yNil {
+			nonNil = vx
+		}
+		elem := nonNil.Elem()
+		return elem.Kind() == reflect.Struct && isEffectivelyZero(elem)
+	}
+	return cmp.FilterValues(
+		func(x, y any) bool {
+			vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+			if !vx.IsValid() || !vy.IsValid() {
+				return false
+			}
+			return shouldEquate(vx, vy)
+		},
+		cmp.Comparer(func(_, _ any) bool {
+			return true // filter already guarantees equivalence
 		}),
 	)
 }

--- a/pkg/apitesting/roundtrip/cmp_test.go
+++ b/pkg/apitesting/roundtrip/cmp_test.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+package roundtrip
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestNormalizeMeta(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	obj := &metav1.ObjectMeta{
+		Name:              "keep-me",
+		ResourceVersion:   "12345",
+		Generation:        42,
+		UID:               types.UID("some-uid"),
+		ManagedFields:     []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+		CreationTimestamp: ts,
+		Labels:            map[string]string{"key": "val"},
+		Annotations:       map[string]string{"note": "1"},
+	}
+
+	normalizeMeta(obj)
+
+	if obj.ResourceVersion != "" {
+		t.Errorf("ResourceVersion not cleared: %q", obj.ResourceVersion)
+	}
+	if obj.Generation != 0 {
+		t.Errorf("Generation not cleared: %d", obj.Generation)
+	}
+	if obj.UID != "" {
+		t.Errorf("UID not cleared: %q", obj.UID)
+	}
+	if obj.ManagedFields != nil {
+		t.Errorf("ManagedFields not cleared")
+	}
+	if !obj.CreationTimestamp.IsZero() {
+		t.Errorf("CreationTimestamp not cleared")
+	}
+	// untouched fields survive
+	if obj.Name != "keep-me" {
+		t.Errorf("Name modified: %q", obj.Name)
+	}
+	if obj.Labels["key"] != "val" {
+		t.Errorf("Labels modified")
+	}
+	if obj.Annotations["note"] != "1" {
+		t.Errorf("Annotations modified")
+	}
+}
+
+// withSlice is a helper struct used to test EquateEmptyAndSingleZeroSlice with
+// nested slices inside structs.
+type withSlice struct {
+	Items []string
+}
+
+func TestEquateEmptyAndSingleZeroSlice(t *testing.T) {
+	opt := EquateEmptyAndSingleZeroSlice()
+	// Include EquateEmpty to cover the both-Len==0 case that our option deliberately
+	// leaves to the upstream comparer.
+	allOpts := cmp.Options{opt, cmpopts.EquateEmpty()}
+
+	zeroStr := ""
+
+	cases := []struct {
+		name  string
+		equal bool
+		diff  func() string
+	}{
+		{
+			name:  "empty int slice equals single-zero int slice",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]int{}, []int{0}, allOpts) },
+		},
+		{
+			name:  "nil int slice equals single-zero int slice",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]int(nil), []int{0}, allOpts) },
+		},
+		{
+			name:  "single-zero equals single-zero",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]int{0}, []int{0}, allOpts) },
+		},
+		{
+			name:  "both empty int slices equal via EquateEmpty",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]int{}, []int{}, allOpts) },
+		},
+		{
+			name:  "nonzero element not equated with empty",
+			equal: false,
+			diff:  func() string { return cmp.Diff([]int{1}, []int{}, allOpts) },
+		},
+		{
+			name:  "multi-element slice not equated with empty",
+			equal: false,
+			diff:  func() string { return cmp.Diff([]int{0, 0}, []int{}, allOpts) },
+		},
+		{
+			name:  "nil pointer slice equals single-nil-pointer slice",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]*string{}, []*string{nil}, allOpts) },
+		},
+		{
+			name:  "single nil pointer equals pointer to zero string",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]*string{nil}, []*string{&zeroStr}, allOpts) },
+		},
+		{
+			name:  "nested nil slice equals slice containing nil slice",
+			equal: true,
+			diff:  func() string { return cmp.Diff([][]int{}, [][]int{nil}, allOpts) },
+		},
+		{
+			name:  "nested empty slice equals slice containing empty slice",
+			equal: true,
+			diff:  func() string { return cmp.Diff([][]int{}, [][]int{{}}, allOpts) },
+		},
+		{
+			name:  "struct slice: empty equals slice with zero-value struct",
+			equal: true,
+			diff:  func() string { return cmp.Diff([]withSlice{}, []withSlice{{}}, allOpts) },
+		},
+		{
+			name:  "struct slice: empty equals slice with struct containing nil Items",
+			equal: true,
+			diff: func() string {
+				return cmp.Diff([]withSlice{}, []withSlice{{Items: nil}}, allOpts)
+			},
+		},
+		{
+			name:  "struct slice: empty not equal to slice with non-zero struct",
+			equal: false,
+			diff: func() string {
+				return cmp.Diff([]withSlice{}, []withSlice{{Items: []string{"nonempty"}}}, allOpts)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := tc.diff()
+			if tc.equal && diff != "" {
+				t.Errorf("expected equal, got diff:\n%s", diff)
+			}
+			if !tc.equal && diff == "" {
+				t.Errorf("expected diff, but objects compared as equal")
+			}
+		})
+	}
+}

--- a/pkg/apitesting/roundtrip/fuzzer.go
+++ b/pkg/apitesting/roundtrip/fuzzer.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+package roundtrip
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/randfill"
+)
+
+// dnsLetters is the character set used by ASCIIStringFuzzer.  Restricting to
+// lowercase alphanumerics and hyphens keeps generated strings valid for use as
+// Kubernetes names, label values, and annotation keys.
+const dnsLetters = "abcdefghijklmnopqrstuvwxyz0123456789-"
+
+// ASCIIStringFuzzer is a randfill-compatible fuzzer function that fills string
+// fields with random lowercase-alphanumeric strings of up to 29 characters.
+// Register it via WithExtraFuzzFuncs or rely on the default that NewRoundTripTest
+// includes it automatically.
+//
+// Restricting the character set avoids encoding issues and makes test output
+// readable when a diff is printed.
+func ASCIIStringFuzzer(s *string, c randfill.Continue) {
+	n := c.Rand.Intn(30)
+	b := make([]byte, n)
+	for i := range n {
+		b[i] = dnsLetters[c.Rand.Intn(len(dnsLetters))]
+	}
+	*s = string(b)
+}
+
+// clusterScopedFuzzer is a randfill-compatible fuzzer function for
+// metav1.ObjectMeta that forces Namespace to empty string, ensuring generated
+// objects are valid for cluster-scoped resources.
+func clusterScopedFuzzer(meta *metav1.ObjectMeta, c randfill.Continue) {
+	c.FillNoCustom(meta)
+	meta.Namespace = ""
+}
+
+// namespacedFuzzer is a randfill-compatible fuzzer function for
+// metav1.ObjectMeta that fills Namespace with a random string, ensuring
+// generated objects are valid for namespace-scoped resources.
+func namespacedFuzzer(meta *metav1.ObjectMeta, c randfill.Continue) {
+	c.FillNoCustom(meta)
+	meta.Namespace = c.String(16)
+}

--- a/pkg/apitesting/roundtrip/fuzzer.go
+++ b/pkg/apitesting/roundtrip/fuzzer.go
@@ -29,18 +29,18 @@ func ASCIIStringFuzzer(s *string, c randfill.Continue) {
 	*s = string(b)
 }
 
-// clusterScopedFuzzer is a randfill-compatible fuzzer function for
-// metav1.ObjectMeta that forces Namespace to empty string, ensuring generated
-// objects are valid for cluster-scoped resources.
-func clusterScopedFuzzer(meta *metav1.ObjectMeta, c randfill.Continue) {
-	c.FillNoCustom(meta)
-	meta.Namespace = ""
-}
-
-// namespacedFuzzer is a randfill-compatible fuzzer function for
-// metav1.ObjectMeta that fills Namespace with a random string, ensuring
-// generated objects are valid for namespace-scoped resources.
-func namespacedFuzzer(meta *metav1.ObjectMeta, c randfill.Continue) {
-	c.FillNoCustom(meta)
-	meta.Namespace = c.String(16)
+// objectMetaNamespaceFuzzer returns a randfill-compatible fuzzer function for
+// metav1.ObjectMeta. When namespaced is true the Namespace field is set to a
+// non-empty random string (prefixed with "ns" because c.String(n) picks a
+// length in [0, n) and can produce ""); when false Namespace is cleared to the
+// empty string.
+func objectMetaNamespaceFuzzer(namespaced bool) func(*metav1.ObjectMeta, randfill.Continue) {
+	return func(meta *metav1.ObjectMeta, c randfill.Continue) {
+		c.FillNoCustom(meta)
+		if namespaced {
+			meta.Namespace = "ns" + c.String(15)
+		} else {
+			meta.Namespace = ""
+		}
+	}
 }

--- a/pkg/apitesting/roundtrip/fuzzer_test.go
+++ b/pkg/apitesting/roundtrip/fuzzer_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+package roundtrip
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/randfill"
+)
+
+func TestASCIIStringFuzzer(t *testing.T) {
+	f := randfill.New().Funcs(ASCIIStringFuzzer)
+	for range 200 {
+		var s string
+		f.Fill(&s)
+		if len(s) > 29 {
+			t.Fatalf("string length %d exceeds maximum of 29: %q", len(s), s)
+		}
+		for _, ch := range s {
+			if !strings.ContainsRune(dnsLetters, ch) {
+				t.Fatalf("unexpected character %q in output %q (not in dnsLetters)", ch, s)
+			}
+		}
+	}
+}
+
+func TestObjectMetaNamespaceFuzzer(t *testing.T) {
+	t.Run("cluster-scoped always produces empty Namespace", func(t *testing.T) {
+		f := randfill.New().Funcs(objectMetaNamespaceFuzzer(false))
+		for range 50 {
+			var meta metav1.ObjectMeta
+			f.Fill(&meta)
+			if meta.Namespace != "" {
+				t.Fatalf("cluster-scoped fuzzer produced non-empty Namespace: %q", meta.Namespace)
+			}
+		}
+	})
+
+	t.Run("namespaced always produces non-empty Namespace", func(t *testing.T) {
+		f := randfill.New().Funcs(objectMetaNamespaceFuzzer(true)).NilChance(0)
+		for range 100 {
+			var meta metav1.ObjectMeta
+			f.Fill(&meta)
+			if meta.Namespace == "" {
+				t.Fatal("namespaced fuzzer produced an empty Namespace")
+			}
+		}
+	})
+}

--- a/pkg/apitesting/roundtrip/roundtrip.go
+++ b/pkg/apitesting/roundtrip/roundtrip.go
@@ -1,0 +1,718 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package roundtrip provides a testing utility library for verifying that
+// Crossplane provider managed resources correctly survive serialization and
+// version-conversion round trips.
+//
+// The library exercises two kinds of invariants:
+//
+//  1. Serialization round-trip: an object fuzzed with random data can be
+//     encoded to JSON/YAML and decoded back to an identical object.
+//
+//  2. Conversion round-trip: an object converted spoke→hub→spoke (or
+//     hub→spoke→hub) is bit-identical to the original, proving that no
+//     data is lost across API version conversions registered via
+//     pkg/controller/conversion.RegisterConversions.
+//
+// Basic usage:
+//
+//	func TestRoundTrip(t *testing.T) {
+//	    provider, _ := config.GetProvider(t.Context(), schema, false)
+//	    providerNamespaced, _ := config.GetNamespacedProvider(t.Context(), schema, false)
+//
+//	    testScheme := runtime.NewScheme()
+//	    clusterapis.AddToScheme(testScheme)
+//	    namespacedapis.AddToScheme(testScheme)
+//
+//	    rt, _ := roundtrip.NewRoundTripTest(provider, providerNamespaced, testScheme)
+//
+//	    t.Run("Serialization", rt.TestSerializationRoundtrip)
+//	    t.Run("Conversion",    rt.TestConversionRoundtrip)
+//	}
+package roundtrip
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
+	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	"sigs.k8s.io/randfill"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	ujconversion "github.com/crossplane/upjet/v2/pkg/controller/conversion"
+)
+
+const (
+	// defaultFuzzIterations is the number of fuzz-fill + round-trip cycles run
+	// per (kind, version-pair) when no FuzzerIterations option is set.
+	defaultFuzzIterations = 5
+	// defaultFuzzMinElements is the lower bound on the number of elements
+	// generated for maps and slices during fuzzing.
+	defaultFuzzMinElements = 0
+	// defaultFuzzMaxElements is the upper bound on the number of elements
+	// generated for maps and slices during fuzzing.
+	defaultFuzzMaxElements = 3
+)
+
+// defaultIgnoredKinds lists Kubernetes meta-API kinds that carry no provider
+// types and should be excluded from both serialization and conversion tests.
+var defaultIgnoredKinds = sets.New(
+	"ListOptions", "CreateOptions", "GetOptions",
+	"UpdateOptions", "PatchOptions", "DeleteOptions", "WatchEvent")
+
+var (
+	// cmpoptIgnoreFieldConversionAnnotation drops the upjet internal annotation
+	// that records per-field conversion metadata from object comparisons. The
+	// annotation is written during ConvertTo/ConvertFrom and its exact value is
+	// not part of the user-visible API contract.
+	cmpoptIgnoreFieldConversionAnnotation = cmpopts.IgnoreMapEntries(func(k, v string) bool {
+		return k == "internal.upjet.crossplane.io/field-conversions"
+	})
+
+	// defaultComparisonOptions are the cmp.Options applied to every object
+	// comparison performed by the test suite unless overridden via
+	// WithComparisonOptions.
+	defaultComparisonOptions = []cmp.Option{
+		cmpoptIgnoreFieldConversionAnnotation,
+		cmpopts.EquateEmpty(),
+	}
+)
+
+// RoundTripTest holds all state needed to run serialization and conversion
+// round-trip tests for a single provider.  Create it once with
+// NewRoundTripTest and reuse it across sub-tests.
+type RoundTripTest struct {
+	// providerCluster is the cluster-scoped provider configuration used to
+	// register conversion functions.
+	providerCluster *config.Provider
+	// providerNamespaced is the namespaced provider configuration. May be nil
+	// for providers that only expose cluster-scoped resources.
+	providerNamespaced *config.Provider
+	// scheme holds all types registered by the caller and is used both for
+	// fuzzing (codec factory) and for iterating over known GVKs.
+	scheme *runtime.Scheme
+	// codecFactory is derived from scheme and handed to the k8s fuzzing
+	// infrastructure.
+	codecFactory serializer.CodecFactory
+
+	// fuzzerConfigs is the list of fuzzer configurations to run per
+	// (kind, version-pair).  Each configuration produces an independent
+	// randfill.Filler and runs its own iteration count.  At least one entry is
+	// always present after NewRoundTripTest; callers add more with
+	// WithFuzzerConfig.
+	fuzzerConfigs []fuzzerOptions
+	// extraFuzzFns are additional randfill-compatible fuzzer functions appended
+	// to every fuzzer built from fuzzerConfigs.  Add them with WithExtraFuzzFuncs.
+	extraFuzzFns []any
+
+	// cmpOpts are the cmp.Options used when comparing objects after a round
+	// trip.  Defaults to defaultComparisonOptions; extend with
+	// WithComparisonOptions.
+	cmpOpts []cmp.Option
+
+	// includeGroups, when non-empty, restricts conversion tests to the listed
+	// API groups. Populated by WithIncludeGroups.
+	includeGroups sets.Set[string]
+	// includeGroupKinds, when non-empty, restricts conversion tests to the
+	// listed GroupKinds. Populated by WithIncludeGroupKinds.
+	includeGroupKinds sets.Set[schema.GroupKind]
+	// excludeGroups lists API groups to exclude from conversion tests.  Populated
+	// by WithExcludeGroups.
+	excludeGroups sets.Set[string]
+	// excludeGroupKinds lists specific GroupKinds to exclude from conversion tests.
+	// Populated by WithExcludeGroupKinds.
+	excludeGroupKinds sets.Set[schema.GroupKind]
+}
+
+// fuzzerOptions collects optional configuration for a single randfill.Filler.
+// All fields are pointers so that zero values can be distinguished from "not
+// set", allowing the defaults to apply when a field is absent.
+type fuzzerOptions struct {
+	// FuzzIterations is the number of fuzz-fill + round-trip cycles run for
+	// each (kind, version-pair) by this fuzzer.  Defaults to
+	// defaultFuzzIterations when nil.
+	FuzzIterations *int
+	// NilChance overrides the probability that a pointer field is left nil.
+	// Must be in [0, 1].
+	NilChance *float64
+	// MinElements overrides the minimum number of elements generated for maps
+	// and slices.
+	MinElements *int
+	// MaxElements overrides the maximum number of elements generated for maps
+	// and slices.
+	MaxElements *int
+	// MaxDepth overrides the maximum recursion depth for nested structs.
+	MaxDepth *int
+	// RandSource supplies a custom random source for deterministic fuzzing.
+	// When nil a random seed is chosen automatically.
+	RandSource rand.Source
+	// AllowUnexportedFields, when true, allows the fuzzer to fill unexported
+	// struct fields.
+	AllowUnexportedFields *bool
+	// SkipPatterns lists regexp patterns; fields whose names match any pattern
+	// are skipped by the fuzzer.
+	SkipPatterns []*regexp.Regexp
+}
+
+// fillerWithIterations pairs a ready-to-use randfill.Filler with the number
+// of round-trip cycles it should drive.
+type fillerWithIterations struct {
+	filler     *randfill.Filler
+	iterations int
+}
+
+// FuzzerOption configures a single fuzzerOptions entry.  Pass one or more to
+// WithFuzzerConfig to register a new fuzzer configuration.
+type FuzzerOption func(*fuzzerOptions)
+
+// FuzzerIterations sets the number of fuzz-fill + round-trip cycles this
+// fuzzer configuration will run per (kind, version-pair).
+func FuzzerIterations(n int) FuzzerOption {
+	return func(o *fuzzerOptions) { o.FuzzIterations = &n }
+}
+
+// FuzzerNilChance sets the probability [0, 1] that pointer fields are left
+// nil.  Use 0 to force all pointers to be non-nil.
+func FuzzerNilChance(p float64) FuzzerOption {
+	return func(o *fuzzerOptions) { o.NilChance = &p }
+}
+
+// FuzzerNumElements sets the min and max number of elements generated for maps
+// and slices.
+func FuzzerNumElements(min, max int) FuzzerOption {
+	return func(o *fuzzerOptions) {
+		o.MinElements = &min
+		o.MaxElements = &max
+	}
+}
+
+// FuzzerMaxDepth sets the maximum recursion depth the fuzzer will descend into
+// nested structs.
+func FuzzerMaxDepth(d int) FuzzerOption {
+	return func(o *fuzzerOptions) { o.MaxDepth = &d }
+}
+
+// FuzzerRandSource sets a deterministic random source for this fuzzer
+// configuration.
+func FuzzerRandSource(src rand.Source) FuzzerOption {
+	return func(o *fuzzerOptions) { o.RandSource = src }
+}
+
+// FuzzerSkipPatterns registers regexp patterns; any struct field whose name
+// matches a pattern will be skipped by this fuzzer.
+func FuzzerSkipPatterns(patterns ...*regexp.Regexp) FuzzerOption {
+	return func(o *fuzzerOptions) {
+		o.SkipPatterns = append(o.SkipPatterns, patterns...)
+	}
+}
+
+// FuzzerAllowUnexportedFields allows this fuzzer to fill unexported struct
+// fields.
+func FuzzerAllowUnexportedFields(allow bool) FuzzerOption {
+	return func(o *fuzzerOptions) { o.AllowUnexportedFields = &allow }
+}
+
+// TestOption is a functional option that customises a RoundTripTest.
+type TestOption func(*RoundTripTest)
+
+// WithCodecFactory overrides the codec factory derived from the scheme.  Use
+// this when you need to control codec negotiation (e.g. to add custom
+// serializers).
+func WithCodecFactory(c serializer.CodecFactory) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.codecFactory = c
+	}
+}
+
+// WithIncludeGroups restricts the conversion round-trip test to the given API
+// groups. When neither WithIncludeGroups nor WithIncludeGroupKinds is set,
+// all groups registered in the scheme are tested.
+func WithIncludeGroups(groups ...string) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.includeGroups.Insert(groups...)
+	}
+}
+
+// WithIncludeGroupKinds restricts the conversion round-trip test to the given
+// GroupKinds.  When neither WithIncludeGroups nor WithIncludeGroupKinds is
+// set, all kinds registered in the scheme are tested.
+func WithIncludeGroupKinds(groupKinds ...schema.GroupKind) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.includeGroupKinds.Insert(groupKinds...)
+	}
+}
+
+// WithExcludeGroups excludes the given API groups from the conversion
+// round-trip test.
+func WithExcludeGroups(groups ...string) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.excludeGroups.Insert(groups...)
+	}
+}
+
+// WithExcludeGroupKinds excludes the given GroupKinds from the conversion
+// round-trip test.
+func WithExcludeGroupKinds(groupKinds ...schema.GroupKind) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.excludeGroupKinds.Insert(groupKinds...)
+	}
+}
+
+// WithComparisonOptions appends additional cmp.Options to those used when
+// comparing objects after a round trip.
+func WithComparisonOptions(cmpOpts ...cmp.Option) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.cmpOpts = append(rtt.cmpOpts, cmpOpts...)
+	}
+}
+
+// WithExtraFuzzFuncs appends additional randfill-compatible fuzzer functions
+// (signature: func(*T, randfill.Continue)) to every fuzzer built by the test
+// suite.  This is useful to restrict a field to a valid value domain (e.g.
+// only valid enum strings).
+func WithExtraFuzzFuncs(fns ...any) TestOption {
+	return func(rtt *RoundTripTest) {
+		rtt.extraFuzzFns = append(rtt.extraFuzzFns, fns...)
+	}
+}
+
+// WithFuzzerConfig adds a new fuzzer configuration to the test suite.  The
+// conversion tests run every registered configuration in sequence for each
+// (kind, version-pair), accumulating coverage across different fuzz
+// parameters.
+//
+// Multiple calls each add a distinct configuration:
+//
+//	rt, _ := roundtrip.NewRoundTripTest(provider, nil,
+//	    roundtrip.WithFuzzerConfig(
+//	        roundtrip.FuzzerNilChance(0),
+//	        roundtrip.FuzzerIterations(20),
+//	    ),
+//	    roundtrip.WithFuzzerConfig(
+//	        roundtrip.FuzzerNilChance(0.5),
+//	        roundtrip.FuzzerNumElements(0, 5),
+//	    ),
+//	)
+//
+// When no WithFuzzerConfig is provided, a single default configuration is used
+// (NilChance≈0.2, NumElements 0–3, 10 iterations).
+func WithFuzzerConfig(opts ...FuzzerOption) TestOption {
+	return func(rtt *RoundTripTest) {
+		cfg := fuzzerOptions{}
+		for _, o := range opts {
+			o(&cfg)
+		}
+		rtt.fuzzerConfigs = append(rtt.fuzzerConfigs, cfg)
+	}
+}
+
+// NewRoundTripTest constructs a RoundTripTest and performs one-time setup
+// (scheme codec factory, conversion registration).
+//
+// provider is the cluster-scoped provider configuration.  providerNamespaced
+// is the namespaced variant; pass nil if the provider only exposes
+// cluster-scoped resources.  scheme must have all provider types registered
+// before being passed here.  opts customise test behaviour.
+func NewRoundTripTest(provider *config.Provider, providerNamespaced *config.Provider, scheme *runtime.Scheme, opts ...TestOption) (*RoundTripTest, error) {
+	rt := &RoundTripTest{
+		scheme:             scheme,
+		providerCluster:    provider,
+		providerNamespaced: providerNamespaced,
+		includeGroups:      sets.New[string](),
+		includeGroupKinds:  sets.New[schema.GroupKind](),
+		excludeGroups:      sets.New[string](),
+		excludeGroupKinds:  sets.New[schema.GroupKind](),
+	}
+
+	rt.cmpOpts = append(rt.cmpOpts, defaultComparisonOptions...)
+	for _, opt := range opts {
+		opt(rt)
+	}
+
+	// Guarantee at least one fuzzer configuration so callers never have to
+	// call WithFuzzerConfig explicitly for the common case.
+	if len(rt.fuzzerConfigs) == 0 {
+		rt.fuzzerConfigs = []fuzzerOptions{{}}
+	}
+
+	err := rt.setupTestInfrastructure()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to setup test infrastructure")
+	}
+	return rt, nil
+}
+
+// setupTestInfrastructure performs expensive one-time setup shared across all
+// sub-tests: it rebuilds the codec factory from the (potentially caller-supplied)
+// scheme and registers hub↔spoke conversions for both cluster-scoped and
+// namespaced providers.
+func (rt *RoundTripTest) setupTestInfrastructure() error {
+	rt.codecFactory = serializer.NewCodecFactory(rt.scheme)
+	if err := ujconversion.RegisterConversions(rt.providerCluster, rt.providerNamespaced, rt.scheme); err != nil {
+		return fmt.Errorf("failed to register conversions: %w", err)
+	}
+	return nil
+}
+
+// cmpK8sObjects compares two Kubernetes runtime.Objects for equality after
+// stripping volatile metadata fields (resourceVersion, uid, etc.) that are
+// not part of the provider API contract.  The test is failed immediately if
+// a diff is found.
+func (rt *RoundTripTest) cmpK8sObjects(t *testing.T, a, b runtime.Object) {
+	t.Helper()
+
+	if ao, ok := a.(metav1.Object); ok {
+		normalizeMeta(ao)
+	}
+	if bo, ok := b.(metav1.Object); ok {
+		normalizeMeta(bo)
+	}
+
+	if diff := cmp.Diff(a, b, rt.cmpOpts...); diff != "" {
+		t.Fatalf("round-trip diff (-want +got):\n%s", diff)
+	}
+}
+
+// getFuzzer constructs a randfill.Filler from opts.  A fresh random source is
+// chosen automatically when opts.RandSource is nil, so parallel sub-tests each
+// get an independent sequence and avoid data races.
+func (rt *RoundTripTest) getFuzzer(opts fuzzerOptions) *randfill.Filler {
+	randSource := opts.RandSource
+	if randSource == nil {
+		randSource = rand.NewSource(rand.Int63()) //nolint:gosec // for testing only
+	}
+
+	fuzzerFns := []fuzzer.FuzzerFuncs{genericfuzzer.Funcs, rt.customFuzzFuncs}
+	objFuzzer := fuzzer.FuzzerFor(
+		fuzzer.MergeFuzzerFuncs(fuzzerFns...),
+		randSource,
+		rt.codecFactory,
+	)
+
+	if opts.NilChance != nil {
+		objFuzzer = objFuzzer.NilChance(*opts.NilChance)
+	}
+
+	minElements := defaultFuzzMinElements
+	maxElements := defaultFuzzMaxElements
+	if opts.MinElements != nil {
+		minElements = *opts.MinElements
+	}
+	if opts.MaxElements != nil {
+		maxElements = *opts.MaxElements
+	}
+	objFuzzer = objFuzzer.NumElements(minElements, maxElements)
+
+	if opts.MaxDepth != nil {
+		objFuzzer = objFuzzer.MaxDepth(*opts.MaxDepth)
+	}
+
+	if opts.AllowUnexportedFields != nil {
+		objFuzzer = objFuzzer.AllowUnexportedFields(*opts.AllowUnexportedFields)
+	}
+
+	for _, pattern := range opts.SkipPatterns {
+		objFuzzer = objFuzzer.SkipFieldsWithPattern(pattern)
+	}
+
+	return objFuzzer
+}
+
+// getFillers builds one fillerWithIterations per entry in rt.fuzzerConfigs.
+// Each filler has NumElements(0,1) and NilChance(0) applied on top of its
+// config — a temporary workaround for singleton-list and pointer-slice
+// handling in upjet conversions — and the appropriate scope function
+// (namespaced or cluster-scoped) for ObjectMeta.
+//
+// Callers must not share the returned slice across goroutines: randfill.Filler
+// is not goroutine-safe.  Call getFillers once per kind sub-test.
+func (rt *RoundTripTest) getFillers(namespaced bool) []fillerWithIterations {
+	fillers := make([]fillerWithIterations, 0, len(rt.fuzzerConfigs))
+	for _, cfg := range rt.fuzzerConfigs {
+		f := rt.getFuzzer(cfg).NumElements(0, 1).NilChance(0)
+		if namespaced {
+			f = f.Funcs(namespacedFuzzer)
+		} else {
+			f = f.Funcs(clusterScopedFuzzer)
+		}
+		iters := defaultFuzzIterations
+		if cfg.FuzzIterations != nil {
+			iters = *cfg.FuzzIterations
+		}
+		fillers = append(fillers, fillerWithIterations{filler: f, iterations: iters})
+	}
+	return fillers
+}
+
+// TestSerializationRoundtrip verifies that every type registered in the scheme
+// and passing the include/exclude filters survives a JSON encode→decode cycle
+// with no data loss.  It delegates to the upstream k8s roundtrip helper.
+// The same WithIncludeGroups/WithExcludeGroups/WithIncludeGroupKinds/
+// WithExcludeGroupKinds filters that apply to TestConversionRoundtrip also
+// apply here.  The first fuzzer configuration is used to build the fuzzer.
+func (rt *RoundTripTest) TestSerializationRoundtrip(t *testing.T) {
+	objFuzzer := rt.getFuzzer(rt.fuzzerConfigs[0])
+	roundtrip.RoundTripExternalTypesWithoutProtobuf(t, rt.scheme, rt.codecFactory, objFuzzer, rt.nonRoundTrippableTypes())
+}
+
+// nonRoundTrippableTypes returns a map of GVKs that should be skipped by the
+// serialization round-trip test.  A GVK is skipped when its GroupKind is not
+// present in the set produced by groupsToKindFromScheme — i.e. when it is
+// excluded via WithExcludeGroups/WithExcludeGroupKinds or absent from the
+// include set set by WithIncludeGroups/WithIncludeGroupKinds.
+func (rt *RoundTripTest) nonRoundTrippableTypes() map[schema.GroupVersionKind]bool {
+	hasFilter := rt.includeGroups.Len() > 0 || rt.includeGroupKinds.Len() > 0 ||
+		rt.excludeGroups.Len() > 0 || rt.excludeGroupKinds.Len() > 0
+	if !hasFilter {
+		return nil
+	}
+
+	allowed := rt.groupsToKindFromScheme()
+	result := make(map[schema.GroupVersionKind]bool)
+	for gvk := range rt.scheme.AllKnownTypes() {
+		if gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		groupKinds, ok := allowed[gvk.Group]
+		if !ok || !groupKinds.Has(gvk.GroupKind()) {
+			result[gvk] = true
+		}
+	}
+	return result
+}
+
+// TestConversionRoundtrip iterates over every API group registered in the
+// scheme, discovers hub and spoke versions for each GroupKind, and runs both
+// spoke→hub→spoke and hub→spoke→hub conversions, asserting that the result is
+// identical to the input.
+//
+// All fuzzer configurations registered via WithFuzzerConfig are exercised for
+// each (kind, version-pair).  Groups and kinds can be narrowed or excluded
+// with the WithInclude* and WithExclude* options.  Any GroupKind with fewer
+// than two registered versions is skipped with a log message.
+func (rt *RoundTripTest) TestConversionRoundtrip(t *testing.T) {
+	groupKinds := rt.groupsToKindFromScheme()
+	for group, kinds := range groupKinds {
+		if group == "" {
+			// skip K8s core API group
+			continue
+		}
+		namespaced := rt.providerNamespaced != nil && rt.providerNamespaced.RootGroup != "" &&
+			strings.HasSuffix(group, rt.providerNamespaced.RootGroup)
+
+		t.Run(group, func(t *testing.T) {
+			t.Parallel()
+			for _, gk := range kinds.UnsortedList() {
+				availableVersions := rt.scheme.VersionsForGroupKind(gk)
+				if len(availableVersions) < 2 {
+					t.Logf("skipping %q, not multi-version ", gk)
+					continue
+				}
+
+				t.Run(gk.Kind, func(t *testing.T) {
+					t.Parallel()
+					t.Logf("testing group %q", gk)
+					// Each kind sub-test gets its own fillers so parallel kinds
+					// within a group never share a randfill.Filler (not goroutine-safe).
+					rt.testKind(t, gk, availableVersions, rt.getFillers(namespaced))
+				})
+			}
+		})
+	}
+}
+
+// customFuzzFuncs returns the set of fuzzer functions that are always applied:
+// ASCIIStringFuzzer (to keep generated strings within printable ASCII) plus any
+// functions registered by the caller via WithExtraFuzzFuncs.
+func (rt *RoundTripTest) customFuzzFuncs(_ serializer.CodecFactory) []any {
+	fuzzFns := make([]any, 0, len(rt.extraFuzzFns)+1)
+	fuzzFns = append(fuzzFns, ASCIIStringFuzzer)
+	fuzzFns = append(fuzzFns, rt.extraFuzzFns...)
+	return fuzzFns
+}
+
+// testKind identifies the hub and spoke versions for gk, then runs
+// spokeHubSpoke and hubSpokeHub sub-tests for every spoke version, serially.
+// The test is failed if no hub version is found and skipped if any version
+// lacks a conversion implementation.
+func (rt *RoundTripTest) testKind(t *testing.T, gk schema.GroupKind, gvList []schema.GroupVersion, fillers []fillerWithIterations) {
+	var hubVersion string
+	spokes := make([]string, 0, len(gvList))
+	for _, gv := range gvList {
+		gvk := gk.WithVersion(gv.Version)
+		object, err := rt.scheme.New(gvk)
+		if err != nil {
+			t.Fatalf("cannot create object from scheme for %q: %v", gvk.String(), err)
+		}
+		switch object.(type) {
+		case conversion.Hub:
+			if hubVersion != "" {
+				t.Fatalf("multiple Hub versions detected for %s: %q and %q", gk.String(), hubVersion, gv.Version)
+			}
+			hubVersion = gv.Version
+		case conversion.Convertible:
+			spokes = append(spokes, gv.Version)
+		default:
+			t.Errorf("%s implements neither conversion.Hub nor conversion.Convertible", gvk)
+		}
+	}
+
+	if hubVersion == "" {
+		t.Fatalf("No hub version exists in scheme for %s", gk)
+	}
+	if len(spokes) == 0 {
+		t.Fatalf("No spoke version exists in scheme for %s", gk)
+	}
+	t.Logf("Using hub version %q for %s", hubVersion, gk)
+	t.Logf("Using spoke version(s) %q for %s", strings.Join(spokes, ","), gk)
+
+	for _, spokeVersion := range spokes {
+		t.Run(fmt.Sprintf("Spoke_%s_Over_Hub_%s", spokeVersion, hubVersion), func(t *testing.T) {
+			t.Logf("%s: spoke_%s -> hub_%s -> spoke_%s", gk.String(), spokeVersion, hubVersion, spokeVersion)
+			rt.spokeHubSpoke(t, gk.WithVersion(hubVersion), gk.WithVersion(spokeVersion), fillers)
+		})
+		t.Run(fmt.Sprintf("Hub_%s_Over_Spoke_%s", hubVersion, spokeVersion), func(t *testing.T) {
+			t.Logf("%s: hub_%s -> spoke_%s -> hub_%s", gk.String(), hubVersion, spokeVersion, hubVersion)
+			rt.hubSpokeHub(t, gk.WithVersion(hubVersion), gk.WithVersion(spokeVersion), fillers)
+		})
+	}
+}
+
+// spokeHubSpoke verifies the spoke→hub→spoke conversion cycle for every
+// provided filler: a randomly filled spoke object is converted to the hub
+// version and then back to a new spoke instance; the two spokes must be
+// identical.  The cycle repeats fw.iterations times per filler.
+func (rt *RoundTripTest) spokeHubSpoke(t *testing.T, hubGvk, spokeGvk schema.GroupVersionKind, fillers []fillerWithIterations) { //nolint:gocyclo // easier to follow as a unit
+	for _, fw := range fillers {
+		for range fw.iterations {
+			spokeSrcRuntime, err := rt.scheme.New(spokeGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for spoke %s: %v", spokeGvk, err)
+			}
+			spokeSrc, ok := spokeSrcRuntime.(conversion.Convertible)
+			if !ok {
+				t.Fatalf("object is not Convertible: %v", spokeSrcRuntime)
+			}
+
+			hubIntermediateRuntime, err := rt.scheme.New(hubGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for hub %s: %v", hubGvk, err)
+			}
+			hubIntermediate, ok := hubIntermediateRuntime.(conversion.Hub)
+			if !ok {
+				t.Fatalf("object is not Hub: %v", hubIntermediateRuntime)
+			}
+
+			spokeFinalRuntime, err := rt.scheme.New(spokeGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for spoke %s: %v", spokeGvk, err)
+			}
+			spokeFinal, ok := spokeFinalRuntime.(conversion.Convertible)
+			if !ok {
+				t.Fatalf("object is not Convertible: %v", spokeFinalRuntime)
+			}
+
+			fw.filler.Fill(spokeSrcRuntime)
+
+			if err := spokeSrc.ConvertTo(hubIntermediate); err != nil {
+				t.Fatalf("spokeSrc.ConvertTo(hubIntermediate): %v", err)
+			}
+			if err := spokeFinal.ConvertFrom(hubIntermediate); err != nil {
+				t.Fatalf("spokeFinal.ConvertFrom(hubIntermediate): %v", err)
+			}
+			rt.cmpK8sObjects(t, spokeSrc.DeepCopyObject(), spokeFinal.DeepCopyObject())
+		}
+	}
+}
+
+// hubSpokeHub verifies the hub→spoke→hub conversion cycle for every provided
+// filler: a randomly filled hub object is converted to a spoke version and
+// then back to a new hub instance; the two hubs must be identical.  The cycle
+// repeats fw.iterations times per filler.
+func (rt *RoundTripTest) hubSpokeHub(t *testing.T, hubGvk, spokeGvk schema.GroupVersionKind, fillers []fillerWithIterations) { //nolint:gocyclo // easier to follow as a unit
+	for _, fw := range fillers {
+		for range fw.iterations {
+			srcHubRuntime, err := rt.scheme.New(hubGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for source Hub %s: %v", hubGvk, err)
+			}
+			srcHub, ok := srcHubRuntime.(conversion.Hub)
+			if !ok {
+				t.Fatalf("object does not implement conversion.Hub: %v", srcHubRuntime)
+			}
+
+			intermediateSpokeRuntime, err := rt.scheme.New(spokeGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for intermediate spoke %s: %v", spokeGvk, err)
+			}
+			intermediateSpoke, ok := intermediateSpokeRuntime.(conversion.Convertible)
+			if !ok {
+				t.Fatalf("object does not implement conversion.Convertible: %v", intermediateSpokeRuntime)
+			}
+
+			finalHubRuntime, err := rt.scheme.New(hubGvk)
+			if err != nil {
+				t.Fatalf("failed to instantiate object for final hub %s: %v", hubGvk, err)
+			}
+			finalHub, ok := finalHubRuntime.(conversion.Hub)
+			if !ok {
+				t.Fatalf("object is not a conversion.Hub: %v", finalHubRuntime)
+			}
+
+			fw.filler.Fill(srcHubRuntime)
+
+			if err := intermediateSpoke.ConvertFrom(srcHub); err != nil {
+				t.Logf("Source Hub Object: %+v", srcHub)
+				t.Fatalf("intermediateSpoke.ConvertFrom(srcHub): %v", err)
+			}
+			if err := intermediateSpoke.ConvertTo(finalHub); err != nil {
+				t.Logf("Source Hub Object: %+v", srcHub)
+				t.Logf("intermediate Spoke Object: %+v", intermediateSpoke)
+				t.Fatalf("intermediateSpoke.ConvertTo(finalHub): %v", err)
+			}
+
+			rt.cmpK8sObjects(t, srcHub.DeepCopyObject(), finalHub.DeepCopyObject())
+		}
+	}
+}
+
+// groupsToKindFromScheme returns a map from API group to the set of GroupKinds
+// registered in that group, after applying include/exclude filters.  List kinds
+// and Kubernetes meta-API kinds (Options, WatchEvent, …) are always excluded.
+func (rt *RoundTripTest) groupsToKindFromScheme() map[string]sets.Set[schema.GroupKind] { //nolint:gocyclo // easier to follow as a unit
+	hasIncludeFilter := rt.includeGroups.Len() > 0 || rt.includeGroupKinds.Len() > 0
+	ret := make(map[string]sets.Set[schema.GroupKind])
+
+	for gvk := range rt.scheme.AllKnownTypes() {
+		if strings.HasSuffix(gvk.Kind, "List") || defaultIgnoredKinds.Has(gvk.Kind) {
+			continue
+		}
+		if rt.excludeGroups.Has(gvk.Group) || rt.excludeGroupKinds.Has(gvk.GroupKind()) {
+			continue
+		}
+		if hasIncludeFilter && !rt.includeGroups.Has(gvk.Group) && !rt.includeGroupKinds.Has(gvk.GroupKind()) {
+			continue
+		}
+		if _, ok := ret[gvk.Group]; !ok {
+			ret[gvk.Group] = sets.New[schema.GroupKind]()
+		}
+		ret[gvk.Group].Insert(gvk.GroupKind())
+	}
+	return ret
+}

--- a/pkg/apitesting/roundtrip/roundtrip.go
+++ b/pkg/apitesting/roundtrip/roundtrip.go
@@ -452,15 +452,11 @@ func (rt *RoundTripTest) getFuzzer(opts fuzzerOptions) *randfill.Filler {
 //
 // Callers must not share the returned slice across goroutines: randfill.Filler
 // is not goroutine-safe.  Call getFillers once per kind sub-test.
-func (rt *RoundTripTest) getFillers(namespaced bool) []fillerWithIterations {
+func (rt *RoundTripTest) getFillers(isNamespaced bool) []fillerWithIterations {
 	fillers := make([]fillerWithIterations, 0, len(rt.fuzzerConfigs))
 	for _, cfg := range rt.fuzzerConfigs {
 		f := rt.getFuzzer(cfg)
-		if namespaced {
-			f = f.Funcs(namespacedFuzzer)
-		} else {
-			f = f.Funcs(clusterScopedFuzzer)
-		}
+		f = f.Funcs(objectMetaNamespaceFuzzer(isNamespaced))
 		iters := defaultFuzzIterations
 		if cfg.FuzzIterations != nil {
 			iters = *cfg.FuzzIterations

--- a/pkg/apitesting/roundtrip/roundtrip.go
+++ b/pkg/apitesting/roundtrip/roundtrip.go
@@ -11,7 +11,7 @@
 //  1. Serialization round-trip: an object fuzzed with random data can be
 //     encoded to JSON/YAML and decoded back to an identical object.
 //
-//  2. Conversion round-trip: an object converted spoke→hub→spoke (or
+//  2. Conversion round-trip: an object converted spoke→hub→spoke (and
 //     hub→spoke→hub) is bit-identical to the original, proving that no
 //     data is lost across API version conversions registered via
 //     pkg/controller/conversion.RegisterConversions.
@@ -67,7 +67,7 @@ const (
 	defaultFuzzMinElements = 0
 	// defaultFuzzMaxElements is the upper bound on the number of elements
 	// generated for maps and slices during fuzzing.
-	defaultFuzzMaxElements = 3
+	defaultFuzzMaxElements = 1
 )
 
 // defaultIgnoredKinds lists Kubernetes meta-API kinds that carry no provider
@@ -110,7 +110,9 @@ type RoundTripTest struct {
 	// codecFactory is derived from scheme and handed to the k8s fuzzing
 	// infrastructure.
 	codecFactory serializer.CodecFactory
-
+	// when true, skips initialization of codecFactory from given scheme
+	// and user-supplied custom codecFactory is directly used
+	useCustomCodec bool
 	// fuzzerConfigs is the list of fuzzer configurations to run per
 	// (kind, version-pair).  Each configuration produces an independent
 	// randfill.Filler and runs its own iteration count.  At least one entry is
@@ -237,6 +239,7 @@ type TestOption func(*RoundTripTest)
 func WithCodecFactory(c serializer.CodecFactory) TestOption {
 	return func(rtt *RoundTripTest) {
 		rtt.codecFactory = c
+		rtt.useCustomCodec = true
 	}
 }
 
@@ -311,7 +314,7 @@ func WithExtraFuzzFuncs(fns ...any) TestOption {
 //	)
 //
 // When no WithFuzzerConfig is provided, a single default configuration is used
-// (NilChance≈0.2, NumElements 0–3, 10 iterations).
+// (NilChance≈0.2, NumElements 0–1, 10 iterations).
 func WithFuzzerConfig(opts ...FuzzerOption) TestOption {
 	return func(rtt *RoundTripTest) {
 		cfg := fuzzerOptions{}
@@ -363,9 +366,11 @@ func NewRoundTripTest(provider *config.Provider, providerNamespaced *config.Prov
 // scheme and registers hub↔spoke conversions for both cluster-scoped and
 // namespaced providers.
 func (rt *RoundTripTest) setupTestInfrastructure() error {
-	rt.codecFactory = serializer.NewCodecFactory(rt.scheme)
+	if !rt.useCustomCodec {
+		rt.codecFactory = serializer.NewCodecFactory(rt.scheme)
+	}
 	if err := ujconversion.RegisterConversions(rt.providerCluster, rt.providerNamespaced, rt.scheme); err != nil {
-		return fmt.Errorf("failed to register conversions: %w", err)
+		return errors.Wrapf(err, "failed to register conversions")
 	}
 	return nil
 }
@@ -435,17 +440,15 @@ func (rt *RoundTripTest) getFuzzer(opts fuzzerOptions) *randfill.Filler {
 }
 
 // getFillers builds one fillerWithIterations per entry in rt.fuzzerConfigs.
-// Each filler has NumElements(0,1) and NilChance(0) applied on top of its
-// config — a temporary workaround for singleton-list and pointer-slice
-// handling in upjet conversions — and the appropriate scope function
-// (namespaced or cluster-scoped) for ObjectMeta.
+// Each filler has the appropriate (namespaced or cluster-scoped) scope-aware
+// fuzzer function appended for filling ObjectMeta.
 //
 // Callers must not share the returned slice across goroutines: randfill.Filler
 // is not goroutine-safe.  Call getFillers once per kind sub-test.
 func (rt *RoundTripTest) getFillers(namespaced bool) []fillerWithIterations {
 	fillers := make([]fillerWithIterations, 0, len(rt.fuzzerConfigs))
 	for _, cfg := range rt.fuzzerConfigs {
-		f := rt.getFuzzer(cfg).NumElements(0, 1).NilChance(0)
+		f := rt.getFuzzer(cfg)
 		if namespaced {
 			f = f.Funcs(namespacedFuzzer)
 		} else {
@@ -467,8 +470,12 @@ func (rt *RoundTripTest) getFillers(namespaced bool) []fillerWithIterations {
 // WithExcludeGroupKinds filters that apply to TestConversionRoundtrip also
 // apply here.  The first fuzzer configuration is used to build the fuzzer.
 func (rt *RoundTripTest) TestSerializationRoundtrip(t *testing.T) {
-	objFuzzer := rt.getFuzzer(rt.fuzzerConfigs[0])
-	roundtrip.RoundTripExternalTypesWithoutProtobuf(t, rt.scheme, rt.codecFactory, objFuzzer, rt.nonRoundTrippableTypes())
+	for i, fuzzerCfg := range rt.fuzzerConfigs {
+		objFuzzer := rt.getFuzzer(fuzzerCfg)
+		t.Run(fmt.Sprintf("TestSerializationWithFuzzer%d", i), func(t *testing.T) {
+			roundtrip.RoundTripExternalTypesWithoutProtobuf(t, rt.scheme, rt.codecFactory, objFuzzer, rt.nonRoundTrippableTypes())
+		})
+	}
 }
 
 // nonRoundTrippableTypes returns a map of GVKs that should be skipped by the

--- a/pkg/apitesting/roundtrip/roundtrip.go
+++ b/pkg/apitesting/roundtrip/roundtrip.go
@@ -76,6 +76,13 @@ var defaultIgnoredKinds = sets.New(
 	"ListOptions", "CreateOptions", "GetOptions",
 	"UpdateOptions", "PatchOptions", "DeleteOptions", "WatchEvent")
 
+// FuzzFunc is a randfill-compatible fuzzer function. The concrete value must
+// have the signature func(*T, randfill.Continue) where T is the type whose
+// instances should be fuzz-filled. Values are registered with
+// randfill.Filler.Funcs and called during fuzzing. The alias preserves full
+// compatibility with the k8s fuzzer infrastructure, which expects []interface{}.
+type FuzzFunc = any
+
 var (
 	// cmpoptIgnoreFieldConversionAnnotation drops the upjet internal annotation
 	// that records per-field conversion metadata from object comparisons. The
@@ -121,7 +128,7 @@ type RoundTripTest struct {
 	fuzzerConfigs []fuzzerOptions
 	// extraFuzzFns are additional randfill-compatible fuzzer functions appended
 	// to every fuzzer built from fuzzerConfigs.  Add them with WithExtraFuzzFuncs.
-	extraFuzzFns []any
+	extraFuzzFns []FuzzFunc
 
 	// cmpOpts are the cmp.Options used when comparing objects after a round
 	// trip.  Defaults to defaultComparisonOptions; extend with
@@ -289,7 +296,7 @@ func WithComparisonOptions(cmpOpts ...cmp.Option) TestOption {
 // (signature: func(*T, randfill.Continue)) to every fuzzer built by the test
 // suite.  This is useful to restrict a field to a valid value domain (e.g.
 // only valid enum strings).
-func WithExtraFuzzFuncs(fns ...any) TestOption {
+func WithExtraFuzzFuncs(fns ...FuzzFunc) TestOption {
 	return func(rtt *RoundTripTest) {
 		rtt.extraFuzzFns = append(rtt.extraFuzzFns, fns...)
 	}
@@ -547,8 +554,8 @@ func (rt *RoundTripTest) TestConversionRoundtrip(t *testing.T) {
 // customFuzzFuncs returns the set of fuzzer functions that are always applied:
 // ASCIIStringFuzzer (to keep generated strings within printable ASCII) plus any
 // functions registered by the caller via WithExtraFuzzFuncs.
-func (rt *RoundTripTest) customFuzzFuncs(_ serializer.CodecFactory) []any {
-	fuzzFns := make([]any, 0, len(rt.extraFuzzFns)+1)
+func (rt *RoundTripTest) customFuzzFuncs(_ serializer.CodecFactory) []FuzzFunc {
+	fuzzFns := make([]FuzzFunc, 0, len(rt.extraFuzzFns)+1)
 	fuzzFns = append(fuzzFns, ASCIIStringFuzzer)
 	fuzzFns = append(fuzzFns, rt.extraFuzzFns...)
 	return fuzzFns

--- a/pkg/apitesting/roundtrip/roundtrip_test.go
+++ b/pkg/apitesting/roundtrip/roundtrip_test.go
@@ -1,0 +1,589 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+package roundtrip
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ---- minimal runtime.Object types for scheme registration ----
+
+type (
+	testNodeA struct {
+		metav1.TypeMeta
+		metav1.ObjectMeta
+	}
+	testNodeB struct {
+		metav1.TypeMeta
+		metav1.ObjectMeta
+	}
+	testNodeC struct {
+		metav1.TypeMeta
+		metav1.ObjectMeta
+	}
+	testNodeD struct {
+		metav1.TypeMeta
+		metav1.ObjectMeta
+	}
+	testNodeE struct {
+		metav1.TypeMeta
+		metav1.ObjectMeta
+	}
+)
+
+func (o *testNodeA) DeepCopyObject() runtime.Object { c := *o; return &c }
+func (o *testNodeB) DeepCopyObject() runtime.Object { c := *o; return &c }
+func (o *testNodeC) DeepCopyObject() runtime.Object { c := *o; return &c }
+func (o *testNodeD) DeepCopyObject() runtime.Object { c := *o; return &c }
+func (o *testNodeE) DeepCopyObject() runtime.Object { c := *o; return &c }
+
+// ---- hub and spoke types for conversion round-trip tests ----
+
+// hubObject is a minimal conversion.Hub implementation.
+type hubObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Value string
+}
+
+func (h *hubObject) DeepCopyObject() runtime.Object { c := *h; return &c }
+func (h *hubObject) Hub()                           {}
+
+// spokeObject is a minimal conversion.Convertible implementation.
+// ConvertTo/ConvertFrom do a field-complete copy so the round-trip is lossless.
+type spokeObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Value string
+}
+
+func (s *spokeObject) DeepCopyObject() runtime.Object { c := *s; return &c }
+
+func (s *spokeObject) ConvertTo(dst conversion.Hub) error {
+	hub, ok := dst.(*hubObject)
+	if !ok {
+		return fmt.Errorf("unexpected hub type %T", dst)
+	}
+	hub.ObjectMeta = s.ObjectMeta
+	hub.Value = s.Value
+	return nil
+}
+
+func (s *spokeObject) ConvertFrom(src conversion.Hub) error {
+	hub, ok := src.(*hubObject)
+	if !ok {
+		return fmt.Errorf("unexpected hub type %T", src)
+	}
+	s.ObjectMeta = hub.ObjectMeta
+	s.Value = hub.Value
+	return nil
+}
+
+// ---- GVK constants used across tests ----
+
+var (
+	gvkWidgetV1       = schema.GroupVersionKind{Group: "a.io", Version: "v1", Kind: "Widget"}
+	gvkWidget2V1      = schema.GroupVersionKind{Group: "a.io", Version: "v1", Kind: "Widget2"}
+	gvkWidgetListV1   = schema.GroupVersionKind{Group: "a.io", Version: "v1", Kind: "WidgetList"}
+	gvkDeleteV1       = schema.GroupVersionKind{Group: "a.io", Version: "v1", Kind: "DeleteOptions"}
+	gvkWidgetInternal = schema.GroupVersionKind{Group: "a.io", Version: runtime.APIVersionInternal, Kind: "Widget"}
+	gvkGadgetV1       = schema.GroupVersionKind{Group: "b.io", Version: "v1", Kind: "Gadget"}
+)
+
+// makeFilterTestScheme returns a scheme populated with types covering the
+// boundary conditions exercised by groupsToKindFromScheme and
+// nonRoundTrippableTypes:
+//
+//   - Widget/Widget2 in "a.io" v1 (two normal kinds in one group)
+//   - WidgetList     in "a.io" v1 (List-suffix → always excluded)
+//   - DeleteOptions  in "a.io" v1 (defaultIgnoredKinds member → always excluded)
+//   - Widget         in "a.io" __internal (internal version → excluded by nonRoundTrippable)
+//   - Gadget         in "b.io" v1 (second group)
+func makeFilterTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(gvkWidgetV1, &testNodeA{})
+	s.AddKnownTypeWithName(gvkWidget2V1, &testNodeB{})
+	s.AddKnownTypeWithName(gvkWidgetListV1, &testNodeC{})
+	s.AddKnownTypeWithName(gvkDeleteV1, &testNodeD{})
+	s.AddKnownTypeWithName(gvkWidgetInternal, &testNodeE{})
+	s.AddKnownTypeWithName(gvkGadgetV1, &testNodeA{})
+	return s
+}
+
+// newTestRT returns a RoundTripTest with all set fields initialised and the
+// given scheme attached.  It does NOT call setupTestInfrastructure (which
+// would touch the global conversion singleton), so it is safe to call from
+// many test functions in the same binary.
+func newTestRT(s *runtime.Scheme) *RoundTripTest {
+	return &RoundTripTest{
+		scheme:            s,
+		includeGroups:     sets.New[string](),
+		includeGroupKinds: sets.New[schema.GroupKind](),
+		excludeGroups:     sets.New[string](),
+		excludeGroupKinds: sets.New[schema.GroupKind](),
+		cmpOpts:           append([]cmp.Option(nil), defaultComparisonOptions...),
+	}
+}
+
+// ---- FuzzerOption unit tests ----
+
+func TestFuzzerOptions(t *testing.T) {
+	t.Run("FuzzerIterations", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerIterations(7)(&opts)
+		if opts.FuzzIterations == nil || *opts.FuzzIterations != 7 {
+			t.Errorf("expected 7, got %v", opts.FuzzIterations)
+		}
+	})
+
+	t.Run("FuzzerNilChance", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerNilChance(0.3)(&opts)
+		if opts.NilChance == nil || *opts.NilChance != 0.3 {
+			t.Errorf("expected 0.3, got %v", opts.NilChance)
+		}
+	})
+
+	t.Run("FuzzerNumElements", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerNumElements(2, 8)(&opts)
+		if opts.MinElements == nil || *opts.MinElements != 2 {
+			t.Errorf("MinElements: expected 2, got %v", opts.MinElements)
+		}
+		if opts.MaxElements == nil || *opts.MaxElements != 8 {
+			t.Errorf("MaxElements: expected 8, got %v", opts.MaxElements)
+		}
+	})
+
+	t.Run("FuzzerMaxDepth", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerMaxDepth(10)(&opts)
+		if opts.MaxDepth == nil || *opts.MaxDepth != 10 {
+			t.Errorf("expected 10, got %v", opts.MaxDepth)
+		}
+	})
+
+	t.Run("FuzzerRandSource", func(t *testing.T) {
+		src := rand.NewSource(42)
+		opts := fuzzerOptions{}
+		FuzzerRandSource(src)(&opts)
+		if opts.RandSource != src {
+			t.Error("RandSource not stored")
+		}
+	})
+
+	t.Run("FuzzerSkipPatterns", func(t *testing.T) {
+		p1 := regexp.MustCompile("^skip")
+		p2 := regexp.MustCompile("^ignore")
+		opts := fuzzerOptions{}
+		FuzzerSkipPatterns(p1, p2)(&opts)
+		if len(opts.SkipPatterns) != 2 {
+			t.Fatalf("expected 2 patterns, got %d", len(opts.SkipPatterns))
+		}
+		if opts.SkipPatterns[0] != p1 || opts.SkipPatterns[1] != p2 {
+			t.Error("patterns not stored in order")
+		}
+	})
+
+	t.Run("FuzzerSkipPatterns_append", func(t *testing.T) {
+		p1 := regexp.MustCompile("^a")
+		p2 := regexp.MustCompile("^b")
+		opts := fuzzerOptions{}
+		FuzzerSkipPatterns(p1)(&opts)
+		FuzzerSkipPatterns(p2)(&opts)
+		if len(opts.SkipPatterns) != 2 {
+			t.Fatalf("expected 2 patterns after two calls, got %d", len(opts.SkipPatterns))
+		}
+	})
+
+	t.Run("FuzzerAllowUnexportedFields_true", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerAllowUnexportedFields(true)(&opts)
+		if opts.AllowUnexportedFields == nil || !*opts.AllowUnexportedFields {
+			t.Errorf("expected true, got %v", opts.AllowUnexportedFields)
+		}
+	})
+
+	t.Run("FuzzerAllowUnexportedFields_false", func(t *testing.T) {
+		opts := fuzzerOptions{}
+		FuzzerAllowUnexportedFields(false)(&opts)
+		if opts.AllowUnexportedFields == nil || *opts.AllowUnexportedFields {
+			t.Errorf("expected false, got %v", opts.AllowUnexportedFields)
+		}
+	})
+}
+
+// ---- TestOption unit tests ----
+
+func TestTestOptions(t *testing.T) {
+	t.Run("WithFuzzerConfig_appends", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		n := 7
+		WithFuzzerConfig(FuzzerIterations(n))(rt)
+		if len(rt.fuzzerConfigs) != 1 {
+			t.Fatalf("expected 1 config, got %d", len(rt.fuzzerConfigs))
+		}
+		if rt.fuzzerConfigs[0].FuzzIterations == nil || *rt.fuzzerConfigs[0].FuzzIterations != n {
+			t.Errorf("FuzzIterations not set in config")
+		}
+
+		WithFuzzerConfig(FuzzerNilChance(0.5))(rt)
+		if len(rt.fuzzerConfigs) != 2 {
+			t.Fatalf("second WithFuzzerConfig did not append; got %d configs", len(rt.fuzzerConfigs))
+		}
+	})
+
+	t.Run("WithIncludeGroups", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		WithIncludeGroups("a.io", "b.io")(rt)
+		if !rt.includeGroups.Has("a.io") || !rt.includeGroups.Has("b.io") {
+			t.Error("groups not inserted into includeGroups")
+		}
+		if rt.includeGroups.Has("c.io") {
+			t.Error("unexpected group present")
+		}
+	})
+
+	t.Run("WithExcludeGroups", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		WithExcludeGroups("x.io")(rt)
+		if !rt.excludeGroups.Has("x.io") {
+			t.Error("group not inserted into excludeGroups")
+		}
+	})
+
+	t.Run("WithIncludeGroupKinds", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		gk := schema.GroupKind{Group: "a.io", Kind: "Widget"}
+		WithIncludeGroupKinds(gk)(rt)
+		if !rt.includeGroupKinds.Has(gk) {
+			t.Error("GroupKind not inserted into includeGroupKinds")
+		}
+	})
+
+	t.Run("WithExcludeGroupKinds", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		gk := schema.GroupKind{Group: "a.io", Kind: "Widget"}
+		WithExcludeGroupKinds(gk)(rt)
+		if !rt.excludeGroupKinds.Has(gk) {
+			t.Error("GroupKind not inserted into excludeGroupKinds")
+		}
+	})
+
+	t.Run("WithComparisonOptions_appends", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		before := len(rt.cmpOpts)
+		WithComparisonOptions(EquateEmptyAndSingleZeroSlice())(rt)
+		if len(rt.cmpOpts) != before+1 {
+			t.Errorf("expected %d cmpOpts, got %d", before+1, len(rt.cmpOpts))
+		}
+	})
+
+	t.Run("WithExtraFuzzFuncs_appends", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		fn := func() {}
+		WithExtraFuzzFuncs(fn)(rt)
+		if len(rt.extraFuzzFns) != 1 {
+			t.Fatalf("expected 1 extra fuzz fn, got %d", len(rt.extraFuzzFns))
+		}
+	})
+
+	t.Run("WithCodecFactory_sets_custom", func(t *testing.T) {
+		rt := newTestRT(runtime.NewScheme())
+		cf := serializer.NewCodecFactory(runtime.NewScheme())
+		WithCodecFactory(cf)(rt)
+		if !rt.useCustomCodec {
+			t.Error("useCustomCodec should be true after WithCodecFactory")
+		}
+	})
+}
+
+// ---- groupsToKindFromScheme tests ----
+
+func TestGroupsToKindFromScheme(t *testing.T) {
+	scheme := makeFilterTestScheme(t)
+
+	gkWidget := gvkWidgetV1.GroupKind()
+	gkWidget2 := gvkWidget2V1.GroupKind()
+	gkGadget := gvkGadgetV1.GroupKind()
+
+	cases := []struct {
+		name          string
+		apply         func(*RoundTripTest)
+		expectIn      map[string][]schema.GroupKind // group → kinds that must be present
+		expectAbsent  map[string][]schema.GroupKind // group → kinds that must be absent
+		expectNoGroup []string                      // groups that must not appear at all
+	}{
+		{
+			name:  "no filter returns all non-List non-ignored kinds",
+			apply: func(*RoundTripTest) {},
+			expectIn: map[string][]schema.GroupKind{
+				"a.io": {gkWidget, gkWidget2},
+				"b.io": {gkGadget},
+			},
+			// List-suffix and defaultIgnoredKinds must never appear
+			expectAbsent: map[string][]schema.GroupKind{
+				"a.io": {gvkWidgetListV1.GroupKind(), gvkDeleteV1.GroupKind()},
+			},
+		},
+		{
+			name:  "ExcludeGroups removes entire group",
+			apply: func(rt *RoundTripTest) { WithExcludeGroups("a.io")(rt) },
+			expectIn: map[string][]schema.GroupKind{
+				"b.io": {gkGadget},
+			},
+			expectNoGroup: []string{"a.io"},
+		},
+		{
+			name: "ExcludeGroupKinds removes specific kind within group",
+			apply: func(rt *RoundTripTest) {
+				WithExcludeGroupKinds(gkWidget)(rt)
+			},
+			expectIn: map[string][]schema.GroupKind{
+				"a.io": {gkWidget2},
+				"b.io": {gkGadget},
+			},
+			expectAbsent: map[string][]schema.GroupKind{
+				"a.io": {gkWidget},
+			},
+		},
+		{
+			name:  "IncludeGroups restricts to listed group only",
+			apply: func(rt *RoundTripTest) { WithIncludeGroups("b.io")(rt) },
+			expectIn: map[string][]schema.GroupKind{
+				"b.io": {gkGadget},
+			},
+			expectNoGroup: []string{"a.io"},
+		},
+		{
+			name: "IncludeGroupKinds restricts to listed kind only",
+			apply: func(rt *RoundTripTest) {
+				WithIncludeGroupKinds(gkWidget)(rt)
+			},
+			expectIn: map[string][]schema.GroupKind{
+				"a.io": {gkWidget},
+			},
+			expectAbsent: map[string][]schema.GroupKind{
+				"a.io": {gkWidget2},
+			},
+			expectNoGroup: []string{"b.io"},
+		},
+		{
+			name: "IncludeGroups with ExcludeGroupKinds",
+			apply: func(rt *RoundTripTest) {
+				WithIncludeGroups("a.io")(rt)
+				WithExcludeGroupKinds(gkWidget)(rt)
+			},
+			expectIn: map[string][]schema.GroupKind{
+				"a.io": {gkWidget2},
+			},
+			expectAbsent: map[string][]schema.GroupKind{
+				"a.io": {gkWidget},
+			},
+			expectNoGroup: []string{"b.io"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newTestRT(scheme)
+			tc.apply(rt)
+			result := rt.groupsToKindFromScheme()
+
+			for group, kinds := range tc.expectIn {
+				gks, ok := result[group]
+				if !ok {
+					t.Errorf("group %q missing from result", group)
+					continue
+				}
+				for _, gk := range kinds {
+					if !gks.Has(gk) {
+						t.Errorf("group %q missing expected kind %q", group, gk.Kind)
+					}
+				}
+			}
+
+			for group, kinds := range tc.expectAbsent {
+				gks, ok := result[group]
+				if !ok {
+					continue // group absent → kinds absent trivially
+				}
+				for _, gk := range kinds {
+					if gks.Has(gk) {
+						t.Errorf("group %q unexpectedly contains kind %q", group, gk.Kind)
+					}
+				}
+			}
+
+			for _, group := range tc.expectNoGroup {
+				if _, ok := result[group]; ok {
+					t.Errorf("group %q should not appear in result", group)
+				}
+			}
+		})
+	}
+}
+
+// ---- nonRoundTrippableTypes tests ----
+
+func TestNonRoundTrippableTypes(t *testing.T) {
+	scheme := makeFilterTestScheme(t)
+
+	t.Run("no filter returns nil", func(t *testing.T) {
+		rt := newTestRT(scheme)
+		if got := rt.nonRoundTrippableTypes(); got != nil {
+			t.Errorf("expected nil with no filters, got %v", got)
+		}
+	})
+
+	t.Run("ExcludeGroups marks excluded GVKs as non-round-trippable", func(t *testing.T) {
+		rt := newTestRT(scheme)
+		WithExcludeGroups("a.io")(rt)
+		nrt := rt.nonRoundTrippableTypes()
+
+		// External-version Widget in excluded group must be non-round-trippable.
+		if !nrt[gvkWidgetV1] {
+			t.Errorf("expected %v to be non-round-trippable", gvkWidgetV1)
+		}
+		// Gadget in the allowed group must NOT be non-round-trippable.
+		if nrt[gvkGadgetV1] {
+			t.Errorf("expected %v to be round-trippable", gvkGadgetV1)
+		}
+		// Internal-version Widget must not appear (internal versions are skipped).
+		if nrt[gvkWidgetInternal] {
+			t.Errorf("internal-version GVK %v must not appear in nonRoundTrippableTypes", gvkWidgetInternal)
+		}
+	})
+
+	t.Run("IncludeGroups marks non-included GVKs as non-round-trippable", func(t *testing.T) {
+		rt := newTestRT(scheme)
+		WithIncludeGroups("b.io")(rt)
+		nrt := rt.nonRoundTrippableTypes()
+
+		if !nrt[gvkWidgetV1] {
+			t.Errorf("expected %v (excluded by include filter) to be non-round-trippable", gvkWidgetV1)
+		}
+		if nrt[gvkGadgetV1] {
+			t.Errorf("expected %v (in included group) to be round-trippable", gvkGadgetV1)
+		}
+	})
+}
+
+// ---- getFillers tests ----
+
+func TestGetFillers(t *testing.T) {
+	s := runtime.NewScheme()
+	cf := serializer.NewCodecFactory(s)
+
+	iters5, iters10 := 5, 10
+
+	rt := newTestRT(s)
+	rt.codecFactory = cf
+	rt.fuzzerConfigs = []fuzzerOptions{
+		{FuzzIterations: &iters5},
+		{}, // nil FuzzIterations → default
+		{FuzzIterations: &iters10},
+	}
+
+	t.Run("returns one filler per config", func(t *testing.T) {
+		fillers := rt.getFillers(false)
+		if len(fillers) != 3 {
+			t.Fatalf("expected 3 fillers, got %d", len(fillers))
+		}
+	})
+
+	t.Run("custom iteration count is honoured", func(t *testing.T) {
+		fillers := rt.getFillers(false)
+		if fillers[0].iterations != iters5 {
+			t.Errorf("expected %d, got %d", iters5, fillers[0].iterations)
+		}
+		if fillers[2].iterations != iters10 {
+			t.Errorf("expected %d, got %d", iters10, fillers[2].iterations)
+		}
+	})
+
+	t.Run("nil FuzzIterations uses default", func(t *testing.T) {
+		fillers := rt.getFillers(false)
+		if fillers[1].iterations != defaultFuzzIterations {
+			t.Errorf("expected defaultFuzzIterations (%d), got %d",
+				defaultFuzzIterations, fillers[1].iterations)
+		}
+	})
+
+	t.Run("cluster-scoped filler zeroes Namespace", func(t *testing.T) {
+		fillers := rt.getFillers(false)
+		var meta metav1.ObjectMeta
+		fillers[0].filler.Fill(&meta)
+		if meta.Namespace != "" {
+			t.Errorf("cluster-scoped filler produced non-empty Namespace: %q", meta.Namespace)
+		}
+	})
+
+	t.Run("namespaced filler produces non-empty Namespace in most runs", func(t *testing.T) {
+		fillers := rt.getFillers(true)
+		sawNonEmpty := false
+		for range 50 {
+			var meta metav1.ObjectMeta
+			fillers[0].filler.Fill(&meta)
+			if meta.Namespace != "" {
+				sawNonEmpty = true
+				break
+			}
+		}
+		if !sawNonEmpty {
+			t.Error("namespaced filler never produced non-empty Namespace in 50 runs")
+		}
+	})
+}
+
+// ---- spokeHubSpoke / hubSpokeHub tests ----
+
+// makeConversionTestRT builds a RoundTripTest with hub (v1) and spoke (v2alpha1)
+// registered in the scheme, ready for spokeHubSpoke and hubSpokeHub calls.
+func makeConversionTestRT(t *testing.T) (*RoundTripTest, schema.GroupVersionKind, schema.GroupVersionKind) {
+	t.Helper()
+
+	hubGVK := schema.GroupVersionKind{Group: "rt.test.io", Version: "v1", Kind: "TestObj"}
+	spokeGVK := schema.GroupVersionKind{Group: "rt.test.io", Version: "v2alpha1", Kind: "TestObj"}
+
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(hubGVK, &hubObject{})
+	s.AddKnownTypeWithName(spokeGVK, &spokeObject{})
+
+	src := rand.NewSource(99)
+	iters := 10
+
+	rt := newTestRT(s)
+	rt.codecFactory = serializer.NewCodecFactory(s)
+	rt.fuzzerConfigs = []fuzzerOptions{{
+		FuzzIterations: &iters,
+		RandSource:     src,
+	}}
+
+	return rt, hubGVK, spokeGVK
+}
+
+func TestSpokeHubSpoke(t *testing.T) {
+	rt, hubGVK, spokeGVK := makeConversionTestRT(t)
+	fillers := rt.getFillers(false)
+	rt.spokeHubSpoke(t, hubGVK, spokeGVK, fillers)
+}
+
+func TestHubSpokeHub(t *testing.T) {
+	rt, hubGVK, spokeGVK := makeConversionTestRT(t)
+	fillers := rt.getFillers(false)
+	rt.hubSpokeHub(t, hubGVK, spokeGVK, fillers)
+}

--- a/pkg/apitesting/roundtrip/roundtrip_test.go
+++ b/pkg/apitesting/roundtrip/roundtrip_test.go
@@ -198,7 +198,7 @@ func TestFuzzerOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("FuzzerSkipPatterns_append", func(t *testing.T) {
+	t.Run("FuzzerSkipPatternsAppend", func(t *testing.T) {
 		p1 := regexp.MustCompile("^a")
 		p2 := regexp.MustCompile("^b")
 		opts := fuzzerOptions{}
@@ -209,7 +209,7 @@ func TestFuzzerOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("FuzzerAllowUnexportedFields_true", func(t *testing.T) {
+	t.Run("FuzzerAllowUnexportedFieldsTrue", func(t *testing.T) {
 		opts := fuzzerOptions{}
 		FuzzerAllowUnexportedFields(true)(&opts)
 		if opts.AllowUnexportedFields == nil || !*opts.AllowUnexportedFields {
@@ -217,7 +217,7 @@ func TestFuzzerOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("FuzzerAllowUnexportedFields_false", func(t *testing.T) {
+	t.Run("FuzzerAllowUnexportedFieldsFalse", func(t *testing.T) {
 		opts := fuzzerOptions{}
 		FuzzerAllowUnexportedFields(false)(&opts)
 		if opts.AllowUnexportedFields == nil || *opts.AllowUnexportedFields {
@@ -229,7 +229,7 @@ func TestFuzzerOptions(t *testing.T) {
 // ---- TestOption unit tests ----
 
 func TestTestOptions(t *testing.T) {
-	t.Run("WithFuzzerConfig_appends", func(t *testing.T) {
+	t.Run("WithFuzzerConfigAppends", func(t *testing.T) {
 		rt := newTestRT(runtime.NewScheme())
 		n := 7
 		WithFuzzerConfig(FuzzerIterations(n))(rt)
@@ -283,7 +283,7 @@ func TestTestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("WithComparisonOptions_appends", func(t *testing.T) {
+	t.Run("WithComparisonOptionsAppends", func(t *testing.T) {
 		rt := newTestRT(runtime.NewScheme())
 		before := len(rt.cmpOpts)
 		WithComparisonOptions(EquateEmptyAndSingleZeroSlice())(rt)
@@ -292,7 +292,7 @@ func TestTestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("WithExtraFuzzFuncs_appends", func(t *testing.T) {
+	t.Run("WithExtraFuzzFuncsAppends", func(t *testing.T) {
 		rt := newTestRT(runtime.NewScheme())
 		fn := func() {}
 		WithExtraFuzzFuncs(fn)(rt)
@@ -301,7 +301,7 @@ func TestTestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("WithCodecFactory_sets_custom", func(t *testing.T) {
+	t.Run("WithCodecFactorySetsCustom", func(t *testing.T) {
 		rt := newTestRT(runtime.NewScheme())
 		cf := serializer.NewCodecFactory(runtime.NewScheme())
 		WithCodecFactory(cf)(rt)
@@ -534,17 +534,10 @@ func TestGetFillers(t *testing.T) {
 
 	t.Run("namespaced filler produces non-empty Namespace in most runs", func(t *testing.T) {
 		fillers := rt.getFillers(true)
-		sawNonEmpty := false
-		for range 50 {
-			var meta metav1.ObjectMeta
-			fillers[0].filler.Fill(&meta)
-			if meta.Namespace != "" {
-				sawNonEmpty = true
-				break
-			}
-		}
-		if !sawNonEmpty {
-			t.Error("namespaced filler never produced non-empty Namespace in 50 runs")
+		var meta metav1.ObjectMeta
+		fillers[0].filler.Fill(&meta)
+		if meta.Namespace == "" {
+			t.Error("namespaced filler produced empty Namespace")
 		}
 	})
 }


### PR DESCRIPTION
### Description of your changes

This PR introduces `pkg/apitesting/roundtrip`, a reusable testing utility library, that providers built on upjet
can drop into their test suites to automatically verify the roundtrip correctness of their generated API types.

Similar to the approach in the Kubernetes ecosystem, the library utilizes fuzz-based round-trip testing: generate
randomly filled objects and assert they survive the full encode/decode or conversion cycle unchanged.
This library extracts that common boilerplate into a single, maintained place so providers can opt in with minimal setup.

Two categories of invariants are covered:

- **Serialization** — every registered API type can be JSON-encoded and decoded back to an identical object. This catches incorrect field types, and other schema mismatches that would cause silent data loss when Kubernetes stores or returns a resource.
- **Version conversion** — every multi-version type survives a full hub↔spoke round trip (`spoke → hub → spoke` and `hub → spoke → hub`) with no data loss.
- This ensures that upjet's generated conversion functions faithfully preserve all fields across API versions.

Note: The tests focus on the serialization/conversion machinery aspect.
The test data is fuzz-based and does not focus on "semantically valid" API objects of the corresponding external provider API.  

### How it works

**Serialization test**

This test utilizes upstream k8s "k8s.io/apimachinery/pkg/api/apitesting/roundtrip" for serialization tests.

1. Discover all API types registered in the scheme (respecting include/exclude filters).
2. For each type, generate a randomly filled instance using the fuzzer.
3. Encode the object to JSON and decode it back into a new instance.
4. Assert the two instances are equal.

**Conversion test**

1. Discover all API groups and GroupKinds registered in the scheme.
2. For each GroupKind with more than one version, identify which version is the hub and which are spokes (based on the `conversion.Hub` / `conversion.Convertible` interfaces).
   - Skips `GroupKind`s with one available version
3. For every hub↔spoke pair, run two sub-tests:
   - **spoke → hub → spoke**: fill a spoke object, convert to hub, convert back to a new spoke, compare.
   - **hub → spoke → hub**: fill a hub object, convert to spoke, convert back to a new hub, compare.
4. Each sub-test repeats the cycle N times with freshly fuzzed/randomized data (configurable, default 5 iterations).
5. Assert the final object is identical to the original using `go-cmp` with any registered comparison options.


### Wiring at providers

Provider wires the library once in a test file, supplying the upjet provider object and a runtime scheme with types registered:
The test runner discovers all types and API versions registered in the scheme automatically — no per-resource configuration is needed.
Optionally, some test behavior can be customized. See `Customization` section.
```go
func TestRoundTrip(t *testing.T) {
	// 
    provider, _ := config.GetProvider(t.Context(), schema, false)
	providerNamespaced := config.GetProviderNamespaced(t.Context(), schema, false)

    testScheme := runtime.NewScheme()
    clusterapis.AddToScheme(testScheme)
	namespacedapis.AddToScheme(testScheme)

    rt, _ := roundtrip.NewRoundTripTest(provider, providerNamespaced, testScheme
	// ... customization options 
	)
    t.Run("Serialization", rt.TestSerializationRoundtrip)
    t.Run("Conversion",    rt.TestConversionRoundtrip)
}
```


### Customisation

When provider-specific quirks require it, the library exposes options to tune behavior without modifying shared code:

- **API Filtering** — include or exclude specific API groups or GroupKinds from testing.
- **Fuzzer tuning** — configure nil probability, slice sizes, iteration count, or register custom fill functions for fields that must match a specific value domain (e.g. enum strings).
- **Multiple fuzzer passes** — register several fuzzer configurations that run in sequence, e.g. one dense pass and one sparse pass, to improve coverage.
- **Comparison options** — plug in `go-cmp` options to handle known legitimate asymmetries in conversions

### Changes

- New package `pkg/apitesting/roundtrip` with three files:
  - `roundtrip.go` — core test runner, options, and parallelism-safe sub-test structure
  - `fuzzer.go` — Fuzzer helpers
  - `cmp.go` — k8s object comparison helpers
- Documentation added under `docs/api-roundtrip-testing.md`.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
