### PR TITLE
Decouple conversion webhook registration from leader election

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -23,6 +23,15 @@ import (
 	{{ .Imports }}
 )
 
+// SetupWebhookWithManager registers the conversion webhook for {{ .CRD.Kind }}.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }}")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles {{ .CRD.Kind }} managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -120,15 +129,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	{{- end}}
 	if o.MetricOptions != nil {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
-	}
-
-	// register webhooks for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }}
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }}")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -39,3 +39,17 @@ func SetupGated{{ .Group }}(mgr ctrl.Manager, o controller.Options) error {
 	}
 	return nil
 }
+
+// SetupWebhookWithManager{{ .Group }} registers conversion webhooks for all resource kinds in the group.
+func SetupWebhookWithManager{{ .Group }}(mgr ctrl.Manager) error {
+	for _, setup := range []func(ctrl.Manager) error{
+		{{- range $alias := .Aliases }}
+		{{ $alias }}SetupWebhookWithManager,
+		{{- end }}
+	} {
+		if err := setup(mgr); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Description of your changes

Conversion webhook registration was accidentally gated behind leader election through the `SetupGated`/gate mechanism. `SetupGated` stores a closure that only fires on the elected leader, so follower pods never called `ctrl.NewWebhookManagedBy` and their webhook servers returned 404 for every conversion request. With two replicas and `--leader-election`, some conversion webhook calls fail.

The fix separates webhook registration from reconciler setup:

- **`controller.go.tmpl`**: adds `SetupWebhookWithManager` — a standalone function that registers the conversion webhook for a single resource kind. Removes the `if o.StartWebhooks { ... }` block from `Setup`; webhook registration is no longer the reconciler's responsibility.

- **`setup.go.tmpl`**: adds the `SetupWebhookWithManager{{ .Group }}` aggregator, following the same pattern as `Setup{{ .Group }}` and `SetupGated{{ .Group }}`, so providers can register all webhooks for a group in a single call.

Providers call `SetupWebhookWithManager_<group>` once before `mgr.Start()` on every pod, independent of the gate and leader election. Reconciler setup remains behind the gate and runs only on the leader.

See the generated provider with these changes: https://github.com/crossplane-contrib/provider-upjet-gcp/pull/953 and https://github.com/crossplane-contrib/provider-upjet-aws/pull/2122

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally by sending webhook calls to the webhook handlers.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
