### PR TITLE
ci: Bump golangci-lint version to v2.10.1 [release-2.2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 env:
   # Common versions
   GO_VERSION: "1.24"
-  GOLANGCI_VERSION: "v1.64.8"
+  GOLANGCI_VERSION: "v2.10.1"
   DOCKER_BUILDX_VERSION: "v0.28.0"
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
@@ -89,7 +89,7 @@ jobs:
       # this action because it leaves 'annotations' (i.e. it comments on PRs to
       # point out linter violations).
       - name: Lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 # v9.2.0
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,207 +2,194 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-run:
-  timeout: 10m
-
+version: "2"
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-    - format: colored-line-number
-  print-linter-name: true
-  show-stats: true
-
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: false
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-    exclude-functions:
-      - io/ioutil.ReadFile
-      - io/ioutil.ReadDir
-      - io/ioutil.ReadAll
-
-  revive:
-    # confidence for issues, default is 0.8
-    confidence: 0.8
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-
-  gci:
-    custom-order: true
-    sections:
-      - standard
-      - default
-      - prefix(github.com/crossplane/upjet)
-      - blank
-      - dot
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-
-  lll:
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
-
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-
-    settings: # settings passed to gocritic
-      captLocal: # must be valid enabled check name
-        paramsOnly: true
-      rangeValCopy:
-        sizeThreshold: 32
-
-  nolintlint:
-    require-explanation: false
-    require-specific: true
-
+    text:
+      path: stdout
+      print-linter-name: true
 linters:
   enable:
-    - govet
-    - gocyclo
-    - gocritic
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - goconst
-    - gci
-    - gofmt # We enable this as well as goimports for its simplify mode.
-    - gosimple
-    - prealloc
-    - revive
-    - staticcheck
-    - unconvert
-    - unused
+    - gocritic
+    - gocyclo
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
     - misspell
+    - musttag
     - nakedret
+    - nilerr
+    - nilnesserr
+    - noctx
     - nolintlint
+    - prealloc
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unconvert
+    - unparam
+    - zerologlint
+  settings:
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        - io/ioutil.ReadFile
+        - io/ioutil.ReadDir
+        - io/ioutil.ReadAll
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      enabled-tags:
+        - performance
+      settings:
+        captLocal:
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+    gocyclo:
+      min-complexity: 10
+    lll:
+      tab-width: 1
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      require-explanation: false
+      require-specific: true
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+    revive:
+      confidence: 0.8
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
+    rules:
+      # Exclude some linters from running on tests files.
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+          - scopelint
+          - unparam
+        path: _test(ing)?\.go
 
-  presets:
-    - bugs
-    - unused
-  fast: false
+      # Ease some gocritic warnings on test files.
+      - linters:
+          - gocritic
+        path: _test\.go
+        text: (unnamedResult|exitAfterDefer)
 
+      # These are performance optimisations rather than style issues per se.
+      # They warn when function arguments or range values copy a lot of memory
+      # rather than using a pointer.
+      - linters:
+          - gocritic
+        text: '(hugeParam|rangeValCopy):'
+
+      # This "TestMain should call os.Exit to set exit code" warning is not clever
+      # enough to notice that we call a helper method that calls os.Exit.
+      - linters:
+          - staticcheck
+        text: 'SA3000:'
+
+      # This is a "potential hardcoded credentials" warning. It's triggered by
+      # any variable with 'secret' in the same, and thus hits a lot of false
+      # positives in Kubernetes land where a Secret is an object type.
+      - linters:
+          - gosec
+        text: 'G101:'
+
+      # This is an 'errors unhandled' warning that duplicates errcheck.
+      - linters:
+          - gosec
+        text: 'G104:'
+
+      # Some k8s dependencies do not have JSON tags on all fields in structs.
+      - linters:
+          - musttag
+        path: k8s.io/
+
+      # This exclusion is necessary because this package relies on deprecated
+      # functions and fields to maintain compatibility with older versions. This
+      # package acts as a migration framework, supporting users coming from
+      # previous versions. In the future, we may extract this package into a
+      # separate module and decouple its dependencies from upjet.
+      - linters:
+          - staticcheck
+        path: pkg/migration/
+        text: 'SA1019:'
+      - linters:
+          - staticcheck
+        text: 'QF1008:'
+      # Ease some deprecated field usage, we still handle them
+      - linters:
+          - staticcheck
+        path: pkg/types/reference.go
+        text: 'SA1019:'
+      - linters:
+          - staticcheck
+        path: pkg/types/markers/crossplane.go
+        text: 'SA1019:'
+      - linters:
+          - govet
+        text: 'buildtag:'
+        path: pkg/generate.go
+      - linters:
+          - nolintlint
+        path: pkg/controller/proposed_state.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Excluding configuration per-path and per-linter
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test(ing)?\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - scopelint
-        - unparam
-
-    # Ease some gocritic warnings on test files.
-    - path: _test\.go
-      text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
-
-    # These are performance optimisations rather than style issues per se.
-    # They warn when function arguments or range values copy a lot of memory
-    # rather than using a pointer.
-    - text: "(hugeParam|rangeValCopy):"
-      linters:
-      - gocritic
-
-    # This "TestMain should call os.Exit to set exit code" warning is not clever
-    # enough to notice that we call a helper method that calls os.Exit.
-    - text: "SA3000:"
-      linters:
-      - staticcheck
-
-    - text: "k8s.io/api/core/v1"
-      linters:
-      - goimports
-
-    # This is a "potential hardcoded credentials" warning. It's triggered by
-    # any variable with 'secret' in the same, and thus hits a lot of false
-    # positives in Kubernetes land where a Secret is an object type.
-    - text: "G101:"
-      linters:
-      - gosec
-      - gas
-
-    # This is an 'errors unhandled' warning that duplicates errcheck.
-    - text: "G104:"
-      linters:
-      - gosec
-      - gas
-
-    # Some k8s dependencies do not have JSON tags on all fields in structs.
-    - path: k8s.io/
-      linters:
-        - musttag
-
-    # This exclusion is necessary because this package relies on deprecated
-    # functions and fields to maintain compatibility with older versions. This
-    # package acts as a migration framework, supporting users coming from
-    # previous versions. In the future, we may extract this package into a
-    # separate module and decouple its dependencies from upjet.
-    - path: pkg/migration/
-      linters:
-        - staticcheck
-      text: "SA1019:"
-
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing
-  # large codebase. It's not practical to fix all existing issues at the moment
-  # of integration: much better don't allow issues in new code.
-  # Default is false.
-  new: false
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  # Maximum issues count per one linter. Set to 0 to disable.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  # Maximum count of issues with the same text. Set to 0 to disable.
   max-same-issues: 0
+  new: false
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/crossplane/upjet)
+        - blank
+        - dot
+      custom-order: true
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO_PROJECT := github.com/crossplane/$(PROJECT_NAME)/v2
 
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
-GOLANGCILINT_VERSION ?= 1.64.8
+GOLANGCILINT_VERSION ?= 2.10.1
 # GO_REQUIRED_VERSION ?= 1.22
 
 PLATFORMS ?= linux_amd64 linux_arm64

