### PR TITLE
Check for previous null values in filtered diffs

### DIFF
--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -357,10 +357,20 @@ func (c *TerraformPluginFrameworkConnector) getResourceConfigTerraformValue(ctx 
 // when only computed attributes or not-specified argument diffs
 // exist in the raw diff and no actual diff exists in the
 // parametrizable attributes.
+// Exception: a diff where the prior value (Value2) is non-null and the
+// planned value (Value1) is null represents an explicit removal of a
+// previously-set optional attribute and must not be filtered.
 func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(rawDiff []tftypes.ValueDiff) bool {
 	filteredDiff := make([]tftypes.ValueDiff, 0)
 	for _, diff := range rawDiff {
+		// Keep diffs where the planned value is non-null and known.
 		if diff.Value1 != nil && diff.Value1.IsKnown() && !diff.Value1.IsNull() {
+			filteredDiff = append(filteredDiff, diff)
+			continue
+		}
+		// Keep diffs where the prior value was non-null and the planned value
+		// is null — this is an explicit removal of a previously-set attribute.
+		if diff.Value1 != nil && diff.Value1.IsNull() && diff.Value2 != nil && !diff.Value2.IsNull() {
 			filteredDiff = append(filteredDiff, diff)
 		}
 	}

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -357,10 +357,13 @@ func (c *TerraformPluginFrameworkConnector) getResourceConfigTerraformValue(ctx 
 // when only computed attributes or not-specified argument diffs
 // exist in the raw diff and no actual diff exists in the
 // parametrizable attributes.
-// Exception: a diff where the prior value (Value2) is non-null and the
-// planned value (Value1) is null represents an explicit removal of a
-// previously-set optional attribute and must not be filtered.
-func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(rawDiff []tftypes.ValueDiff) bool {
+// Exceptions:
+//   - A diff where the prior value (Value2) is non-null and the
+//     planned value (Value1) is null, and the diff does not belong to
+//     an attribute which is computed-only or one of its ancestors is
+//     computed-only. Such a case is taken as a previously set value being
+//     unset and is thus, not filtered.
+func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(ctx context.Context, rawDiff []tftypes.ValueDiff) bool {
 	filteredDiff := make([]tftypes.ValueDiff, 0)
 	for _, diff := range rawDiff {
 		// Keep diffs where the planned value is non-null and known.
@@ -368,13 +371,37 @@ func (n *terraformPluginFrameworkExternalClient) filteredDiffExists(rawDiff []tf
 			filteredDiff = append(filteredDiff, diff)
 			continue
 		}
-		// Keep diffs where the prior value was non-null and the planned value
-		// is null — this is an explicit removal of a previously-set attribute.
-		if diff.Value1 != nil && diff.Value1.IsNull() && diff.Value2 != nil && !diff.Value2.IsNull() {
-			filteredDiff = append(filteredDiff, diff)
+		// Check if a previously set value is now unset. If not,
+		// then it will be filtered out at this stage.
+		if diff.Value1 == nil || !diff.Value1.IsNull() || diff.Value2 == nil || diff.Value2.IsNull() {
+			continue
 		}
+		// Check if the attribute at diff path is computed-only, or
+		// if one of its ancestors is computed-only. If so, the diff
+		// will be filtered out at this stage.
+		if n.isUnderComputedOnlyAttribute(ctx, diff.Path) {
+			continue
+		}
+		filteredDiff = append(filteredDiff, diff)
 	}
 	return len(filteredDiff) > 0
+}
+
+// isUnderComputedOnlyAttribute returns true if the attribute itself or
+// one of its ancestors is computed-only.
+func (n *terraformPluginFrameworkExternalClient) isUnderComputedOnlyAttribute(ctx context.Context, p *tftypes.AttributePath) bool {
+	for cur := p; cur != nil && len(cur.Steps()) > 0; cur = cur.WithoutLastStep() {
+		attr, err := n.resourceSchema.AttributeAtTerraformPath(ctx, cur)
+		if err != nil || attr == nil {
+			// Not an attribute, a block or an attribute without a schema, etc.
+			// Continue with its parent.
+			continue
+		}
+		if attr.IsComputed() && !attr.IsOptional() {
+			return true
+		}
+	}
+	return false
 }
 
 // getDiffPlanResponse calls the underlying native TF provider's PlanResourceChange RPC,
@@ -428,7 +455,7 @@ func (n *terraformPluginFrameworkExternalClient) getDiffPlanResponse(ctx context
 		n.plannedIdentity = planResponse.PlannedIdentity
 	}
 
-	return planResponse, n.filteredDiffExists(rawDiff), nil
+	return planResponse, n.filteredDiffExists(ctx, rawDiff), nil
 }
 
 // filterRequiresReplace checks the TF plan response for fields that require/force resource

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -1343,8 +1343,8 @@ func TestFilteredDiffExists(t *testing.T) {
 		"NestedObjectRemoval": {
 			rawDiff: []tftypes.ValueDiff{
 				{Value1: nil, Value2: strVal("ClusterIP")}, // child attr, Value1 nil
-				{Value1: nil, Value2: strVal("Cluster")},  // child attr, Value1 nil
-				{Value1: nullVal(), Value2: strVal("3")},  // parent object null → removal
+				{Value1: nil, Value2: strVal("Cluster")},   // child attr, Value1 nil
+				{Value1: nullVal(), Value2: strVal("3")},   // parent object null → removal
 			},
 			want: true,
 		},

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -1272,3 +1272,91 @@ func newMockTPFResourceWithIdentity() *mockTPFResourceWithIdentity {
 		},
 	}
 }
+
+func TestFilteredDiffExists(t *testing.T) {
+	strVal := func(s string) *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, s)
+		return &v
+	}
+	nullVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, nil)
+		return &v
+	}
+	unknownVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+		return &v
+	}
+
+	cases := map[string]struct {
+		rawDiff []tftypes.ValueDiff
+		want    bool
+	}{
+		"EmptyDiff": {
+			rawDiff: []tftypes.ValueDiff{},
+			want:    false,
+		},
+		"PlannedNonNullPriorNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: strVal("foo"), Value2: nullVal()},
+			},
+			want: true,
+		},
+		"PlannedNonNullPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: strVal("new"), Value2: strVal("old")},
+			},
+			want: true,
+		},
+		// Explicit removal: prior was set, planned is null. The fix ensures
+		// this is not filtered out.
+		"PlannedNullPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nullVal(), Value2: strVal("foo")},
+			},
+			want: true,
+		},
+		// Field was never specified; both sides are null — no real diff.
+		"PlannedNullPriorNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nullVal(), Value2: nullVal()},
+			},
+			want: false,
+		},
+		// Value1 nil means the child attribute has no individual planned value
+		// (e.g. when its parent object is null). Should remain filtered.
+		"PlannedNilPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nil, Value2: strVal("foo")},
+			},
+			want: false,
+		},
+		// Unknown planned value corresponds to a computed field — filtered.
+		"PlannedUnknownPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: unknownVal(), Value2: strVal("foo")},
+			},
+			want: false,
+		},
+		// Simulates optional nested object removal: child attribute diffs have
+		// nil Value1, but the parent-level diff has null Value1 / non-null
+		// Value2 and must be detected.
+		"NestedObjectRemoval": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nil, Value2: strVal("ClusterIP")}, // child attr, Value1 nil
+				{Value1: nil, Value2: strVal("Cluster")},  // child attr, Value1 nil
+				{Value1: nullVal(), Value2: strVal("3")},  // parent object null → removal
+			},
+			want: true,
+		},
+	}
+
+	client := &terraformPluginFrameworkExternalClient{}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := client.filteredDiffExists(tc.rawDiff)
+			if got != tc.want {
+				t.Errorf("filteredDiffExists() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -1403,9 +1403,252 @@ func TestFilteredDiffExists(t *testing.T) {
 	client := &terraformPluginFrameworkExternalClient{}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := client.filteredDiffExists(tc.rawDiff)
+			got := client.filteredDiffExists(context.TODO(), tc.rawDiff)
 			if got != tc.want {
 				t.Errorf("filteredDiffExists() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// diffGatingSchema is a Terraform Plugin Framework resource schema that covers
+// the schema node kinds a reported diff path can point at: the computed-only
+// attributes and their descendants, the atomic collection attributes and their
+// elements, the nested attributes, the blocks and the dynamic attributes.
+func diffGatingSchema() rschema.Schema {
+	nested := map[string]rschema.Attribute{"x": rschema.StringAttribute{Optional: true}}
+	return rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"opt":              rschema.StringAttribute{Optional: true},
+			"opt_computed":     rschema.StringAttribute{Optional: true, Computed: true},
+			"computed_only":    rschema.StringAttribute{Computed: true},
+			"tags":             rschema.MapAttribute{Optional: true, ElementType: types.StringType},
+			"computed_tags":    rschema.MapAttribute{Computed: true, ElementType: types.StringType},
+			"opt_parent":       rschema.SingleNestedAttribute{Optional: true, Attributes: nested},
+			"computed_parent":  rschema.SingleNestedAttribute{Computed: true, Attributes: nested},
+			"opt_dynamic":      rschema.DynamicAttribute{Optional: true},
+			"computed_dynamic": rschema.DynamicAttribute{Computed: true},
+			// the add-on shape of the reported issue: an optional root with the
+			// computed children, so that the removal of the root is detectable
+			"add_ons": rschema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]rschema.Attribute{
+					"emissary": rschema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]rschema.Attribute{
+							"replicas": rschema.Int64Attribute{Optional: true, Computed: true},
+						},
+					},
+				},
+			},
+		},
+		Blocks: map[string]rschema.Block{
+			"settings": rschema.SingleNestedBlock{Attributes: nested},
+			"rules":    rschema.ListNestedBlock{NestedObject: rschema.NestedBlockObject{Attributes: nested}},
+		},
+	}
+}
+
+func TestFilteredDiffExistsComputedOnly(t *testing.T) {
+	strVal := func(s string) *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, s)
+		return &v
+	}
+	nullVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, nil)
+		return &v
+	}
+	unknownVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+		return &v
+	}
+	// removal reports a diff where the previously set value at the given path
+	// is now unset, i.e., the planned value is null and the prior value is not.
+	removal := func(p *tftypes.AttributePath) tftypes.ValueDiff {
+		return tftypes.ValueDiff{Path: p, Value1: nullVal(), Value2: strVal("prior")}
+	}
+	path := tftypes.NewAttributePath
+
+	cases := map[string]struct {
+		reason string
+		diff   tftypes.ValueDiff
+		want   bool
+	}{
+		"OptionalAttributeUnset": {
+			reason: "Unsetting an optional attribute is a diff.",
+			diff:   removal(path().WithAttributeName("opt")),
+			want:   true,
+		},
+		"OptionalComputedAttributeUnset": {
+			reason: "Unsetting an optional+computed attribute is a diff because it can be configured.",
+			diff:   removal(path().WithAttributeName("opt_computed")),
+			want:   true,
+		},
+		"ComputedOnlyAttributeUnset": {
+			reason: "A computed-only attribute cannot be unset via the MR spec, so a null planned value is not a diff.",
+			diff:   removal(path().WithAttributeName("computed_only")),
+			want:   false,
+		},
+		"ComputedOnlyAttributeChanged": {
+			reason: "A known and non-null planned value is a diff even for a computed-only attribute.",
+			diff:   tftypes.ValueDiff{Path: path().WithAttributeName("computed_only"), Value1: strVal("planned"), Value2: strVal("prior")},
+			want:   true,
+		},
+		"UnknownPlannedValue": {
+			reason: "An unknown planned value corresponds to a computed field and is not a diff.",
+			diff:   tftypes.ValueDiff{Path: path().WithAttributeName("opt"), Value1: unknownVal(), Value2: strVal("prior")},
+			want:   false,
+		},
+		"OptionalMapElementUnset": {
+			reason: "The elements of an atomic collection attribute are resolved to the enclosing attribute, which is configurable here.",
+			diff:   removal(path().WithAttributeName("tags").WithElementKeyString("env")),
+			want:   true,
+		},
+		"ComputedOnlyMapElementUnset": {
+			reason: "The elements of an atomic collection attribute are resolved to the enclosing attribute, which is computed-only here.",
+			diff:   removal(path().WithAttributeName("computed_tags").WithElementKeyString("env")),
+			want:   false,
+		},
+		"AttributeUnderOptionalParentUnset": {
+			reason: "A configurable attribute under a configurable parent can be unset.",
+			diff:   removal(path().WithAttributeName("opt_parent").WithAttributeName("x")),
+			want:   true,
+		},
+		"AttributeUnderComputedOnlyParentUnset": {
+			reason: "Terraform does not allow a computed-only attribute to be configured, so its descendants cannot be unset either.",
+			diff:   removal(path().WithAttributeName("computed_parent").WithAttributeName("x")),
+			want:   false,
+		},
+		"OptionalNestedAttributeUnset": {
+			reason: "Unsetting an optional nested attribute is a diff, which is the case reported for the add-ons.",
+			diff:   removal(path().WithAttributeName("add_ons").WithAttributeName("emissary")),
+			want:   true,
+		},
+		"ComputedChildOfOptionalNestedAttributeUnset": {
+			reason: "An optional+computed child of a configurable nested attribute can be configured, so unsetting it is a diff.",
+			diff:   removal(path().WithAttributeName("add_ons").WithAttributeName("emissary").WithAttributeName("replicas")),
+			want:   true,
+		},
+		"DynamicSubPathUnderOptionalUnset": {
+			reason: "A path under a dynamic attribute is resolved to the dynamic attribute itself, which is configurable here.",
+			diff:   removal(path().WithAttributeName("opt_dynamic").WithAttributeName("foo")),
+			want:   true,
+		},
+		"DynamicSubPathUnderComputedOnlyUnset": {
+			reason: "A path under a dynamic attribute is resolved to the dynamic attribute itself, which is computed-only here.",
+			diff:   removal(path().WithAttributeName("computed_dynamic").WithAttributeName("foo")),
+			want:   false,
+		},
+		"BlockUnset": {
+			reason: "A block is always configurable, so unsetting it is a diff.",
+			diff:   removal(path().WithAttributeName("settings")),
+			want:   true,
+		},
+		"BlockElementUnset": {
+			reason: "A block element does not resolve to an attribute and the diff is preserved.",
+			diff:   removal(path().WithAttributeName("rules").WithElementKeyInt(0)),
+			want:   true,
+		},
+		"RootPathUnset": {
+			reason: "The root path does not resolve to an attribute and the diff is preserved.",
+			diff:   removal(path()),
+			want:   true,
+		},
+	}
+
+	n := &terraformPluginFrameworkExternalClient{resourceSchema: diffGatingSchema()}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := n.filteredDiffExists(context.TODO(), []tftypes.ValueDiff{tc.diff})
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("%s\nfilteredDiffExists(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// TestFilteredDiffExistsNestedAttributeRemoval reproduces the reported
+// scenario, where an optional nested attribute with the computed children is
+// removed from the MR spec, on the raw diff computed by Terraform itself. The
+// child attributes of the removed object have no planned values at all, so only
+// the diff reported for the removed object carries the null planned value.
+func TestFilteredDiffExistsNestedAttributeRemoval(t *testing.T) {
+	ctx := context.TODO()
+	// addOnsSchema returns a resource schema with an "add_ons.emissary" nested
+	// attribute whose children are computed. The emissary attribute itself is
+	// either configurable or computed-only.
+	addOnsSchema := func(emissaryComputedOnly bool) rschema.Schema {
+		emissary := rschema.SingleNestedAttribute{
+			Optional: true,
+			Attributes: map[string]rschema.Attribute{
+				"replicas":     rschema.Int64Attribute{Optional: true, Computed: true},
+				"service_type": rschema.StringAttribute{Optional: true, Computed: true},
+			},
+		}
+		if emissaryComputedOnly {
+			emissary.Optional = false
+			emissary.Computed = true
+		}
+		return rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"add_ons": rschema.SingleNestedAttribute{
+					Optional:   true,
+					Attributes: map[string]rschema.Attribute{"emissary": emissary},
+				},
+			},
+		}
+	}
+
+	cases := map[string]struct {
+		reason string
+		sch    rschema.Schema
+		want   bool
+	}{
+		"ConfigurableAddOnRemoved": {
+			reason: "Removing a configurable nested attribute must be reported as a diff so that an update is issued.",
+			sch:    addOnsSchema(false),
+			want:   true,
+		},
+		"ComputedOnlyAddOnRemoved": {
+			reason: "A computed-only nested attribute cannot be removed via the MR spec, so the raw diff of the provider is filtered.",
+			sch:    addOnsSchema(true),
+			want:   false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			resourceType, ok := tc.sch.Type().TerraformType(ctx).(tftypes.Object)
+			if !ok {
+				t.Fatalf("%s\nresource schema type is not a tftypes.Object", tc.reason)
+			}
+			addOnsType := resourceType.AttributeTypes["add_ons"].(tftypes.Object)  //nolint:forcetypeassert // the type is known from the schema above
+			emissaryType := addOnsType.AttributeTypes["emissary"].(tftypes.Object) //nolint:forcetypeassert // the type is known from the schema above
+			addOns := func(emissary tftypes.Value) tftypes.Value {
+				return tftypes.NewValue(resourceType, map[string]tftypes.Value{
+					"add_ons": tftypes.NewValue(addOnsType, map[string]tftypes.Value{"emissary": emissary}),
+				})
+			}
+			// the external resource has the add-on configured
+			prior := addOns(tftypes.NewValue(emissaryType, map[string]tftypes.Value{
+				"replicas":     tftypes.NewValue(tftypes.Number, 3),
+				"service_type": tftypes.NewValue(tftypes.String, "ClusterIP"),
+			}))
+			// the add-on has been removed from the MR spec
+			planned := addOns(tftypes.NewValue(emissaryType, nil))
+
+			rawDiff, err := planned.Diff(prior)
+			if err != nil {
+				t.Fatalf("%s\ncannot diff the planned and the prior values: %v", tc.reason, err)
+			}
+			if len(rawDiff) == 0 {
+				t.Fatalf("%s\nexpected a non-empty raw diff for the removed add-on", tc.reason)
+			}
+
+			n := &terraformPluginFrameworkExternalClient{resourceSchema: tc.sch}
+			got := n.filteredDiffExists(ctx, rawDiff)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("%s\nfilteredDiffExists(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -1322,3 +1322,91 @@ func newMockTPFResourceWithIdentity() *mockTPFResourceWithIdentity {
 		},
 	}
 }
