### PR TITLE
feat: add Description field to SSA InjectedKey

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -384,6 +384,7 @@ func setExternalTagsWithPaved(externalTags map[string]string, paved *fieldpath.P
 type InjectedKey struct {
 	Key          string
 	DefaultValue string
+	Description  string
 }
 
 // ListMapKeys is the list map keys when the server-side apply merge strategy

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -384,7 +384,9 @@ func setExternalTagsWithPaved(externalTags map[string]string, paved *fieldpath.P
 type InjectedKey struct {
 	Key          string
 	DefaultValue string
-	Description  string
+	// Description is the OpenAPI schema description for the injected list-map key field.
+	// If empty, defaults to a standard description about server-side apply merge behavior.
+	Description string
 }
 
 // ListMapKeys is the list map keys when the server-side apply merge strategy

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -120,10 +120,14 @@ func injectServerSideApplyListMergeKeys(cfg *config.Resource) error { //nolint:g
 				return errors.Errorf("element schema for the object list %q already contains the argument key %q", f, k)
 			}
 		}
+		desc := descriptionInjectedKey
+		if s.ListMergeStrategy.ListMapKeys.InjectedKey.Description != "" {
+			desc = s.ListMergeStrategy.ListMapKeys.InjectedKey.Description
+		}
 		el.Schema[s.ListMergeStrategy.ListMapKeys.InjectedKey.Key] = &schema.Schema{
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: descriptionInjectedKey,
+			Description: desc,
 		}
 		if s.ListMergeStrategy.ListMapKeys.InjectedKey.DefaultValue != "" {
 			el.Schema[s.ListMergeStrategy.ListMapKeys.InjectedKey.Key].Default = s.ListMergeStrategy.ListMapKeys.InjectedKey.DefaultValue

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -209,6 +209,97 @@ func TestBuilder_generateTypeName(t *testing.T) {
 	}
 }
 
+func TestInjectServerSideApplyListMergeKeys(t *testing.T) {
+	type want struct {
+		description string
+		err         error
+	}
+	cases := map[string]struct {
+		cfg  *config.Resource
+		want want
+	}{
+		"DefaultDescription": {
+			cfg: &config.Resource{
+				TerraformResource: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule": {
+							Type: schema.TypeList,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {Type: schema.TypeString},
+								},
+							},
+						},
+					},
+				},
+				ServerSideApplyMergeStrategies: map[string]config.MergeStrategy{
+					"rule": {
+						ListMergeStrategy: config.ListMergeStrategy{
+							MergeStrategy: config.ListTypeMap,
+							ListMapKeys: config.ListMapKeys{
+								InjectedKey: config.InjectedKey{
+									Key: "index",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				description: descriptionInjectedKey,
+			},
+		},
+		"CustomDescription": {
+			cfg: &config.Resource{
+				TerraformResource: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule": {
+							Type: schema.TypeList,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {Type: schema.TypeString},
+								},
+							},
+						},
+					},
+				},
+				ServerSideApplyMergeStrategies: map[string]config.MergeStrategy{
+					"rule": {
+						ListMergeStrategy: config.ListMergeStrategy{
+							MergeStrategy: config.ListTypeMap,
+							ListMapKeys: config.ListMapKeys{
+								InjectedKey: config.InjectedKey{
+									Key:         "index",
+									Description: "Custom description for the injected key.",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				description: "Custom description for the injected key.",
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			err := injectServerSideApplyListMergeKeys(tc.cfg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("injectServerSideApplyListMergeKeys(...): -want error, +got error: %s", diff)
+			}
+			if err != nil {
+				return
+			}
+			el := tc.cfg.TerraformResource.Schema["rule"].Elem.(*schema.Resource)
+			got := el.Schema["index"].Description
+			if diff := cmp.Diff(tc.want.description, got); diff != "" {
+				t.Errorf("injectServerSideApplyListMergeKeys(...) description: -want, +got: %s", diff)
+			}
+		})
+	}
+}
+
 func TestBuild(t *testing.T) {
 	type args struct {
 		crdScope CRDScope


### PR DESCRIPTION
### Description of your changes

Add a customizable `Description` field to `InjectedKey` struct. Before, SSA injected keys always got hardcoded description.

Now providers can set their own description. For instance, omit the **_"this is an injected field with a default value..."_** sentence, which might be misleading when there isn't a default value set.

Fixes #671 

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Add unit test.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md