### PR TITLE
fix panic when null prior in proposedNewAttributes

### DIFF
--- a/pkg/controller/proposed_state.go
+++ b/pkg/controller/proposed_state.go
@@ -490,7 +490,9 @@ func proposedNewAttributes(attrs map[string]rschema.Attribute, prior, config tft
 	for name, attr := range attrs {
 		var priorV tftypes.Value
 		if prior.IsNull() {
-			priorV = tftypes.NewValue(priorMap[name].Type(), nil)
+			// prior.As silently fails on null values, leaving priorMap empty.
+			// Derive the null value's type from the schema instead of priorMap.
+			priorV = tftypes.NewValue(attr.GetType().TerraformType(context.TODO()), nil)
 		} else {
 			priorV = priorMap[name]
 		}

--- a/pkg/controller/proposed_state_test.go
+++ b/pkg/controller/proposed_state_test.go
@@ -7,65 +7,95 @@ package controller
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// TestProposedNewAttributes_NullPriorNestedAttribute is a regression test for a
-// panic that occurred when a SingleNestedAttribute's prior value was a typed
-// null (e.g. the TF provider returned null for an unset optional addon).
-//
-// proposedNewAttributes previously called priorMap[name].Type() where priorMap
-// was empty (prior.As silently fails on null), yielding a zero-value
-// tftypes.Value whose Type() returns nil, causing tftypes.NewValue to panic.
-func TestProposedNewAttributes_NullPriorNestedAttribute(t *testing.T) {
+func TestProposedNewAttributes(t *testing.T) {
 	addonAttrTypes := map[string]tftypes.Type{
 		"external_traffic_policy": tftypes.String,
 		"replicas":                tftypes.Number,
 	}
 	addonObjType := tftypes.Object{AttributeTypes: addonAttrTypes}
 	topObjType := tftypes.Object{
-		AttributeTypes: map[string]tftypes.Type{
-			"addon": addonObjType,
-		},
+		AttributeTypes: map[string]tftypes.Type{"addon": addonObjType},
 	}
-
 	schema := rschema.Schema{
 		Attributes: map[string]rschema.Attribute{
 			"addon": rschema.SingleNestedAttribute{
 				Optional: true,
 				Attributes: map[string]rschema.Attribute{
-					"external_traffic_policy": rschema.StringAttribute{
-						Optional: true,
-						Computed: true,
-					},
-					"replicas": rschema.NumberAttribute{
-						Optional: true,
-						Computed: true,
-					},
+					"external_traffic_policy": rschema.StringAttribute{Optional: true, Computed: true},
+					"replicas":                rschema.NumberAttribute{Optional: true, Computed: true},
 				},
 			},
 		},
 	}
 
-	// prior: resource exists, but addon attribute is a typed null (unset optional
-	// nested attribute as returned by a TF provider Read).
-	prior := tftypes.NewValue(topObjType, map[string]tftypes.Value{
-		"addon": tftypes.NewValue(addonObjType, nil),
-	})
+	type args struct {
+		prior  tftypes.Value
+		config tftypes.Value
+	}
+	type want struct {
+		result tftypes.Value
+	}
 
-	// config: user has now specified the addon.
-	config := tftypes.NewValue(topObjType, map[string]tftypes.Value{
-		"addon": tftypes.NewValue(addonObjType, map[string]tftypes.Value{
-			"external_traffic_policy": tftypes.NewValue(tftypes.String, nil),
-			"replicas":                tftypes.NewValue(tftypes.Number, nil),
-		}),
-	})
+	// cmp.Comparer via tftypes.Value.Equal handles unexported fields.
+	tfValueCmp := cmp.Comparer(func(a, b tftypes.Value) bool { return a.Equal(b) })
 
-	// Must not panic.
-	result := proposedState(schema, prior, config)
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NullPriorNestedAttributeWithNonNullConfig": {
+			reason: "Must not panic and must return a known non-null result when prior nested attribute is a typed null but config sets it.",
+			args: args{
+				prior: tftypes.NewValue(topObjType, map[string]tftypes.Value{
+					// Typed null: TF provider returned null for an unset optional addon.
+					"addon": tftypes.NewValue(addonObjType, nil),
+				}),
+				config: tftypes.NewValue(topObjType, map[string]tftypes.Value{
+					"addon": tftypes.NewValue(addonObjType, map[string]tftypes.Value{
+						"external_traffic_policy": tftypes.NewValue(tftypes.String, nil),
+						"replicas":                tftypes.NewValue(tftypes.Number, nil),
+					}),
+				}),
+			},
+			want: want{
+				// Optional+Computed children with null config keep prior value.
+				// Prior children are typed nulls derived from the schema (not priorMap).
+				result: tftypes.NewValue(topObjType, map[string]tftypes.Value{
+					"addon": tftypes.NewValue(addonObjType, map[string]tftypes.Value{
+						"external_traffic_policy": tftypes.NewValue(tftypes.String, nil),
+						"replicas":                tftypes.NewValue(tftypes.Number, nil),
+					}),
+				}),
+			},
+		},
+	}
 
-	if !result.IsKnown() || result.IsNull() {
-		t.Errorf("expected a known non-null result, got %s", result)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var result tftypes.Value
+			panicked := false
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						panicked = true
+					}
+				}()
+				result = proposedState(schema, tc.args.prior, tc.args.config)
+			}()
+
+			if panicked {
+				t.Errorf("\n%s\nproposedState(...): unexpected panic", tc.reason)
+				return
+			}
+			if diff := cmp.Diff(tc.want.result, result, tfValueCmp); diff != "" {
+				t.Errorf("\n%s\nproposedState(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }

--- a/pkg/controller/proposed_state_test.go
+++ b/pkg/controller/proposed_state_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestProposedNewAttributes_NullPriorNestedAttribute is a regression test for a
+// panic that occurred when a SingleNestedAttribute's prior value was a typed
+// null (e.g. the TF provider returned null for an unset optional addon).
+//
+// proposedNewAttributes previously called priorMap[name].Type() where priorMap
+// was empty (prior.As silently fails on null), yielding a zero-value
+// tftypes.Value whose Type() returns nil, causing tftypes.NewValue to panic.
+func TestProposedNewAttributes_NullPriorNestedAttribute(t *testing.T) {
+	addonAttrTypes := map[string]tftypes.Type{
+		"external_traffic_policy": tftypes.String,
+		"replicas":                tftypes.Number,
+	}
+	addonObjType := tftypes.Object{AttributeTypes: addonAttrTypes}
+	topObjType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"addon": addonObjType,
+		},
+	}
+
+	schema := rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"addon": rschema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]rschema.Attribute{
+					"external_traffic_policy": rschema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"replicas": rschema.NumberAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+
+	// prior: resource exists, but addon attribute is a typed null (unset optional
+	// nested attribute as returned by a TF provider Read).
+	prior := tftypes.NewValue(topObjType, map[string]tftypes.Value{
+		"addon": tftypes.NewValue(addonObjType, nil),
+	})
+
+	// config: user has now specified the addon.
+	config := tftypes.NewValue(topObjType, map[string]tftypes.Value{
+		"addon": tftypes.NewValue(addonObjType, map[string]tftypes.Value{
+			"external_traffic_policy": tftypes.NewValue(tftypes.String, nil),
+			"replicas":                tftypes.NewValue(tftypes.Number, nil),
+		}),
+	})
+
+	// Must not panic.
+	result := proposedState(schema, prior, config)
+
+	if !result.IsKnown() || result.IsNull() {
+		t.Errorf("expected a known non-null result, got %s", result)
+	}
+}


