### PR TITLE
Set AsyncOperationInProgress in async Observe paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,3 +146,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )
+
+replace github.com/crossplane/crossplane-runtime/v2 => github.com/ajnye/crossplane-runtime/v2 v2.2.1-0.20260429154540-465317a68bee

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/ajnye/crossplane-runtime/v2 v2.2.1-0.20260429154540-465317a68bee h1:6Wp0RzkQQGKWCw89AbWHDWN/9HoF+ONUOv318FR4sQU=
+github.com/ajnye/crossplane-runtime/v2 v2.2.1-0.20260429154540-465317a68bee/go.mod h1:8I+x4w5bG4x8aO8ifF/QC8GZoNCN6v21NHzgoYPNYAQ=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/kong v0.2.16/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
@@ -37,8 +39,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime/v2 v2.2.0 h1:jLoQm9D5buk9lBqwRtQ40ueaFotjOljJATq+24bVYI8=
-github.com/crossplane/crossplane-runtime/v2 v2.2.0/go.mod h1:8I+x4w5bG4x8aO8ifF/QC8GZoNCN6v21NHzgoYPNYAQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -224,8 +224,9 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 	case res.ASyncInProgress:
 		mg.SetConditions(resource.AsyncOperationOngoingCondition())
 		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
+			ResourceExists:           true,
+			ResourceUpToDate:         true,
+			AsyncOperationInProgress: true,
 		}, nil
 	case !res.Exists:
 		return managed.ExternalObservation{
@@ -474,8 +475,9 @@ func (e *external) Import(ctx context.Context, tr resource.Terraformed) (managed
 	if res.ASyncInProgress {
 		tr.SetConditions(resource.AsyncOperationOngoingCondition())
 		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
+			ResourceExists:           true,
+			ResourceUpToDate:         true,
+			AsyncOperationInProgress: true,
 		}, nil
 	}
 	// If the resource doesn't exist, we don't need to do anything else.

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -117,8 +117,9 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Observe(ctx context.Contex
 	if n.opTracker.LastOperation.IsRunning() {
 		n.logger.WithValues("opType", n.opTracker.LastOperation.Type).Debug("ongoing async operation")
 		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
+			ResourceExists:           true,
+			ResourceUpToDate:         true,
+			AsyncOperationInProgress: true,
 		}, nil
 	}
 

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -119,8 +119,9 @@ func (n *terraformPluginSDKAsyncExternal) Observe(ctx context.Context, mg xpreso
 	if n.opTracker.LastOperation.IsRunning() {
 		n.logger.WithValues("opType", n.opTracker.LastOperation.Type).Debug("ongoing async operation")
 		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
+			ResourceExists:           true,
+			ResourceUpToDate:         true,
+			AsyncOperationInProgress: true,
 		}, nil
 	}
 	n.opTracker.LastOperation.Clear(true)

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -189,10 +189,27 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 				},
 			},
 		},
+		"AsyncInProgress": {
+			args: args{
+				r:   mockResource{},
+				cfg: cfgAsync,
+				obj: objAsync,
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:           true,
+					ResourceUpToDate:         true,
+					AsyncOperationInProgress: true,
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, CallbackFns{})
+			if name == "AsyncInProgress" {
+				terraformPluginSDKAsyncExternal.opTracker.LastOperation.MarkStart("update")
+			}
 			observation, err := terraformPluginSDKAsyncExternal.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -273,8 +273,9 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists:   true,
-					ResourceUpToDate: true,
+					ResourceExists:           true,
+					ResourceUpToDate:         true,
+					AsyncOperationInProgress: true,
 				},
 			},
 		},
@@ -398,8 +399,9 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists:   true,
-					ResourceUpToDate: true,
+					ResourceExists:           true,
+					ResourceUpToDate:         true,
+					AsyncOperationInProgress: true,
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Set `AsyncOperationInProgress: true` in `ExternalObservation` at all four sites where upjet returns `ResourceUpToDate: true` during an async operation. This signals the managed reconciler (via the companion crossplane-runtime change) to set `Synced=False(ReconcilePending)` instead of the misleading `Synced=True(ReconcileSuccess)`.

### Changes

**`pkg/controller/external.go`** (2 sites):
- Main `Observe()` — `ASyncInProgress` switch branch
- `Import()` — ObserveOnly async path

**`pkg/controller/external_async_tfpluginsdk.go`** (1 site):
- `Observe()` — `opTracker.LastOperation.IsRunning()` branch

**`pkg/controller/external_async_tfpluginfw.go`** (1 site):
- `Observe()` — `opTracker.LastOperation.IsRunning()` branch

**Tests**:
- Updated `RefreshInProgress` and `ObserveOnlyAsyncInProgress` in `external_test.go` to assert `AsyncOperationInProgress: true`
- Added `AsyncInProgress` test case to `external_async_tfpluginsdk_test.go` — sets opTracker to running, asserts the field is returned
- Full test suite passes with no regressions

### Why

During long-running async operations (e.g. MSK cluster instance type changes taking 60+ minutes), upjet returns `ResourceUpToDate: true` to prevent the reconciler from calling `Update()`. This causes the reconciler to set `Synced=True(ReconcileSuccess)` on every reconcile pass — a false positive that suppresses alerts and misleads automation polling `Synced` for convergence.

With this change, the reconciler will set `Synced=False(ReconcilePending)` during async operations, correctly reflecting that the resource has not yet reached its desired state. `Ready=True` is unaffected (the resource is still serving).

### Dependencies

Requires crossplane-runtime to have the `AsyncOperationInProgress` field and `ReconcilePending` condition:
- crossplane-runtime PR: https://github.com/crossplane/crossplane-runtime/pull/984
- crossplane PR (condition types): https://github.com/crossplane/crossplane/pull/7352

### Related

- Issue: https://github.com/crossplane/upjet/issues/609
- crossplane-runtime issue: https://github.com/crossplane/crossplane-runtime/issues/941