### PR TITLE
Fix Race on MR Status Between Async Callbacks & Managed Reconciler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,56 @@ jobs:
           flags: unittests
           files: _output/tests/linux_amd64/coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  race-tests:
+    runs-on: ubuntu-latest
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+    steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          large-packages: false
+          swap-storage: false
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(make go.cachedir)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-build-race-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-race-tests-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-pkg-race-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-race-tests-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      # Runs the unit tests with the Go race detector enabled to guard against
+      # regressions of concurrency bugs such as the managed resource status
+      # update data race. See: https://github.com/crossplane/upjet/issues/472
+      - name: Run Race Tests
+        run: make test.race

--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,14 @@ go.cachedir:
 go.mod.cachedir:
 	@go env GOMODCACHE
 
-.PHONY: reviewable submodules fallthrough go.mod.cachedir go.cachedir
+# test.race runs the unit tests with the Go race detector enabled. The race
+# detector requires cgo, so we enable it here.
+# Do NOT directly use the `go.test.unit` make target of
+# the build submodule here. There's a `pipefail` issue with that target,
+# which will mask any failing tests.
+test.race:
+	@$(INFO) go test race
+	@CGO_ENABLED=1 $(GOHOST) test -race $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
+	@$(OK) go test race
+
+.PHONY: reviewable submodules fallthrough go.mod.cachedir go.cachedir test.race

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -209,6 +209,10 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -225,8 +229,8 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 
 			n.opTracker.LastOperation.MarkEnd()
 			name := types.NamespacedName{
-				Namespace: mg.GetNamespace(),
-				Name:      mg.GetName(),
+				Namespace: mgCopy.GetNamespace(),
+				Name:      mgCopy.GetName(),
 			}
 			// we request an immediate reconcile upon success to set the status, or
 			// in case of failure (err != nil), if there's no cached error.
@@ -239,7 +243,7 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async create starting...")
-		_, ph.err = n.terraformPluginFrameworkExternalClient.Create(ctx, mg)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Create(ctx, mgCopy)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
@@ -251,6 +255,10 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -267,8 +275,8 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 
 			n.opTracker.LastOperation.MarkEnd()
 			name := types.NamespacedName{
-				Namespace: mg.GetNamespace(),
-				Name:      mg.GetName(),
+				Namespace: mgCopy.GetNamespace(),
+				Name:      mgCopy.GetName(),
 			}
 			// we request an immediate reconcile upon success to set the status, or
 			// in case of failure (err != nil), if there's no cached error.