### PR DESCRIPTION
### Description of your changes


- Fixes a panic (`AttributeName("..."): missing value type`) in `proposedNewAttributes` ([pkg/controller/proposed_state.go:495](pkg/controller/proposed_state.go#L495)) triggered during `Observe` when a `SingleNestedAttribute`'s prior TF state value is a typed null
- Derives the null placeholder's type from the schema attribute definition rather than from the (empty) prior state map
- Adds a regression test covering the null-prior + non-null-config path

### Root Cause

`proposedNewAttributes` handles the case where `prior.IsNull()` by constructing null placeholder values for each attribute in the loop. The original code read the type from `priorMap[name]`:

```go
priorV = tftypes.NewValue(priorMap[name].Type(), nil)
```

However, prior.As(&priorMap) silently returns an error and leaves priorMap empty when prior is null. A Go map miss on an empty map returns a zero-value tftypes.Value, and .Type() on a zero-value returns nil. Passing nil to tftypes.NewValue causes the panic.

This affects any resource where:

An optional SingleNestedAttribute (e.g. an addon block) is absent from the TF provider's Read response, causing a typed null in TF state
The user then sets that attribute in their Crossplane claim
Upjet's Observe path calls proposedState to compute the planned diff — triggering the panic on every reconciliation loop
Because Go map iteration order is non-deterministic, a different child attribute name appears in the panic message each time (external_traffic_policy, service_annotations, node_selector, version, etc.).


Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added `TestProposedNewAttributes_NullPriorNestedAttribute` in [proposed_state_test.go](pkg/controller/proposed_state_test.go) reproduces the exact scenario: top-level resource exists (non-null prior), optional nested attribute is a typed null in prior state, user sets the attribute in config

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