+
+func TestFilteredDiffExists(t *testing.T) {
+	strVal := func(s string) *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, s)
+		return &v
+	}
+	nullVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, nil)
+		return &v
+	}
+	unknownVal := func() *tftypes.Value {
+		v := tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+		return &v
+	}
+
+	cases := map[string]struct {
+		rawDiff []tftypes.ValueDiff
+		want    bool
+	}{
+		"EmptyDiff": {
+			rawDiff: []tftypes.ValueDiff{},
+			want:    false,
+		},
+		"PlannedNonNullPriorNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: strVal("foo"), Value2: nullVal()},
+			},
+			want: true,
+		},
+		"PlannedNonNullPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: strVal("new"), Value2: strVal("old")},
+			},
+			want: true,
+		},
+		// Explicit removal: prior was set, planned is null. The fix ensures
+		// this is not filtered out.
+		"PlannedNullPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nullVal(), Value2: strVal("foo")},
+			},
+			want: true,
+		},
+		// Field was never specified; both sides are null — no real diff.
+		"PlannedNullPriorNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nullVal(), Value2: nullVal()},
+			},
+			want: false,
+		},
+		// Value1 nil means the child attribute has no individual planned value
+		// (e.g. when its parent object is null). Should remain filtered.
+		"PlannedNilPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nil, Value2: strVal("foo")},
+			},
+			want: false,
+		},
+		// Unknown planned value corresponds to a computed field — filtered.
+		"PlannedUnknownPriorNonNull": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: unknownVal(), Value2: strVal("foo")},
+			},
+			want: false,
+		},
+		// Simulates optional nested object removal: child attribute diffs have
+		// nil Value1, but the parent-level diff has null Value1 / non-null
+		// Value2 and must be detected.
+		"NestedObjectRemoval": {
+			rawDiff: []tftypes.ValueDiff{
+				{Value1: nil, Value2: strVal("ClusterIP")}, // child attr, Value1 nil
+				{Value1: nil, Value2: strVal("Cluster")},  // child attr, Value1 nil
+				{Value1: nullVal(), Value2: strVal("3")},  // parent object null → removal
+			},
+			want: true,
+		},
+	}
+
+	client := &terraformPluginFrameworkExternalClient{}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := client.filteredDiffExists(tc.rawDiff)
+			if got != tc.want {
+				t.Errorf("filteredDiffExists() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -1393,8 +1393,8 @@ func TestFilteredDiffExists(t *testing.T) {
 		"NestedObjectRemoval": {
 			rawDiff: []tftypes.ValueDiff{
 				{Value1: nil, Value2: strVal("ClusterIP")}, // child attr, Value1 nil
-				{Value1: nil, Value2: strVal("Cluster")},  // child attr, Value1 nil
-				{Value1: nullVal(), Value2: strVal("3")},  // parent object null → removal
+				{Value1: nil, Value2: strVal("Cluster")},   // child attr, Value1 nil
+				{Value1: nullVal(), Value2: strVal("3")},   // parent object null → removal
 			},
 			want: true,
 		},


### PR DESCRIPTION
### Description of your changes

## Summary

`filteredDiffExists` in `pkg/controller/external_tfpluginfw.go` discarded any
diff where the planned value (`Value1`) was null, on the assumption that a null
planned value means "field was never specified." This is correct for fields that
were never set, but it is wrong for Optional non-Computed attributes that a
user explicitly removes: the prior state is non-null, the planned state is null,
and that transition is a real diff that must trigger an Update.

for example: 

1. User removes a nested attribute from their Claim
2. Composition patches null attribute to the MR's spec.forProvider
3. Upjet computes proposed state attribute = null (correct)
4. Upjet sends proposed state to TF provider's PlanResourceChange
5. TF provider returns planned state with attribute = null (correct)
6. Upjet diffs planned state vs prior state: Value1 (planned) = null, Value2 (prior) = non-null
7. filteredDiffExists filters out the diff because Value1 is null
8. Upjet concludes no diff exists — no Update is triggered
9. Block remains on the cluster

The result was that removing an optional nested attribute through a Crossplane
claim had no effect — Upjet concluded the resource was up-to-date and never
called the provider's Update RPC.

## Fix

Add a second keep-condition to the filter: retain a diff when the planned value
(`Value1`) is null **and** the prior value (`Value2`) is non-null. This is the
unambiguous signature of an explicit removal.

The existing behavior is preserved for all other cases:
- `Value1` nil (child attributes of a null parent object) → still filtered
- `Value1` unknown (computed fields) → still filtered  
- Both values null (field never specified) → still filtered


Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added table-driven tests in `TestFilteredDiffExists` cover the core removal case,
the "never specified" case that must stay filtered, and the nested-object removal
scenario where child-attribute diffs have nil `Value1` but the parent-level diff
carries the null/non-null transition.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
