### PR TITLE
Set InstanceState's RawConfig & RawPlan if Resource is not found

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -521,6 +521,18 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 	} else if diffState != nil {
 		diffState.Attributes = nil
 		diffState.ID = ""
+		// We still need to populate a non-nil RawPlan & RawConfig in InstanceState
+		// as the Terraform provider being called with this state may assume that
+		// they are not nil. An example is Terraform AWS provider's
+		// transparent tagging interceptor, which calls
+		// ResourceDiff.GetRawPlan().GetAttr("tags"), which will panic on the
+		// zero cty.Value with "value is not an object".
+		if diffState.RawPlan.IsNull() {
+			diffState.RawPlan = n.rawConfig
+		}
+		if diffState.RawConfig.IsNull() {
+			diffState.RawConfig = n.rawConfig
+		}
 	}
 
 	n.instanceDiff = nil

--- a/pkg/controller/external_tfpluginsdk_test.go
+++ b/pkg/controller/external_tfpluginsdk_test.go
@@ -168,7 +168,7 @@ func TestTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKConnector(nil, tc.args.setupFn, tc.args.cfg, tc.args.ots, WithTerraformPluginSDKLogger(logTest))
-			_, err := c.Connect(context.TODO(), &tc.args.obj)
+			_, err := c.Connect(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -271,12 +271,109 @@ func TestTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			observation, err := terraformPluginSDKExternal.Observe(context.TODO(), &tc.args.obj)
+			observation, err := terraformPluginSDKExternal.Observe(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+// TestTerraformPluginSDKObserveNotFound is a regression test
+// for the "value is not an object" panic (e.g., in provider-aws).
+// When Observe calls schema.Diff with an InstanceState whose RawPlan is
+// the zero cty.Value, the AWS provider's setTagsAll() interceptor calls
+// diff.GetRawPlan().GetAttr("tags"), and go-cty's Value.GetAttr panics with
+// "value is not an object" on the nil cty.Value.
+// The same applies to RawConfig.
+func TestTerraformPluginSDKObserveNotFound(t *testing.T) {
+	tagsTimeout := timeout
+	cases := map[string]struct {
+		customizeDiff schema.CustomizeDiffFunc
+		description   string
+	}{
+		"RawConfig": {
+			customizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+				// Calling d.GetRawConfig().GetAttr on a zero RawConfig will panic.
+				_ = d.GetRawConfig().GetAttr("name")
+				return nil
+			},
+			description: "Observed a panic when reading from InstanceState.RawConfig",
+		},
+		"RawPlan": {
+			customizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+				// Calling d.GetRawPlan().GetAttr on a zero RawPlan will panic.
+				_ = d.GetRawPlan().GetAttr("tags")
+				return nil
+			},
+			description: "Observed a panic when reading from InstanceState.RawPlan",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfgWithTags := &config.Resource{
+				TerraformResource: &schema.Resource{
+					Timeouts: &schema.ResourceTimeout{
+						Create: &tagsTimeout,
+						Read:   &tagsTimeout,
+						Update: &tagsTimeout,
+						Delete: &tagsTimeout,
+					},
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"tags_all": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+					CustomizeDiff: tc.customizeDiff,
+				},
+				ExternalName: config.IdentifierFromProvider,
+				Sensitive: config.Sensitive{AdditionalConnectionDetailsFn: func(_ map[string]any) (map[string][]byte, error) {
+					return nil, nil
+				}},
+			}
+
+			notFound := mockResource{
+				RefreshWithoutUpgradeFn: func(_ context.Context, _ *tf.InstanceState, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+					// Force into the state where the op tracker cache exists
+					// but resource is not found.
+					return nil, nil
+				},
+			}
+
+			ext := prepareTerraformPluginSDKExternal(notFound, cfgWithTags)
+			ext.opTracker.SetTfState(&tf.InstanceState{
+				ID:         "example-id",
+				Attributes: map[string]string{"name": "example"},
+			})
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%s: %v", tc.description, r)
+				}
+			}()
+
+			_, err := ext.Observe(t.Context(), &obj)
+			if err != nil {
+				t.Fatalf("Observe(...) returned an unexpected error: %v", err)
 			}
 		})
 	}