@@ -281,7 +289,7 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async update starting...")
-		_, ph.err = n.terraformPluginFrameworkExternalClient.Update(ctx, mg)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Update(ctx, mgCopy)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginfw_test.go
+++ b/pkg/controller/external_async_tfpluginfw_test.go
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+)
+
+func prepareTerraformPluginFrameworkAsyncExternal(testConfig testConfiguration, fns CallbackFns) *terraformPluginFrameworkAsyncExternalClient {
+	return &terraformPluginFrameworkAsyncExternalClient{
+		terraformPluginFrameworkExternalClient: prepareTPFExternalWithTestConfig(testConfig),
+		callback:                               fns,
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkConnect(t *testing.T) {
+	type args struct {
+		setupFn terraform.SetupFn
+		cfg     *config.Resource
+		ots     *OperationTrackerStore
+		obj     xpresource.Managed
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Successful": {
+			args: args{
+				setupFn: func(_ context.Context, _ client.Client, _ xpresource.Managed) (terraform.Setup, error) {
+					return terraform.Setup{
+						FrameworkProvider: &mockTPFProvider{},
+					}, nil
+				},
+				cfg: newBaseUpjetConfig(),
+				obj: newObjAsync(),
+				ots: ots,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewTerraformPluginFrameworkAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginFrameworkAsyncLogger(logTest))
+			_, err := c.Connect(t.Context(), tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkObserve(t *testing.T) {
+	type want struct {
+		obs managed.ExternalObservation
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"NotExists": {
+			testConfiguration: testConfiguration{
+				r:               newMockBaseTPFResource(),
+				cfg:             newBaseUpjetConfig(),
+				obj:             newBaseObject(),
+				currentStateMap: nil,
+				plannedStateMap: map[string]any{
+					"name": "example",
+				},
+				params: map[string]any{
+					"name": "example",
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          false,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: false,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+			},
+		},
+		"UpToDate": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				params: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+				currentStateMap: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+				plannedStateMap: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: true,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{})
+			observation, err := terraformPluginFrameworkAsyncExternal.Observe(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
+				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkCreate(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:               newMockBaseTPFResource(),
+				cfg:             newBaseUpjetConfig(),
+				obj:             newBaseObject(),
+				currentStateMap: nil,
+				plannedStateMap: map[string]any{
+					"name": "example",
+				},
+				params: map[string]any{
+					"name": "example",
+				},
+				newStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Create(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Create(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkUpdate(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				currentStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+				plannedStateMap: map[string]any{
+					"name": "example-updated",
+					"id":   "example-id",
+				},
+				params: map[string]any{
+					"name": "example-updated",
+				},
+				newStateMap: map[string]any{
+					"name": "example-updated",
+					"id":   "example-id",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Update(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Update(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkDelete(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				currentStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+				plannedStateMap: nil,
+				params: map[string]any{
+					"name": "example",
+				},
+				newStateMap: nil,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Delete(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Delete(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+// TestAsyncTerraformPluginFrameworkCreateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Create
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginFrameworkCreateRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:               newMockBaseTPFResource(),
+		cfg:             newBaseUpjetConfig(),
+		currentStateMap: nil,
+		plannedStateMap: map[string]any{
+			"name": "example",
+		},
+		params: map[string]any{
+			"name": "example",
+		},
+		newStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Create(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Create(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginFrameworkUpdateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Update
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginFrameworkUpdateRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:   newMockBaseTPFResource(),
+		cfg: newBaseUpjetConfig(),
+		currentStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+		plannedStateMap: map[string]any{
+			"name": "example-updated",
+			"id":   "example-id",
+		},
+		params: map[string]any{
+			"name": "example-updated",
+		},
+		newStateMap: map[string]any{
+			"name": "example-updated",
+			"id":   "example-id",
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Update(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Update(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginFrameworkDeleteRace is a guard test asserting that
+// upjet's async Delete operation does not concurrently access a managed
+// resource's status while the managed reconciler does.
+// Current async client Delete does not modify MR status or spec.
+// Must be run with `go test -race`.
+func TestAsyncTerraformPluginFrameworkDeleteRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:   newMockBaseTPFResource(),
+		cfg: newBaseUpjetConfig(),
+		currentStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+		plannedStateMap: nil,
+		params: map[string]any{
+			"name": "example",
+		},
+		newStateMap: nil,
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Delete(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Delete(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		// Managed reconciler does not call SetObservation during deletion.
+		// This is an extra check at the moment.
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -143,6 +143,10 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -159,8 +163,8 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 
 			n.opTracker.LastOperation.MarkEnd()
 			name := types.NamespacedName{
-				Namespace: mg.GetNamespace(),
-				Name:      mg.GetName(),
+				Namespace: mgCopy.GetNamespace(),
+				Name:      mgCopy.GetName(),
 			}
 			// we request an immediate reconcile upon success to set the status, or
 			// in case of failure (err != nil), if there's no cached error.
@@ -173,7 +177,7 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async create starting...", "tfID", n.opTracker.GetTfID())
-		_, ph.err = n.terraformPluginSDKExternal.Create(ctx, mg)
+		_, ph.err = n.terraformPluginSDKExternal.Create(ctx, mgCopy)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
@@ -185,6 +189,10 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -201,8 +209,8 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 
 			n.opTracker.LastOperation.MarkEnd()
 			name := types.NamespacedName{
-				Namespace: mg.GetNamespace(),
-				Name:      mg.GetName(),
+				Namespace: mgCopy.GetNamespace(),
+				Name:      mgCopy.GetName(),
 			}
 			if cErr := n.callback.Update(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
@@ -211,7 +219,7 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async update starting...", "tfID", n.opTracker.GetTfID())
-		_, ph.err = n.terraformPluginSDKExternal.Update(ctx, mg)
+		_, ph.err = n.terraformPluginSDKExternal.Update(ctx, mgCopy)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -212,6 +212,10 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 				Namespace: mgCopy.GetNamespace(),
 				Name:      mgCopy.GetName(),
 			}
+			// we request an immediate reconcile upon success to set the status, or
+			// in case of failure (err != nil), if there's no cached error.
+			// If there already exists a cached error, managed reconciler
+			// will already requeue.
 			if cErr := n.callback.Update(name, err == nil || currentErr == nil)(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
 			}

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -113,7 +113,7 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginSDKAsyncLogger(logTest))
-			_, err := c.Connect(context.TODO(), tc.args.obj)
+			_, err := c.Connect(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -179,7 +179,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, CallbackFns{})
-			observation, err := terraformPluginSDKAsyncExternal.Observe(context.TODO(), tc.args.obj)
+			observation, err := terraformPluginSDKAsyncExternal.Observe(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
@@ -226,7 +226,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Create(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Create(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Create(...): -want error, +got error:\n", diff)
 			}
@@ -270,7 +270,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Update(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Update(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Update(...): -want error, +got error:\n", diff)
 			}
@@ -314,12 +314,142 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Delete(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Delete(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Delete(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
+}
+
+// TestAsyncTerraformPluginSDKCreateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Create
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginSDKCreateRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Create(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Create(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginSDKUpdateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Update
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginSDKUpdateRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Update(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Update(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginSDKDeleteRace is a guard test asserting that upjet's
+// async Delete operation does not concurrently access a managed resource's
+// status while the managed reconciler does. Current async client Delete
+// implementation does not modify MR status or spec.
+// Must be run with `go test -race`.
+func TestAsyncTerraformPluginSDKDeleteRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Delete(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Delete(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		// Managed reconciler does not call SetObservation during deletion.
+		// This is an extra check at the moment.
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
 }
 
 func newObjAsync() *fake.Terraformed {

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -61,20 +61,6 @@ var (
 			return nil, nil
 		}},
 	}
-	objAsync = &fake.Terraformed{
-		Parameterizable: fake.Parameterizable{
-			Parameters: map[string]any{
-				"name": "example",
-				"map": map[string]any{
-					"key": "value",
-				},
-				"list": []any{"elem1", "elem2"},
-			},
-		},
-		Observable: fake.Observable{
-			Observation: map[string]any{},
-		},
-	}
 )
 
 func prepareTerraformPluginSDKAsyncExternal(r Resource, cfg *config.Resource, fns CallbackFns) *terraformPluginSDKAsyncExternal {
@@ -119,7 +105,7 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 					return terraform.Setup{}, nil
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				ots: ots,
 			},
 		},
@@ -157,7 +143,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
@@ -177,7 +163,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
@@ -226,7 +212,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					CreateFn: func(nn types.NamespacedName) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -242,7 +228,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Create(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Create(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
@@ -270,7 +256,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					UpdateFn: func(nn types.NamespacedName) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -286,7 +272,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Update(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Update(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
@@ -314,7 +300,7 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					DestroyFn: func(nn types.NamespacedName) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -330,8 +316,25 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Delete(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Delete(...): -want error, +got error:\n", diff)
 			}
 		})
+	}
+}
+
+func newObjAsync() *fake.Terraformed {
+	return &fake.Terraformed{
+		Parameterizable: fake.Parameterizable{
+			Parameters: map[string]any{
+				"name": "example",
+				"map": map[string]any{
+					"key": "value",
+				},
+				"list": []any{"elem1", "elem2"},
+			},
+		},
+		Observable: fake.Observable{
+			Observation: map[string]any{},
+		},
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #472 

The async TF plugin SDKv2 and framework external clients can potentially race when calling `SetObservation` on the MR status with crossplane-runtime's managed reconciler. The following stack traces from `upbound/provider-aws-rds:v1.23.0` demonstrates the race:
```
...
goroutine 46312177 [runnable]:
reflect.mapassign0(0x190ce800, 0x4002f5cd10?, 0x400382acf0?, 0x4002f5cd10)
	/opt/hostedtoolcache/go/1.23.8/x64/src/runtime/map.go:1487 +0x24
reflect.mapassign(0x400382acf0?, 0x45d664?, 0x400382acf0?, 0x65736c61?)
	/opt/hostedtoolcache/go/1.23.8/x64/src/reflect/value.go:3904 +0xac
github.com/modern-go/reflect2.(*UnsafeMapType).UnsafeSetIndex(...)
	/home/runner/go/pkg/mod/github.com/modern-go/reflect2@v1.0.2/unsafe_map.go:76
github.com/json-iterator/go.(*mapDecoder).Decode(0x400199dbd0, 0x4006ad5af0, 0x400382acf0)
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect_map.go:191 +0x330
github.com/json-iterator/go.(*placeholderDecoder).Decode(0x4008654e60?, 0x4006ad5ae0?, 0x4006a81c58?)
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect.go:324 +0x28
github.com/json-iterator/go.(*structFieldDecoder).Decode(0x40086550a0, 0x4507f0?, 0x400382acf0)
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect_struct_decoder.go:1054 +0x54
github.com/json-iterator/go.(*eightFieldsStructDecoder).Decode(0x4009a75170, 0x4006ad5aa8, 0x400382acf0)
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect_struct_decoder.go:895 +0x170
github.com/json-iterator/go.(*Iterator).ReadVal(0x400382acf0, {0x198a7060, 0x4006ad5aa8})
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect.go:79 +0x134
github.com/json-iterator/go.(*frozenConfig).Unmarshal(0x40007c2320, {0x4006fb0000?, 0x400928b7a0?, 0x400928b020?}, {0x198a7060, 0x4006ad5aa8})
	/home/runner/go/pkg/mod/github.com/json-iterator/go@v1.1.12/config.go:348 +0x70
github.com/upbound/provider-aws/apis/rds/v1beta1.(*ParameterGroup).SetObservation(0x4006ad58c8, 0x40047d1380?)
	/runner/_work/provider-aws-rds/provider-aws-rds/apis/rds/v1beta1/zz_parametergroup_terraformed.go:43 +0x98
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKExternal).Update(0x40039822d0, {0x1f0d2580, 0x40010bf3b0}, {0x1f29c2e8, 0x4006ad58c8})
	/home/runner/go/pkg/mod/github.com/crossplane/upjet@v1.5.2-0.20250612145416-771188e36da2/pkg/controller/external_tfpluginsdk.go:723 +0x3b0
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKAsyncExternal).Update.func1()
	/home/runner/go/pkg/mod/github.com/crossplane/upjet@v1.5.2-0.20250612145416-771188e36da2/pkg/controller/external_async_tfpluginsdk.go:199 +0x18c
created by github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKAsyncExternal).Update in goroutine 14346
	/home/runner/go/pkg/mod/github.com/crossplane/upjet@v1.5.2-0.20250612145416-771188e36da2/pkg/controller/external_async_tfpluginsdk.go:178 +0x120
```
, and
```
...
goroutine 14346 [running]:
reflect.mapassign_faststr0(0x190ce800, 0xf1ea4?, {0x400d2b0b10?, 0x17e65d60?}, 0x400e1644c0)
	/opt/hostedtoolcache/go/1.23.8/x64/src/runtime/map.go:1493 +0x28
reflect.mapassign_faststr(0x17e65d60?, 0x400e1644c0?, {0x400d2b0b10, 0x13}, 0x19?)
	/opt/hostedtoolcache/go/1.23.8/x64/src/reflect/value.go:3913 +0xbc
reflect.Value.SetMapIndex({0x190ce800?, 0x4006ad5ae8?, 0x10e5?}, {0x1844c720, 0x400c928290, 0x98}, {0x17e65d60, 0x400e1644c0, 0x196})
	/opt/hostedtoolcache/go/1.23.8/x64/src/reflect/value.go:2458 +0x1c4
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0x400df19380, {0x190ce800?, 0x4006ad5ae8?, 0x12ff?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:909 +0x13c4
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0x400df19380, {0x190ce800?, 0x4006ad5ae8?, 0x4?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x40
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0x400df19380, {0x1b277e00?, 0x4006ad5aa8?, 0x1b83e0a0?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0xe90
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0x400df19380, {0x1b277e00?, 0x4006ad5aa8?, 0xa?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x40
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0x400df19380, {0x1a2cdc80?, 0x4006ad5a88?, 0x2fce?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0xe90
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0x400df19380, {0x1a2cdc80?, 0x4006ad5a88?, 0x6?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x40
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0x400df19380, {0x1b8eaf60?, 0x4006ad58c8?, 0x2a19cc?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0xe90
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0x400df19380, {0x1b8eaf60?, 0x4006ad58c8?, 0x2a1010?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x40
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).unmarshal(0x400df19380, {0x1b8eaf60?, 0x4006ad58c8?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:188 +0x100
sigs.k8s.io/json/internal/golang/encoding/json.Unmarshal({0x4006b7d000, 0x2643, 0x3000}, {0x1b8eaf60, 0x4006ad58c8}, {0x400617ec50, 0x2, 0x400617ec30?})
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:113 +0x124
sigs.k8s.io/json.UnmarshalCaseSensitivePreserveInts(...)
	/home/runner/go/pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/json.go:62
k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).unmarshal(0x1ee4ad70?, {0x1ee61000?, 0x4006ad58c8?}, {0x4006b7d000?, 0x400bff76a0?, 0x12?}, {0x4006b7d000?, 0x7?, 0x400d899480?})
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.30.0/pkg/runtime/serializer/json/json.go:258 +0x188
k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode(0x40014b1590, {0x4006b7d000, 0x2643, 0x3000}, 0x0, {0x1ee61000, 0x4006ad58c8})
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.30.0/pkg/runtime/serializer/json/json.go:206 +0x4dc
k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode({{0x1edda380?, 0x40014b1590?}}, {0x4006b7d000?, 0x199?, 0x1b8eaf60?}, 0x4006ad58c8?, {0x1ee61000?, 0x4006ad58c8?})
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.30.0/pkg/runtime/helper.go:256 +0x50
sigs.k8s.io/controller-runtime/pkg/client/apiutil.targetZeroingDecoder.Decode({{0x1edd3360?, 0x400d1819f0?}}, {0x4006b7d000, 0x2643, 0x3000}, 0x0, {0x1ee61000, 0x4006ad58c8})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/client/apiutil/apimachinery.go:215 +0x8c
k8s.io/client-go/rest.Result.Into({{0x4006b7d000, 0x2643, 0x3000}, {0x0, 0x0, 0x0}, {0x400de41170, 0x10}, {0x0, 0x0}, ...}, ...)
	/home/runner/go/pkg/mod/k8s.io/client-go@v0.30.0/rest/request.go:1373 +0x98
sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).UpdateSubResource(0x40006510e0, {0x1f0d2580, 0x40010e97a0}, {0x1f210198, 0x4006ad58c8}, {0x1bac435e, 0x6}, {0x0, 0x0, 0x0?})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/client/typed_client.go:247 +0x470
sigs.k8s.io/controller-runtime/pkg/client.(*subResourceClient).Update(0x400b2a7ea8, {0x1f0d2580, 0x40010e97a0}, {0x1f210198, 0x4006ad58c8}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/client/client.go:590 +0x1e8
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0x40053cefc0, {0x1f0d24d8, 0x400e6afdd0}, {{{0x0, 0x0}, {0x400e6e78a8, 0x13}}})
	/home/runner/go/pkg/mod/github.com/crossplane/crossplane-runtime@v1.17.0/pkg/reconciler/managed/reconciler.go:1309 +0x7820
github.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile(0x40014a4a00, {0x1f0d24d8, 0x400e6afdd0}, {{{0x0?, 0x5?}, {0x400e6e78a8?, 0x400a3a6d08?}}})
	/home/runner/go/pkg/mod/github.com/crossplane/crossplane-runtime@v1.17.0/pkg/ratelimiter/reconciler.go:54 +0x124
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1f103910?, {0x1f0d24d8?, 0x400e6afdd0?}, {{{0x0?, 0xb?}, {0x400e6e78a8?, 0x0?}}})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:114 +0x80
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x40088893f0, {0x1f0d2510, 0x40014b1ae0}, {0x1a3bcb80, 0x400b6c8920})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:311 +0x2d0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x40088893f0, {0x1f0d2510, 0x40014b1ae0})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:261 +0x158
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:222 +0x70
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 4336
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:218 +0x3b8
```

Goroutine `14346` corresponds to the managed reconciler doing a `Status.Update` concurrently with the async SDKv2 client (goroutine `46312177`) doing a `SetObservation` on the very same object.

The data race sometimes manifests itself with a `fatal error: concurrent map writes` (in which case the provider pod crashes) but we've also observed cases where it manifests itself with a recoved panic as in:
```
E0505 03:20:54 Observed a panic: "assignment to entry in nil map"
...
github.com/modern-go/reflect2.(*UnsafeMapType).UnsafeSetIndex(...)        unsafe_map.go:76
github.com/json-iterator/go.(*mapDecoder).Decode(...)                     reflect_map.go:191
github.com/json-iterator/go.(*structFieldDecoder).Decode(...)
github.com/json-iterator/go.(*eightFieldsStructDecoder).Decode(...)
github.com/json-iterator/go.(*frozenConfig).Unmarshal(...)               config.go:348
github.com/upbound/provider-aws/apis/rds/v1beta1.(*ParameterGroup).SetObservation(...)
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKExternal).Update(...)     external_tfpluginsdk.go:723
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKAsyncExternal).Update.func1()  external_async_tfpluginsdk.go:199
created by ...terraformPluginSDKAsyncExternal.Update in goroutine 14358                        external_async_tfpluginsdk.go:178
```
, depending on the ordering of the calls.

This PR introduces data-race tests for both clients (among some other tests for the async framework client), runs them in the CI, and addresses the data race by making a deep-copy of the MR before it's handed over to the async workers.

The effectiveness of the fix has also been verified via the introduced data race tests.

**Note**: We could carry out a similar investigation for the TF CLI-based external client's async operations but we currently lack any proper reports for such an analysis. This PR thus only focuses on the async plugin SDKv2 & framework external client issues, such as the ones reported in https://github.com/crossplane/upjet/issues/472, https://github.com/crossplane-contrib/provider-upjet-aws/issues/1487 or https://github.com/crossplane-contrib/provider-upjet-aws/issues/1426.

Thank you @jake-ciolek & @chlunde for the investigations & discussions in https://github.com/crossplane/upjet/issues/472, those discussions have been extremely helpful in understanding the issues.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The newly implemented data race detection tests for the Terraform plugin SDKv2 and framework external clients are failing without the fixes as expected here: https://github.com/crossplane/upjet/actions/runs/27228955559/job/80403667522?pr=670

And they are passing with the proposed fixes here: https://github.com/crossplane/upjet/actions/runs/27229964678/job/80407207794?pr=670

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
