### PR TITLE
Make the Default Rate Limiter for the Event Handler Configurable

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -38,6 +38,14 @@ const (
 	rateLimiterCallback = "asyncCallback"
 )
 
+type asyncOperation string
+
+const (
+	opCreate  asyncOperation = "create"
+	opUpdate  asyncOperation = "update"
+	opDestroy asyncOperation = "destroy"
+)
+
 var _ CallbackProvider = &APICallbacks{}
 
 // APISecretClient is a client for getting k8s secrets
@@ -113,7 +121,7 @@ type APICallbacks struct {
 	enableStatusUpdates bool
 }
 
-func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform.CallbackFn {
+func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op asyncOperation, requestReconcile bool) terraform.CallbackFn {
 	return func(err error, ctx context.Context) error {
 		tr := ac.newTerraformed()
 		if kErr := ac.kube.Get(ctx, nn, tr); kErr != nil {
@@ -128,11 +136,11 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform
 		if err != nil {
 			wrapMsg := ""
 			switch op {
-			case "create":
+			case opCreate:
 				wrapMsg = errXPReconcileCreate
-			case "update":
+			case opUpdate:
 				wrapMsg = errXPReconcileUpdate
-			case "destroy":
+			case opDestroy:
 				wrapMsg = errXPReconcileDelete
 			}
 			tr.SetConditions(xpv1.ReconcileError(errors.Wrap(err, wrapMsg)))
@@ -143,7 +151,7 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform
 			tr.SetConditions(resource.AsyncOperationFinishedCondition())
 		}
 		uErr := errors.Wrapf(ac.kube.Status().Update(ctx, tr), errUpdateStatusFmt, tr.GetObjectKind().GroupVersionKind().String(), nn, op)
-		if ac.eventHandler != nil {
+		if ac.eventHandler != nil && requestReconcile {
 			rateLimiter := handler.NoRateLimiter
 			switch {
 			case err != nil:
@@ -162,7 +170,7 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op string) terraform
 }
 
 // Create makes sure the error is saved in async operation condition.
-func (ac *APICallbacks) Create(name types.NamespacedName) terraform.CallbackFn {
+func (ac *APICallbacks) Create(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn {
 	// request will be requeued although the managed reconciler already
 	// requeues with exponential back-off during the creation phase
 	// because the upjet external client returns ResourceExists &
@@ -170,19 +178,19 @@ func (ac *APICallbacks) Create(name types.NamespacedName) terraform.CallbackFn {
 	// in-progress immediately following a Create call. This will
 	// delay a reobservation of the resource (while being created)
 	// for the poll period.
-	return ac.callbackFn(name, "create")
+	return ac.callbackFn(name, opCreate, requestReconcile)
 }
 
 // Update makes sure the error is saved in async operation condition.
-func (ac *APICallbacks) Update(name types.NamespacedName) terraform.CallbackFn {
-	return ac.callbackFn(name, "update")
+func (ac *APICallbacks) Update(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn {
+	return ac.callbackFn(name, opUpdate, requestReconcile)
 }
 
 // Destroy makes sure the error is saved in async operation condition.
-func (ac *APICallbacks) Destroy(name types.NamespacedName) terraform.CallbackFn {
+func (ac *APICallbacks) Destroy(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn {
 	// request will be requeued although the managed reconciler requeues
 	// with exponential back-off during the deletion phase because
 	// during the async deletion operation, external client's
 	// observe just returns success to the managed reconciler.
-	return ac.callbackFn(name, "destroy")
+	return ac.callbackFn(name, opDestroy, requestReconcile)
 }

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -121,7 +121,7 @@ type APICallbacks struct {
 	enableStatusUpdates bool
 }
 
-func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op asyncOperation, requestReconcile bool) terraform.CallbackFn {
+func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op asyncOperation, requestReconcile bool) terraform.CallbackFn { //nolint:gocyclo // for better readability
 	return func(err error, ctx context.Context) error {
 		tr := ac.newTerraformed()
 		if kErr := ac.kube.Get(ctx, nn, tr); kErr != nil {

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -96,7 +96,7 @@ func TestAPICallbacksCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Create(types.NamespacedName{Name: "name"})(tc.args.err, context.TODO())
+			err := e.Create(types.NamespacedName{Name: "name"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -178,7 +178,7 @@ func TestAPICallbacksUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Update(types.NamespacedName{Name: "name"})(tc.args.err, context.TODO())
+			err := e.Update(types.NamespacedName{Name: "name"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nUpdate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -260,7 +260,7 @@ func TestAPICallbacks_Destroy(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Destroy(types.NamespacedName{Name: "name"})(tc.args.err, context.TODO())
+			err := e.Destroy(types.NamespacedName{Name: "name"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDestroy(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -352,7 +352,7 @@ func TestAPICallbacksCreate_namespaced(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Create(types.NamespacedName{Name: "name", Namespace: "foo-ns"})(tc.args.err, context.TODO())
+			err := e.Create(types.NamespacedName{Name: "name", Namespace: "foo-ns"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -444,7 +444,7 @@ func TestAPICallbacksUpdate_namespaced(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Update(types.NamespacedName{Name: "name", Namespace: "foo-ns"})(tc.args.err, context.TODO())
+			err := e.Update(types.NamespacedName{Name: "name", Namespace: "foo-ns"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nUpdate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -536,7 +536,7 @@ func TestAPICallbacks_Destroy_namespaced(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Destroy(types.NamespacedName{Name: "name", Namespace: "foo-ns"})(tc.args.err, context.TODO())
+			err := e.Destroy(types.NamespacedName{Name: "name", Namespace: "foo-ns"}, true)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDestroy(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	xpfake "github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -17,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/crossplane/upjet/v2/pkg/controller/handler"
 	"github.com/crossplane/upjet/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/resource/fake"
 	tjerrors "github.com/crossplane/upjet/v2/pkg/terraform/errors"
@@ -186,7 +188,7 @@ func TestAPICallbacksUpdate(t *testing.T) {
 	}
 }
 
-func TestAPICallbacks_Destroy(t *testing.T) {
+func TestAPICallbacksDestroy(t *testing.T) {
 	type args struct {
 		mgr ctrl.Manager
 		mg  xpresource.ManagedKind
@@ -268,7 +270,7 @@ func TestAPICallbacks_Destroy(t *testing.T) {
 	}
 }
 
-func TestAPICallbacksCreate_namespaced(t *testing.T) {
+func TestAPICallbacksCreateNamespaced(t *testing.T) {
 	type args struct {
 		mgr ctrl.Manager
 		mg  xpresource.ManagedKind
@@ -360,7 +362,7 @@ func TestAPICallbacksCreate_namespaced(t *testing.T) {
 	}
 }
 
-func TestAPICallbacksUpdate_namespaced(t *testing.T) {
+func TestAPICallbacksUpdateNamespaced(t *testing.T) {
 	type args struct {
 		mgr ctrl.Manager
 		mg  xpresource.ManagedKind
@@ -452,7 +454,7 @@ func TestAPICallbacksUpdate_namespaced(t *testing.T) {
 	}
 }
 
-func TestAPICallbacks_Destroy_namespaced(t *testing.T) {
+func TestAPICallbacksDestroyNamespaced(t *testing.T) {
 	type args struct {
 		mgr ctrl.Manager
 		mg  xpresource.ManagedKind
@@ -537,6 +539,263 @@ func TestAPICallbacks_Destroy_namespaced(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
 			err := e.Destroy(types.NamespacedName{Name: "name", Namespace: "foo-ns"}, true)(tc.args.err, context.TODO())
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDestroy(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// okManager returns a manager whose client successfully handles Get and
+// Status().Update so that the callback reaches the requestReconcile gate.
+func okManager() ctrl.Manager {
+	return &xpfake.Manager{
+		Client: &test.MockClient{
+			MockGet: test.NewMockGetFn(nil),
+			MockStatusUpdate: func(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return nil
+			},
+		},
+		Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
+	}
+}
+
+// newUnprimedEventHandler returns an EventHandler whose underlying queue has
+// not been initialized. RequestReconcile on such a handler returns false,
+// which the APICallbacks surfaces as an errReconcileRequestFmt error. The
+// tests use this to assert whether RequestReconcile was invoked at all,
+// without depending on a real workqueue.
+func newUnprimedEventHandler() *handler.EventHandler {
+	return handler.NewEventHandler(handler.WithLogger(logging.NewNopLogger()))
+}
+
+func TestAPICallbacksCreateRequestReconcile(t *testing.T) {
+	type args struct {
+		err              error
+		withEventHandler bool
+		requestReconcile bool
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NoEventHandlerRequestReconcileTrue": {
+			reason: "Without an event handler, requestReconcile=true must be a no-op.",
+			args: args{
+				requestReconcile: true,
+			},
+		},
+		"NoEventHandlerRequestReconcileFalse": {
+			reason: "Without an event handler, requestReconcile=false must be a no-op.",
+			args: args{
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalse": {
+			reason: "When the event handler is set but requestReconcile=false, no reconcile request must be queued.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalseOnError": {
+			reason: "A callback error must not trigger a reconcile request when requestReconcile=false.",
+			args: args{
+				err:              tjerrors.NewApplyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileTrue": {
+			reason: "When the event handler is set and requestReconcile=true, the callback must attempt to queue a reconcile request; with an uninitialized queue this surfaces as an errReconcileRequestFmt error.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opCreate),
+			},
+		},
+		"WithEventHandlerRequestReconcileTrueOnError": {
+			reason: "On callback error with requestReconcile=true, the callback must still attempt to queue a rate-limited reconcile request.",
+			args: args{
+				err:              tjerrors.NewApplyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opCreate),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var opts []APICallbacksOption
+			if tc.args.withEventHandler {
+				opts = append(opts, WithEventHandler(newUnprimedEventHandler()))
+			}
+			e := NewAPICallbacks(okManager(), xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})), opts...)
+			err := e.Create(types.NamespacedName{Name: "name"}, tc.args.requestReconcile)(tc.args.err, context.TODO())
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPICallbacksUpdateRequestReconcile(t *testing.T) {
+	type args struct {
+		err              error
+		withEventHandler bool
+		requestReconcile bool
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NoEventHandlerRequestReconcileTrue": {
+			reason: "Without an event handler, requestReconcile=true must be a no-op.",
+			args: args{
+				requestReconcile: true,
+			},
+		},
+		"NoEventHandlerRequestReconcileFalse": {
+			reason: "Without an event handler, requestReconcile=false must be a no-op.",
+			args: args{
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalse": {
+			reason: "When the event handler is set but requestReconcile=false, no reconcile request must be queued.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalseOnError": {
+			reason: "A callback error must not trigger a reconcile request when requestReconcile=false.",
+			args: args{
+				err:              tjerrors.NewApplyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileTrue": {
+			reason: "When the event handler is set and requestReconcile=true, the callback must attempt to queue a reconcile request; with an uninitialized queue this surfaces as an errReconcileRequestFmt error.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opUpdate),
+			},
+		},
+		"WithEventHandlerRequestReconcileTrueOnError": {
+			reason: "On callback error with requestReconcile=true, the callback must still attempt to queue a rate-limited reconcile request.",
+			args: args{
+				err:              tjerrors.NewApplyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opUpdate),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var opts []APICallbacksOption
+			if tc.args.withEventHandler {
+				opts = append(opts, WithEventHandler(newUnprimedEventHandler()))
+			}
+			e := NewAPICallbacks(okManager(), xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})), opts...)
+			err := e.Update(types.NamespacedName{Name: "name"}, tc.args.requestReconcile)(tc.args.err, context.TODO())
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nUpdate(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPICallbacksDestroyRequestReconcile(t *testing.T) {
+	type args struct {
+		err              error
+		withEventHandler bool
+		requestReconcile bool
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NoEventHandlerRequestReconcileTrue": {
+			reason: "Without an event handler, requestReconcile=true must be a no-op.",
+			args: args{
+				requestReconcile: true,
+			},
+		},
+		"NoEventHandlerRequestReconcileFalse": {
+			reason: "Without an event handler, requestReconcile=false must be a no-op.",
+			args: args{
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalse": {
+			reason: "When the event handler is set but requestReconcile=false, no reconcile request must be queued.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileFalseOnError": {
+			reason: "A callback error must not trigger a reconcile request when requestReconcile=false.",
+			args: args{
+				err:              tjerrors.NewDestroyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: false,
+			},
+		},
+		"WithEventHandlerRequestReconcileTrue": {
+			reason: "When the event handler is set and requestReconcile=true, the callback must attempt to queue a reconcile request; with an uninitialized queue this surfaces as an errReconcileRequestFmt error.",
+			args: args{
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opDestroy),
+			},
+		},
+		"WithEventHandlerRequestReconcileTrueOnError": {
+			reason: "On callback error with requestReconcile=true, the callback must still attempt to queue a rate-limited reconcile request.",
+			args: args{
+				err:              tjerrors.NewDestroyFailed(nil),
+				withEventHandler: true,
+				requestReconcile: true,
+			},
+			want: want{
+				err: errors.Errorf(errReconcileRequestFmt, "", ", Kind=//name", opDestroy),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var opts []APICallbacksOption
+			if tc.args.withEventHandler {
+				opts = append(opts, WithEventHandler(newUnprimedEventHandler()))
+			}
+			e := NewAPICallbacks(okManager(), xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})), opts...)
+			err := e.Destroy(types.NamespacedName{Name: "name"}, tc.args.requestReconcile)(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDestroy(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -382,7 +382,8 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 	defer e.stopProvider()
 	if e.config.UseAsync {
-		return managed.ExternalCreation{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Create(name)), errStartAsyncApply)
+		// TODO: check whether we need a requeue or not.
+		return managed.ExternalCreation{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Create(name, true)), errStartAsyncApply)
 	}
 	tr, ok := mg.(resource.Terraformed)
 	if !ok {
@@ -421,7 +422,8 @@ func (e *external) Update(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 	defer e.stopProvider()
 	if e.config.UseAsync {
-		return managed.ExternalUpdate{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Update(name)), errStartAsyncApply)
+		// TODO: check whether we need a requeue or not.
+		return managed.ExternalUpdate{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Update(name, true)), errStartAsyncApply)
 	}
 	tr, ok := mg.(resource.Terraformed)
 	if !ok {
@@ -452,7 +454,8 @@ func (e *external) Delete(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 	defer e.stopProvider()
 	if e.config.UseAsync {
-		return managed.ExternalDelete{}, errors.Wrap(e.workspace.DestroyAsync(e.callback.Destroy(name)), errStartAsyncDestroy)
+		// TODO: check whether we need a requeue or not.
+		return managed.ExternalDelete{}, errors.Wrap(e.workspace.DestroyAsync(e.callback.Destroy(name, true)), errStartAsyncDestroy)
 	}
 	return managed.ExternalDelete{}, errors.Wrap(e.workspace.Destroy(ctx), errDestroy)
 }

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -218,6 +218,7 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncCreateFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async create ended.", "error", err)
@@ -227,7 +228,11 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Create(name)(err, ctx); cErr != nil {
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
+			if cErr := n.callback.Create(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
 			}
 		}()
@@ -255,6 +260,7 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncUpdateFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async update ended.", "error", err)
@@ -264,7 +270,11 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Update(name)(err, ctx); cErr != nil {
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
+			if cErr := n.callback.Update(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
 			}
 		}()
@@ -296,6 +306,7 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, 
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncDeleteFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async delete ended.", "error", err)
@@ -305,7 +316,11 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Delete(_ context.Context, 
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Destroy(name)(err, ctx); cErr != nil {
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
+			if cErr := n.callback.Destroy(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
 			}
 		}()

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -152,6 +152,7 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncCreateFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async create ended.", "error", err, "tfID", n.opTracker.GetTfID())
@@ -161,7 +162,11 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Create(name)(err, ctx); cErr != nil {
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
+			if cErr := n.callback.Create(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
 			}
 		}()
@@ -189,6 +194,7 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncUpdateFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async update ended.", "error", err, "tfID", n.opTracker.GetTfID())
@@ -198,7 +204,7 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Update(name)(err, ctx); cErr != nil {
+			if cErr := n.callback.Update(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
 			}
 		}()
@@ -230,6 +236,7 @@ func (n *terraformPluginSDKAsyncExternal) Delete(_ context.Context, mg xpresourc
 		var ph panicHandler
 		defer cancel()
 		defer func() { // Finishing operations
+			currentErr := n.opTracker.LastOperation.Error()
 			err := tferrors.NewAsyncDeleteFailed(ph.err)
 			n.opTracker.LastOperation.SetError(err)
 			n.opTracker.logger.Debug("Async delete ended.", "error", err, "tfID", n.opTracker.GetTfID())
@@ -239,7 +246,11 @@ func (n *terraformPluginSDKAsyncExternal) Delete(_ context.Context, mg xpresourc
 				Namespace: mg.GetNamespace(),
 				Name:      mg.GetName(),
 			}
-			if cErr := n.callback.Destroy(name)(err, ctx); cErr != nil {
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
+			if cErr := n.callback.Destroy(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async delete callback failed", "error", cErr.Error())
 			}
 		}()

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -104,15 +104,15 @@ type CallbackFns struct {
 	DestroyFn func(types.NamespacedName) terraform.CallbackFn
 }
 
-func (c CallbackFns) Create(name types.NamespacedName) terraform.CallbackFn {
+func (c CallbackFns) Create(name types.NamespacedName, _ bool) terraform.CallbackFn {
 	return c.CreateFn(name)
 }
 
-func (c CallbackFns) Update(name types.NamespacedName) terraform.CallbackFn {
+func (c CallbackFns) Update(name types.NamespacedName, _ bool) terraform.CallbackFn {
 	return c.UpdateFn(name)
 }
 
-func (c CallbackFns) Destroy(name types.NamespacedName) terraform.CallbackFn {
+func (c CallbackFns) Destroy(name types.NamespacedName, _ bool) terraform.CallbackFn {
 	return c.DestroyFn(name)
 }
 

--- a/pkg/controller/handler/eventhandler.go
+++ b/pkg/controller/handler/eventhandler.go
@@ -22,11 +22,12 @@ const NoRateLimiter = ""
 // EventHandler handles Kubernetes events by queueing reconcile requests for
 // objects and allows upjet components to queue reconcile requests.
 type EventHandler struct {
-	innerHandler   handler.EventHandler
-	queue          workqueue.TypedRateLimitingInterface[reconcile.Request]
-	rateLimiterMap map[string]workqueue.TypedRateLimiter[reconcile.Request]
-	logger         logging.Logger
-	mu             *sync.RWMutex
+	innerHandler       handler.EventHandler
+	queue              workqueue.TypedRateLimitingInterface[reconcile.Request]
+	rateLimiterMap     map[string]workqueue.TypedRateLimiter[reconcile.Request]
+	defaultRateLimiter workqueue.TypedRateLimiter[reconcile.Request]
+	logger             logging.Logger
+	mu                 *sync.RWMutex
 }
 
 // Option configures an option for the EventHandler.
@@ -36,6 +37,15 @@ type Option func(eventHandler *EventHandler)
 func WithLogger(logger logging.Logger) Option {
 	return func(eventHandler *EventHandler) {
 		eventHandler.logger = logger
+	}
+}
+
+// WithDefaultRateLimiter configures the default rate limiter to be used with
+// the EventHandler. If no default rate limiter is used, the EventHandler uses
+// a workqueue.DefaultTypedControllerRateLimiter.
+func WithDefaultRateLimiter(rl workqueue.TypedRateLimiter[reconcile.Request]) Option {
+	return func(eventHandler *EventHandler) {
+		eventHandler.defaultRateLimiter = rl
 	}
 }
 
@@ -68,7 +78,11 @@ func (e *EventHandler) RequestReconcile(rateLimiterName string, name types.Names
 	if rateLimiterName != NoRateLimiter {
 		rateLimiter := e.rateLimiterMap[rateLimiterName]
 		if rateLimiter == nil {
-			rateLimiter = workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]()
+			if e.defaultRateLimiter == nil {
+				rateLimiter = workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]()
+			} else {
+				rateLimiter = e.defaultRateLimiter
+			}
 			e.rateLimiterMap[rateLimiterName] = rateLimiter
 		}
 		if failureLimit != nil && rateLimiter.NumRequeues(item) > *failureLimit {

--- a/pkg/controller/handler/eventhandler_test.go
+++ b/pkg/controller/handler/eventhandler_test.go
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// noopRateLimiter is a stand-in TypedRateLimiter used to assert that the
+// configured default limiter is the exact instance cached and shared across
+// rateLimiterName keys.
+type noopRateLimiter struct{}
+
+func (l *noopRateLimiter) When(_ reconcile.Request) time.Duration { return 0 }
+func (l *noopRateLimiter) Forget(_ reconcile.Request)             {}
+func (l *noopRateLimiter) NumRequeues(_ reconcile.Request) int    { return 0 }
+
+// newPrimedEventHandler returns an EventHandler whose internal queue is
+// initialized via the public event-handler interface so that
+// RequestReconcile is callable.
+func newPrimedEventHandler(t *testing.T, opts ...Option) *EventHandler {
+	t.Helper()
+	opts = append([]Option{WithLogger(logging.NewNopLogger())}, opts...)
+	eh := NewEventHandler(opts...)
+	q := workqueue.NewTypedRateLimitingQueue[reconcile.Request](
+		workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	eh.Create(context.Background(), event.CreateEvent{Object: &corev1.ConfigMap{}}, q)
+	return eh
+}
+
+func TestEventHandlerRequestReconcileDefaultRateLimiter(t *testing.T) {
+	type want struct {
+		// shared indicates whether map entries across distinct
+		// rateLimiterNames should reference the same limiter instance.
+		shared bool
+	}
+	cases := map[string]struct {
+		reason            string
+		withCustomDefault bool
+		want              want
+	}{
+		"FallbackPerName": {
+			reason: "Without WithDefaultRateLimiter, each distinct rateLimiterName receives its own fresh DefaultTypedControllerRateLimiter instance.",
+			want:   want{shared: false},
+		},
+		"SharedAcrossNames": {
+			reason:            "With WithDefaultRateLimiter, the configured limiter instance is reused for every rateLimiterName that has no explicit entry.",
+			withCustomDefault: true,
+			want:              want{shared: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var custom workqueue.TypedRateLimiter[reconcile.Request]
+			var opts []Option
+			if tc.withCustomDefault {
+				custom = &noopRateLimiter{}
+				opts = append(opts, WithDefaultRateLimiter(custom))
+			}
+			eh := newPrimedEventHandler(t, opts...)
+
+			if ok := eh.RequestReconcile("alpha", types.NamespacedName{Name: "a"}, nil); !ok {
+				t.Fatalf("RequestReconcile(alpha) returned false, want true")
+			}
+			if ok := eh.RequestReconcile("beta", types.NamespacedName{Name: "b"}, nil); !ok {
+				t.Fatalf("RequestReconcile(beta) returned false, want true")
+			}
+
+			eh.mu.RLock()
+			alpha, ok := eh.rateLimiterMap["alpha"]
+			if !ok {
+				eh.mu.RUnlock()
+				t.Fatalf("rateLimiterMap missing entry for 'alpha' after RequestReconcile")
+			}
+			beta, ok := eh.rateLimiterMap["beta"]
+			if !ok {
+				eh.mu.RUnlock()
+				t.Fatalf("rateLimiterMap missing entry for 'beta' after RequestReconcile")
+			}
+			eh.mu.RUnlock()
+
+			if alpha == nil || beta == nil {
+				t.Fatalf("%s\nrate limiter entries must be non-nil; got alpha=%v, beta=%v", tc.reason, alpha, beta)
+			}
+
+			switch {
+			case tc.want.shared:
+				if alpha != custom {
+					t.Errorf("%s\nrateLimiterMap['alpha'] is not the configured default limiter (got %T)", tc.reason, alpha)
+				}
+				if beta != custom {
+					t.Errorf("%s\nrateLimiterMap['beta'] is not the configured default limiter (got %T)", tc.reason, beta)
+				}
+			default:
+				if alpha == beta {
+					t.Errorf("%s\nrateLimiterMap['alpha'] and ['beta'] are the same instance; expected distinct fallback limiters", tc.reason)
+				}
+			}
+
+			// Caching: a subsequent call for the same name must reuse
+			// the cached instance rather than allocate a new one.
+			if ok := eh.RequestReconcile("alpha", types.NamespacedName{Name: "a"}, nil); !ok {
+				t.Fatalf("RequestReconcile(alpha) second call returned false")
+			}
+			eh.mu.RLock()
+			alphaAgain := eh.rateLimiterMap["alpha"]
+			eh.mu.RUnlock()
+			if alphaAgain != alpha {
+				t.Errorf("%s\nrateLimiterMap['alpha'] was replaced on second call; expected the cached instance to be reused", tc.reason)
+			}
+		})
+	}
+}
+
+func TestEventHandlerRequestReconcileConcurrent(t *testing.T) {
+	// Exercises caching behavior under concurrent callers. Combined with
+	// `go test -race` this also asserts the absence of data races on
+	// rateLimiterMap.
+	custom := &noopRateLimiter{}
+	eh := newPrimedEventHandler(t, WithDefaultRateLimiter(custom))
+
+	names := []string{"a", "b", "c", "d"}
+	const goroutines = 64
+	const callsPerGoroutine = 8
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < callsPerGoroutine; i++ {
+				rl := names[(g+i)%len(names)]
+				if !eh.RequestReconcile(rl, types.NamespacedName{Name: rl}, nil) {
+					t.Errorf("RequestReconcile(%s) returned false", rl)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	eh.mu.RLock()
+	defer eh.mu.RUnlock()
+	if got, want := len(eh.rateLimiterMap), len(names); got != want {
+		t.Errorf("rateLimiterMap has %d entries; want %d", got, want)
+	}
+	for _, n := range names {
+		rl, ok := eh.rateLimiterMap[n]
+		if !ok {
+			t.Errorf("rateLimiterMap missing entry for %q", n)
+			continue
+		}
+		if rl != custom {
+			t.Errorf("rateLimiterMap[%q] is not the configured default limiter (got %T)", n, rl)
+		}
+	}
+}

--- a/pkg/controller/interfaces.go
+++ b/pkg/controller/interfaces.go
@@ -42,7 +42,16 @@ type Store interface {
 // CallbackProvider provides functions that can be called with the result of
 // async operations.
 type CallbackProvider interface {
-	Create(name types.NamespacedName) terraform.CallbackFn
-	Update(name types.NamespacedName) terraform.CallbackFn
-	Destroy(name types.NamespacedName) terraform.CallbackFn
+	// Create signals completion of the async Create operation for
+	// the given name. If requestReconcile is set, an immediate or rate-limited
+	// reconcile request will be enqueued, depending on the error state.
+	Create(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
+	// Update signals completion of the async Update operation for
+	// the given name. If requestReconcile is set, an immediate or rate-limited
+	// reconcile request will be enqueued, depending on the error state.
+	Update(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
+	// Destroy signals completion of the async Destroy operation for
+	// the given name. If requestReconcile is set, an immediate or rate-limited
+	// reconcile request will be enqueued, depending on the error state.
+	Destroy(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR proposes the `handler.WithDefaultRateLimiter` `handler.Option` so that when initializing a new `handler.EventHandler` via `NewEventHandler`, one can now specify the default rate limiter to be used with the event handler when enqueuing reconciliation requests within the asynchronous callbacks:
```go
...
rl := reconciliationpolicy.NewExponentialFailureRateLimiter(time.Second, 60*time.Second)
eventHandler := handler.NewEventHandler(handler.WithDefaultRateLimiter(rl), handler.WithLogger(o.Logger.WithValues("gvk", v1beta2.Analyzer_GroupVersionKind)))
...
```

The need for this has surfaced when @jonasz-lasut made observations in https://github.com/crossplane-contrib/provider-upjet-azuread/pull/343.

This allows the event handler to use the same rate limiter with the associated controller.

This PR also addresses an issue where multiple reconciliation requests can be enqueued for the same failing async create/update/delete operation. The Terraform plugin SDKv2 & framework external clients now enqueue reconciliation requests in their async callback handlers when:
- The async operation has succeeded: This is needed so that the MR status conditions are properly updated immediately, without waiting for the next poll period expiration.
- The async operation has failed and there's no cached error to be returned back to the managed reconciler: When the async operation fails, the request needs to be enqueued with an exponential back-off. If there already exists a cached error to be returned to the managed reconciler, the callback handlers for the async create/update/delete operations no longer enqueue reconciliation requests because the managed reconciler will already enqueue a rate-limited request.

This PR also updates the signatures of the `controller.CallbackProvider` interface methods so that they now all accept a `requestReconcile` parameter:
```go
// CallbackProvider provides functions that can be called with the result of
// async operations.
type CallbackProvider interface {
	// Create signals completion of the async Create operation for
	// the given name. If requestReconcile is set, an immediate or rate-limited
	// reconcile request will be enqueued, depending on the error state.
	Create(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
	// Update signals completion of the async Update operation for
	// the given name. If requestReconcile is set, an immediate or rate-limited
	// reconcile request will be enqueued, depending on the error state.
	Update(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
	// Destroy signals completion of the async Destroy operation for
	// the given name. If requestReconcile is set, an immediate or rate-limited
	// reconcile request will be enqueued, depending on the error state.
	Destroy(name types.NamespacedName, requestReconcile bool) terraform.CallbackFn
}
```
This allows the caller to specify whether a rate-limited or immediate re-queue request is desired or not. 

**Note**: This PR introduces breaking changes in the `controller.CallbackProvider` interface. Unless a provider has implemented its own `CallbackProvider`, it should not be affected from these breaking changes though. We've already updated the existing `CallbackProvider` implementations that upjet ships. The rest of the existing behavior & APIs should remain backward-compatible with this PR.

**Note**: The behavior of the TF CLI-based external client has not changed with this PR. It always re-queues reconciliation requests, as before. Optimizations for the CLI-based external client are the topic of future PRs. Its behavior should NOT have  changed with this PR.


I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
The event handler behavior has also been manually validated against crossplane-contrib/provider-upjet-azuread. Please also see https://github.com/crossplane-contrib/provider-upjet-aws/pull/2104.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