@@ -324,7 +421,7 @@ func TestTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Create(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Create(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -360,7 +457,7 @@ func TestTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Update(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Update(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -396,7 +493,7 @@ func TestTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Delete(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Delete(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR proposes to set `InstanceState`'s `RawConfig` & `RawPlan` in case the TF state has been cached previously with a zero-valued `RawConfig` or `RawPlan`, and the external resource is now not found. Currently, if there's a cached Terraform state in the tracker store but the external client's `Observe` finds out that the external resource does not (yet) exist, `RawConfig` and `RawPlan` may stay `nil`. And this may panic the underlying Terraform provider in case it tries to read an attribute from the `RawConfig` or `RawPlan`, such as the Terraform AWS provider's tagging interceptor.

We have not been able to reproduce this issue but a review of the external client implementation reveals this can potentially happen right after a successful `Create`. And we've received the following logs from an older version (`v1.21.0`) of the AWS provider, where the Terraform provider accesses the `RawPlan` in `verify.SetTagsDiff`:

```
E0612 09:33:22.750019       1 runtime.go:77] Observed a panic: value is not an object
goroutine 10118 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1b6d6d00, 0x21fef880})
	k8s.io/apimachinery@v0.30.0/pkg/util/runtime/runtime.go:75 +0x85
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:103 +0xb2
panic({0x1b6d6d00?, 0x21fef880?})
	runtime/panic.go:785 +0x132
github.com/hashicorp/go-cty/cty.Value.GetAttr({{{0x0?, 0x0?}}, {0x0?, 0x0?}}, {0x1ed33191, 0x4})
	github.com/hashicorp/go-cty@v1.4.1-0.20200723130312-85980079f637/cty/value_ops.go:695 +0x2fd
github.com/hashicorp/terraform-provider-aws/internal/verify.SetTagsDiff({0x2232a818, 0xc0072ecf60}, 0xc01ec8cb40, {0x1ed18740?, 0xc0048a9d00?})
	github.com/hashicorp/terraform-provider-aws@v0.0.0-00010101000000-000000000000/internal/verify/diff.go:38 +0x165
github.com/hashicorp/terraform-provider-aws/internal/provider.New.(*wrappedResource).CustomizeDiff.func6({0x2232a8c0?, 0xc00c503730?}, 0xc01ec8cb40, {0x1ed18740, 0xc0048a9d00})
	github.com/hashicorp/terraform-provider-aws@v0.0.0-00010101000000-000000000000/internal/provider/intercept.go:186 +0x63
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0xc00179c720, {0x2232a8c0, 0xc00c503730}, 0xc006803380, 0xc001748690, 0xc001750678, {0x1ed18740, 0xc0048a9d00}, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/schema.go:698 +0x4b4
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKExternal).getResourceDataDiff(0xc009bc12c0, {0x2252f4c0, 0xc008f6a308}, {0x2232a8c0, 0xc00c503730}, 0xc006803380, 0x0)
	github.com/crossplane/upjet@v1.5.0/pkg/controller/external_tfpluginsdk.go:421 +0xb5
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKExternal).Observe(0xc009bc12c0, {0x2232a8c0, 0xc00c503730}, {0x224f5b78, 0xc008f6a308})
	github.com/crossplane/upjet@v1.5.0/pkg/controller/external_tfpluginsdk.go:504 +0x851
github.com/crossplane/upjet/pkg/controller.(*terraformPluginSDKAsyncExternal).Observe(0xc017e66ce0, {0x2232a8c0, 0xc00c503730}, {0x224f5b78, 0xc008f6a308})
	github.com/crossplane/upjet@v1.5.0/pkg/controller/external_async_tfpluginsdk.go:127 +0xc5
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0xc00d1a3b00, {0x2232a818, 0xc01e7fc6c0}, {{{0x0, 0x0}, {0xc01b9e97d0, 0x29}}})
	github.com/crossplane/crossplane-runtime@v1.17.0/pkg/reconciler/managed/reconciler.go:973 +0x211f
github.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile(0xc00d236a00, {0x2232a818, 0xc01e7fc6c0}, {{{0x0?, 0x5?}, {0xc01b9e97d0?, 0xc00c1c7d10?}}})
	github.com/crossplane/crossplane-runtime@v1.17.0/pkg/ratelimiter/reconciler.go:54 +0x151
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2235bad0?, {0x2232a818?, 0xc01e7fc6c0?}, {{{0x0?, 0xb?}, {0xc01b9e97d0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:114 +0xa5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc010384630, {0x2232a850, 0xc001603900}, {0x1d6390a0, 0xc002e5c400})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:311 +0x39c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc010384630, {0x2232a850, 0xc001603900})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:261 +0x19d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:222 +0x73
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 2655
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:218 +0x46c
```

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I've added a regression test that setups up the panic conditions.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
