### PR TITLE
[Backport release-1.11] fix: set dotted map keys with correct nesting

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -212,9 +212,14 @@ func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, p
 			}
 		}
 	case schema.TypeString:
+		paramStr, ok := param.(string)
+		if !ok {
+			c.logger.Debug("expected parameter value to be string", "parameterType", fmt.Sprintf("%T", param))
+			return param
+		}
 		// For String types check if it is an HCL string and process
-		if isHCLSnippetPattern.MatchString(param.(string)) {
-			hclProccessedParam, err := processHCLParam(param.(string))
+		if isHCLSnippetPattern.MatchString(paramStr) {
+			hclProccessedParam, err := processHCLParam(paramStr)
 			if err != nil {
 				c.logger.Debug("could not process param, returning original", "param", sc.GoString())
 			} else {

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -234,8 +234,8 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 					return errors.Wrapf(err, errFmtCannotGetSecretValue, ref)
 				}
 				for key, value := range data {
-					if err = pavedTF.SetValue(fmt.Sprintf("%s.%s", tfPath, key), string(value)); err != nil {
-						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s.%s", tfPath, key))
+					if err = pavedTF.SetValue(fmt.Sprintf("%s[%s]", tfPath, key), string(value)); err != nil {
+						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s[%s]", tfPath, key))
 					}
 				}
 				continue

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -1165,6 +1165,85 @@ func TestGetSensitiveParameters(t *testing.T) {
 				},
 			},
 		},
+		// Test for the bug where secret keys containing dots were
+		// incorrectly split by dot notation when building the TF attribute
+		// path, producing a wrong nested structure instead of a dotted map key.
+		// e.g. SetValue("tls_config.tls.crt", v) → {"tls_config":{"tls":{"crt":v}}} (wrong)
+		//      SetValue("tls_config[tls.crt]", v) → {"tls_config":{"tls.crt":v}} (correct)
+		"SecretReferenceWithDottedKeys": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &unstructured.Unstructured{
+					Object: map[string]any{
+						"spec": map[string]any{
+							"forProvider": map[string]any{
+								"tlsSecretRef": map[string]any{
+									"name":      "tls-secret",
+									"namespace": "crossplane-system",
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
+		"SecretReferenceWithDottedKeysInitProvider": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &unstructured.Unstructured{
+					Object: map[string]any{
+						"spec": map[string]any{
+							"initProvider": map[string]any{
+								"tlsSecretRef": map[string]any{
+									"name":      "tls-secret",
+									"namespace": "crossplane-system",
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION

### Description of your changes

Backport of #635 to `release-1.11`.


I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

See #635

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
