### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,4 +194,5 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           flags: unittests
-          file: _output/tests/linux_amd64/coverage.txt
+          files: _output/tests/linux_amd64/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description of your changes

- in CI, adds token to codecov action, for uploading unit test coverage results. Protected branches now require token: per https://docs.codecov.com/docs/codecov-tokens#when-do-i-need-a-token
- rename deprecated `file` parameter to `files`, per https://github.com/codecov/codecov-action#migration-guide

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

CI

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