--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -138,6 +138,7 @@ func (r *Resource) MarkAsRequired(fieldpaths ...string) {
 // useful in cases where external name contains an optional parameter that is
 // defaulted by the provider but we need it to exist or to fix plain buggy
 // schemas.
+//
 // Deprecated: Use Resource.MarkAsRequired instead.
 // This function will be removed in future versions.
 func MarkAsRequired(sch *schema.Resource, fieldpaths ...string) {

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -434,7 +434,7 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 }
 
 // AddResourceConfigurator adds resource specific configurators.
-func (p *Provider) AddResourceConfigurator(resource string, c ResourceConfiguratorFn) { //nolint:interfacer
+func (p *Provider) AddResourceConfigurator(resource string, c ResourceConfiguratorFn) {
 	// Note(turkenh): nolint reasoning - easier to provide a function without
 	// converting to an explicit type supporting the ResourceConfigurator
 	// interface. Since this function would be a frequently used one, it should

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -209,6 +209,7 @@ type References map[string]Reference
 type Reference struct {
 	// Type is the Go type name of the CRD if it is in the same package or
 	// <package-path>.<type-name> if it is in a different package.
+	//
 	// Deprecated: Type is deprecated in favor of TerraformName, which provides
 	// a more stable and less error-prone API compared to Type. TerraformName
 	// will automatically handle name & version configurations that will affect
@@ -612,6 +613,7 @@ type Resource struct {
 	// conflict. By convention, also used in upjet, the field name is preceded by
 	// the value of the generated Kind, for example:
 	// "TagParameters": "ClusterTagParameters"
+	//
 	// Deprecated: OverrideFieldNames has been deprecated in favor of loading
 	// the already existing type names from the older versions of the MR APIS
 	// via the PreviousVersions API.
@@ -708,6 +710,7 @@ func (m SchemaElementOptions) SetAddToObservation(el string) {
 
 // AddToObservation returns true if the schema element at the specified path
 // should be added to the CRD type's Observation type.
+//
 // Deprecated: Use SchemaElementOptions.AddToObservation instead.
 func (m SchemaElementOptions) AddToObservation(el string) bool {
 	return m[el] != nil && m[el].AddToObservation

--- a/pkg/controller/proposed_state.go
+++ b/pkg/controller/proposed_state.go
@@ -165,7 +165,7 @@ func emptyValue(sc rschema.Schema) tftypes.Value {
 func emptyAttribute(attr rschema.Attribute) tftypes.Value {
 	switch attr := attr.(type) {
 	case rschema.NestedAttribute:
-		switch attr.GetNestingMode() {
+		switch attr.GetNestingMode() { //nolint:exhaustive // already exhaustive
 		case NestingModeSingle:
 			vals := make(map[string]tftypes.Value)
 			for key, na := range attr.GetNestedObject().GetAttributes() {
@@ -188,7 +188,7 @@ func emptyAttribute(attr rschema.Attribute) tftypes.Value {
 }
 
 func emptyBlock(blockS rschema.Block) tftypes.Value {
-	switch blockS.GetNestingMode() {
+	switch blockS.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case BlockNestingModeList:
 		return tftypes.NewValue(blockS.Type().TerraformType(context.TODO()), []tftypes.Value{})
 	case BlockNestingModeSet:
@@ -249,7 +249,7 @@ func proposedNewNestedBlock(schema rschema.Block, prior, config tftypes.Value) t
 		Blocks:     resBlocks,
 	}
 
-	switch schema.GetNestingMode() {
+	switch schema.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case BlockNestingModeSingle:
 		// A NestingSingle configuration block value can be null, and since it
 		// cannot be computed we can always take the configuration value.
@@ -277,7 +277,7 @@ func proposedNewNestedType(schema rschema.NestedAttribute, prior, config tftypes
 
 	// Even if the config is null or empty, we will be using this default value.
 	newV := config
-	switch schema.GetNestingMode() {
+	switch schema.GetNestingMode() { //nolint:exhaustive // already exhaustive
 	case NestingModeSingle:
 		// If the config is null, we already have our value. If the attribute
 		// is optional+computed, we won't reach this branch with a null value

--- a/pkg/controller/proposed_state.go
+++ b/pkg/controller/proposed_state.go
@@ -329,7 +329,7 @@ func proposedNewNestingList(schema nestedSchema, prior, config tftypes.Value) tf
 		switch schema := schema.(type) {
 		case rschema.Block:
 			if config.Type().Is(tftypes.Tuple{}) {
-				var elementTypes []tftypes.Type
+				elementTypes := make([]tftypes.Type, 0, len(newVals))
 				for _, val := range newVals {
 					elementTypes = append(elementTypes, val.Type())
 				}
@@ -342,7 +342,7 @@ func proposedNewNestingList(schema nestedSchema, prior, config tftypes.Value) tf
 
 		case rschema.Schema:
 			if config.Type().Is(tftypes.Tuple{}) {
-				var elementTypes []tftypes.Type
+				elementTypes := make([]tftypes.Type, 0, len(newVals))
 				for _, val := range newVals {
 					elementTypes = append(elementTypes, val.Type())
 				}

--- a/pkg/examples/conversion/example_conversions.go
+++ b/pkg/examples/conversion/example_conversions.go
@@ -28,7 +28,7 @@ import (
 // All (generated) manifests under the `startPath` are scanned and the
 // header at the specified path `licenseHeaderPath` is used for the converted
 // example manifests.
-func ApplyAPIConverters(pc *config.Provider, startPath, licenseHeaderPath string) error {
+func ApplyAPIConverters(pc *config.Provider, startPath, licenseHeaderPath string) error { //nolint:gocyclo // easier to follow as a unit
 	resourceRegistry := prepareResourceRegistry(pc)
 
 	var license string
@@ -129,7 +129,7 @@ func writeExampleContent(path string, convertedFileContent string, examples []*u
 	dir := filepath.Dir(newPath)
 
 	// Create all necessary directories if they do not exist
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil { //nolint:gosec
 		return errors.Wrap(err, "failed to create directory")
 	}
 	f, err := os.Create(filepath.Clean(newPath))
@@ -144,7 +144,7 @@ func writeExampleContent(path string, convertedFileContent string, examples []*u
 }
 
 func getLicenseHeader(licensePath string) (string, error) {
-	licenseData, err := os.ReadFile(licensePath)
+	licenseData, err := os.ReadFile(licensePath) //nolint:gosec // used only on generation time
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to read license file: %s", licensePath)
 	}

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -282,14 +282,14 @@ func (r *PipelineRunner) Run(pc *config.Provider) []string { //nolint:gocyclo
 	// So, we set the directory of the command instead of passing in the directory
 	// as an argument to "find".
 	fmt.Printf("Running goimports on apis folder with scope %s\n", r.Scope)
-	apisCmd := exec.Command("bash", "-c", "goimports -w $(find . -iname 'zz_*')")
+	apisCmd := exec.Command("bash", "-c", "goimports -w $(find . -iname 'zz_*')") //nolint:noctx
 	apisCmd.Dir = filepath.Clean(r.DirAPIs)
 	if out, err := apisCmd.CombinedOutput(); err != nil {
 		panic(errors.Wrap(err, "cannot run goimports for apis folder: "+string(out)))
 	}
 
 	fmt.Printf("Running goimports on controller folder with scope %s\n", r.Scope)
-	ctrlCmd := exec.Command("bash", "-c", "goimports -w $(find . -iname 'zz_*')")
+	ctrlCmd := exec.Command("bash", "-c", "goimports -w $(find . -iname 'zz_*')") //nolint:noctx
 	ctrlCmd.Dir = filepath.Clean(r.DirControllers)
 	if out, err := ctrlCmd.CombinedOutput(); err != nil {
 		panic(errors.Wrap(err, "cannot run goimports for controller folder: "+string(out)))

--- a/pkg/pipeline/setup.go
+++ b/pkg/pipeline/setup.go
@@ -103,7 +103,7 @@ func (mg *MainGenerator) Generate(groups []string) error {
 		}
 		defer func() {
 			if err := m.Close(); err != nil {
-				log.Fatalf("Failed to close the templated main %q: %s", f, err.Error())
+				log.Fatalf("Failed to close the templated main %q: %v", f, err)
 			}
 		}()
 		if err := t.Execute(m, map[string]any{

--- a/pkg/registry/reference/references.go
+++ b/pkg/registry/reference/references.go
@@ -131,7 +131,7 @@ func (rr *Injector) getTypePath(tfName string, configResources map[string]*confi
 func (rr *Injector) SetReferenceTypes(configResources map[string]*config.Resource) error {
 	for _, r := range configResources {
 		for attr, ref := range r.References {
-			if ref.Type == "" && ref.TerraformName != "" {
+			if ref.Type == "" && ref.TerraformName != "" { //nolint:staticcheck // still handling deprecated field behavior
 				crdTypePath, err := rr.getTypePath(ref.TerraformName, configResources)
 				if err != nil {
 					return errors.Wrap(err, "cannot set reference types")
@@ -147,7 +147,7 @@ func (rr *Injector) SetReferenceTypes(configResources map[string]*config.Resourc
 					delete(r.References, attr)
 					continue
 				}
-				ref.Type = crdTypePath
+				ref.Type = crdTypePath //nolint:staticcheck // still handling deprecated field behavior
 				r.References[attr] = ref
 			}
 		}

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -447,12 +447,12 @@ func fieldPathToSecretKey(s string) (string, error) {
 		switch s.Type {
 		case fieldpath.SegmentField:
 			if strings.ContainsRune(s.Field, '.') {
-				b.WriteString(fmt.Sprintf("...%s...", s.Field))
+				fmt.Fprintf(&b, "...%s...", s.Field)
 				continue
 			}
-			b.WriteString(fmt.Sprintf(".%s", s.Field))
+			fmt.Fprintf(&b, ".%s", s.Field)
 		case fieldpath.SegmentIndex:
-			b.WriteString(fmt.Sprintf(".%d", s.Index))
+			fmt.Fprintf(&b, ".%d", s.Index)
 		}
 	}
 

--- a/pkg/terraform/operation.go
+++ b/pkg/terraform/operation.go
@@ -45,6 +45,7 @@ func (o *Operation) MarkEnd() {
 
 // Flush cleans the operation information including the registered error from
 // the last reconciliation.
+//
 // Deprecated: Please use Clear, which allows optionally preserving the error
 // from the last reconciliation to implement proper SYNC status condition for
 // the asynchronous external clients.

--- a/pkg/transformers/resolver.go
+++ b/pkg/transformers/resolver.go
@@ -6,16 +6,17 @@ package transformers
 
 import (
 	"fmt"
-	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
-	"github.com/pkg/errors"
-	"github.com/spf13/afero"
 	"go/ast"
 	"go/format"
 	"go/token"
-	"golang.org/x/tools/go/ast/astutil"
-	"golang.org/x/tools/go/packages"
 	"path/filepath"
 	"strings"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 const (

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -139,7 +139,7 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 	// we need to process all fields in the same order all the time.
 	keys := sortedKeys(res.Schema)
 
-	typeNames, err := NewTypeNames(names, g.Package, cfg.OverrideFieldNames)
+	typeNames, err := NewTypeNames(names, g.Package, cfg.OverrideFieldNames) //nolint:staticcheck // still handling deprecated field behavior
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
### Description of your changes

Backports #557 and #576 to `release-2.2`

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

CI

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
