### PR TITLE
Add support for Terraform runtime conversions in CLI-based external client

### DIFF
--- a/pkg/config/tf_conversion.go
+++ b/pkg/config/tf_conversion.go
@@ -46,6 +46,8 @@ type TerraformConversion interface {
 // ApplyTFConversions applies the configured Terraform conversions on the
 // specified params map in the given mode, i.e., from Crossplane layer to the
 // Terraform layer or vice versa.
+// WARNING: The original params map and the returned map from
+// ApplyTFConversions share the same map object.
 func (r *Resource) ApplyTFConversions(params map[string]any, mode Mode) (map[string]any, error) {
 	var err error
 	for _, c := range r.TerraformConversions {

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -245,9 +245,6 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &tfstate); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot unmarshal state attributes")
 	}
-	if err := tr.SetObservation(tfstate); err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
-	}
 
 	// NOTE(lsviben) although the annotations were supposed to be set and the
 	// managed resource updated during the Create step, we are checking and
@@ -276,9 +273,23 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot get connection details")
 	}
 
+	// Apply Terraform conversions.
+	tfstate, err = e.config.ApplyTFConversions(tfstate, config.FromTerraform)
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, "cannot apply terraform conversions")
+	}
+	// Set the MR state using any Terraform runtime conversions applied.
+	if err := tr.SetObservation(tfstate); err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
+	}
+
 	var lateInitedParams bool
 	if policyHasLateInit {
-		lateInitedParams, err = tr.LateInitialize(res.State.GetAttributes())
+		buff, err := json.JSParser.Marshal(tfstate)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "cannot marshal state attributes")
+		}
+		lateInitedParams, err = tr.LateInitialize(buff)
 		if err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, "cannot late initialize parameters")
 		}
@@ -433,11 +444,16 @@ func (e *external) Update(ctx context.Context, mg xpresource.Managed) (managed.E
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errApply)
 	}
-	attr := map[string]any{}
-	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &attr); err != nil {
+	tfstate := map[string]any{}
+	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &tfstate); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot unmarshal state attributes")
 	}
-	return managed.ExternalUpdate{}, errors.Wrap(tr.SetObservation(attr), "cannot set observation")
+	// Apply Terraform conversions.
+	tfstate, err = e.config.ApplyTFConversions(tfstate, config.FromTerraform)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot apply terraform conversions")
+	}
+	return managed.ExternalUpdate{}, errors.Wrap(tr.SetObservation(tfstate), "cannot set observation")
 }
 
 func (e *external) Delete(ctx context.Context, mg xpresource.Managed) (managed.ExternalDelete, error) {
@@ -497,12 +513,20 @@ func (e *external) Import(ctx context.Context, tr resource.Terraformed) (managed
 	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &tfstate); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot unmarshal state attributes")
 	}
-	if err := tr.SetObservation(tfstate); err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
-	}
+
 	conn, err := resource.GetConnectionDetails(tfstate, tr, e.config)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot get connection details")
+	}
+
+	// Apply Terraform conversions.
+	tfstate, err = e.config.ApplyTFConversions(tfstate, config.FromTerraform)
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, "cannot apply terraform conversions when importing")
+	}
+	// Set the MR state using any Terraform runtime conversions applied.
+	if err := tr.SetObservation(tfstate); err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation when importing")
 	}
 
 	tr.SetConditions(xpv1.Available())

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -110,20 +110,26 @@ func NewFileProducer(ctx context.Context, client resource.SecretClient, dir stri
 		}
 	}
 
-	if err = resource.GetSensitiveParameters(ctx, client, tr, params, tr.GetConnectionDetailsMapping()); err != nil {
-		return nil, errors.Wrap(err, "cannot get sensitive parameters")
-	}
-	fp.Config.ExternalName.SetIdentifierArgumentFn(params, meta.GetExternalName(tr))
-	// apply dynamic-pseudo type conversions to params here
+	// Apply Terraform conversions.
 	params, err = cfg.ApplyTFConversions(params, config.ToTerraform)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot apply terraform parameter conversions")
 	}
+	if err = resource.GetSensitiveParameters(ctx, client, tr, params, tr.GetConnectionDetailsMapping()); err != nil {
+		return nil, errors.Wrap(err, "cannot get sensitive parameters")
+	}
+	fp.Config.ExternalName.SetIdentifierArgumentFn(params, meta.GetExternalName(tr))
 	fp.parameters = params
 
 	obs, err := tr.GetObservation()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get observation")
+	}
+
+	// Apply Terraform conversions.
+	obs, err = cfg.ApplyTFConversions(obs, config.ToTerraform)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot apply terraform conversions on MR state")
 	}
 
 	secretRef, err := getConnectionSecretRef(tr)
@@ -171,7 +177,7 @@ type FileProducer struct {
 }
 
 // BuildMainTF produces the contents of the mainTF file as a map.  This format is conducive to
-// inspection for tests.  WriteMainTF calls this function an serializes the result to a file as JSON.
+// inspection for tests.  WriteMainTF calls this function and serializes the result to a file as JSON.
 func (fp *FileProducer) BuildMainTF() map[string]any {
 	// If the resource is in a deletion process, we need to remove the deletion
 	// protection.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR adds support for Terraform runtime conversions in the Terraform CLI-based external client. @sergenyalcin is working on a Crossplane provider for f5xc based on https://github.com/volterraedge/terraform-provider-volterra and it's CLI-based. Currently, when we try to convert the singleton lists in that provider's APIs to embedded objects, the reconciliations fail at runtime.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested against a Crossplane provider based on https://github.com/volterraedge/terraform-provider-volterra.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
