### PR TITLE
Set WithDeterministicExternalName on generated controllers

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -117,6 +117,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
     {{- end }}
 		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
+		managed.WithDeterministicExternalName({{ not .DisableNameInitializer }}),
 		managed.WithPollInterval(o.PollInterval),
 	}
 	if o.PollJitter != 0 {


### PR DESCRIPTION
### Description of your changes

Generated controllers never pass `managed.WithDeterministicExternalName`, so `deterministicExternalName` is always false for every upjet resource. A resource with a user-supplied (deterministic) external name then cannot recover from an incomplete create: if `external-create-pending` ends up the newest of the three create-* annotations (for example the provider restarts mid async create), crossplane-runtime refuses to retry and the MR sticks indefinitely on:

```
cannot determine creation result - remove the external-create-pending annotation if it is safe to proceed
```

crossplane-runtime already handles this safely: with `deterministicExternalName` true it logs "proceeding due to deterministic external name" and continues, because re-queuing a deterministically named resource cannot leak one. This passes that flag, derived from the existing `DisableNameInitializer` template variable (`IdentifierFromProvider` sets it true, so non-deterministic; user-supplied external names leave it false, so deterministic).

Fixes #681

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`make reviewable` passes (generate is a no-op, lint and unit tests green). I also rendered the changed template fragment directly to confirm the output: `DisableNameInitializer` true yields `managed.WithDeterministicExternalName(false)`, false yields `(true)`. No committed golden/fixture controllers reference these opts, so there is nothing to regenerate.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
