### PR TITLE
[Backport release-1.10] fix(types): omit XValidation for required fields with references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,4 +194,58 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           flags: unittests
-          file: _output/tests/linux_amd64/coverage.txt
+          files: _output/tests/linux_amd64/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  race-tests:
+    runs-on: ubuntu-latest
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+    steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          large-packages: false
+          swap-storage: false
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(make go.cachedir)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-build-race-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-race-tests-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-pkg-race-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-race-tests-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      # Runs the unit tests with the Go race detector enabled to guard against
+      # regressions of concurrency bugs such as the managed resource status
+      # update data race. See: https://github.com/crossplane/upjet/issues/472
+      - name: Run Race Tests
+        run: make test.race

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,14 @@ go.cachedir:
 go.mod.cachedir:
 	@go env GOMODCACHE
 
-.PHONY: reviewable submodules fallthrough go.mod.cachedir go.cachedir
+# test.race runs the unit tests with the Go race detector enabled. The race
+# detector requires cgo, so we enable it here.
+# Do NOT directly use the `go.test.unit` make target of
+# the build submodule here. There's a `pipefail` issue with that target,
+# which will mask any failing tests.
+test.race:
+	@$(INFO) go test race
+	@CGO_ENABLED=1 $(GOHOST) test -race $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
+	@$(OK) go test race
+
+.PHONY: reviewable submodules fallthrough go.mod.cachedir go.cachedir test.race

--- a/pkg/config/conversion/list_conversion.go
+++ b/pkg/config/conversion/list_conversion.go
@@ -90,7 +90,9 @@ type ConvertOptions struct {
 // an embedded object will be converted into a singleton list or a singleton
 // list will be converted into an embedded object) is determined by the mode
 // parameter.
-func Convert(params map[string]any, paths []string, mode ListConversionMode, opts *ConvertOptions) (map[string]any, error) { //nolint:gocyclo // easier to follow as a unit
+func Convert(params map[string]any, p []string, mode ListConversionMode, opts *ConvertOptions) (map[string]any, error) { //nolint:gocyclo // easier to follow as a unit
+	// make a copy of p to prevent races on the configured conversion paths.
+	paths := append([]string(nil), p...)
 	switch mode {
 	case ToSingletonList:
 		slices.Sort(paths)

--- a/pkg/controller/conversion/functions.go
+++ b/pkg/controller/conversion/functions.go
@@ -45,6 +45,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	}
 
 	// first PrioritizedManagedConversions are run in their registration order
+	r.logger.Debug("Running the registered PrioritizedManagedConversions.")
 	for _, c := range r.GetConversions(dst) {
 		if pc, ok := c.(conversion.PrioritizedManagedConversion); ok {
 			if _, err := pc.ConvertManaged(src, dst); err != nil {
@@ -65,6 +66,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	srcPaved := fieldpath.Pave(srcMap)
 	dstPaved := fieldpath.Pave(dstMap)
 	// then run the PavedConversions
+	r.logger.Debug("Running the registered PavedConversions.")
 	for _, c := range r.GetConversions(dst) {
 		if pc, ok := c.(conversion.PavedConversion); ok {
 			if _, err := pc.ConvertPaved(srcPaved, dstPaved); err != nil {
@@ -79,6 +81,7 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 	}
 
 	// finally at the third stage, run the ManagedConverters
+	r.logger.Debug("Running the registered ManagedConverters.")
 	for _, c := range r.GetConversions(dst) {
 		if tc, ok := c.(conversion.ManagedConversion); ok {
 			if _, ok := tc.(conversion.PrioritizedManagedConversion); ok {

--- a/pkg/controller/conversion/functions_test.go
+++ b/pkg/controller/conversion/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
@@ -169,6 +170,7 @@ func TestRoundTrip(t *testing.T) {
 			}
 			r := &registry{
 				scheme: s,
+				logger: logging.NewNopLogger(),
 			}
 			if err := r.RegisterConversions(p); err != nil {
 				t.Fatalf("\n%s\nRegisterConversions(p): Failed to register the conversions with the registry.\n", tc.reason)

--- a/pkg/controller/conversion/registry.go
+++ b/pkg/controller/conversion/registry.go
@@ -5,6 +5,7 @@
 package conversion
 
 import (
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -23,6 +24,17 @@ var instance *registry
 type registry struct {
 	provider *config.Provider
 	scheme   *runtime.Scheme
+	logger   logging.Logger
+}
+
+// RegistryOption sets an option for the conversion registry.
+type RegistryOption func(*registry)
+
+// WithLogger configures the logger to be used with the conversion registry.
+func WithLogger(logger logging.Logger) RegistryOption {
+	return func(r *registry) {
+		r.logger = logger
+	}
 }
 
 // RegisterConversions registers the API version conversions from the specified
@@ -56,12 +68,16 @@ func GetConversions(tr resource.Terraformed) []conversion.Conversion {
 // for the types whose versions are to be converted. If a registration for a
 // Go schema is not found in the specified registry, RoundTrip does not error
 // but only wildcard conversions must be used with the registry.
-func RegisterConversions(provider *config.Provider, scheme *runtime.Scheme) error {
+func RegisterConversions(provider *config.Provider, scheme *runtime.Scheme, opts ...RegistryOption) error {
 	if instance != nil {
 		return errors.New(errAlreadyRegistered)
 	}
 	instance = &registry{
 		scheme: scheme,
+		logger: logging.NewNopLogger(),
+	}
+	for _, o := range opts {
+		o(instance)
 	}
 	return instance.RegisterConversions(provider)
 }

--- a/pkg/controller/external_async_tfpluginfw.go
+++ b/pkg/controller/external_async_tfpluginfw.go
@@ -164,6 +164,10 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -178,14 +182,14 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Create(_ context.Context, 
 			n.opTracker.logger.Debug("Async create ended.", "error", err)
 
 			n.opTracker.LastOperation.MarkEnd()
-			if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
+			if cErr := n.callback.Create(mgCopy.GetName())(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
 			}
 		}()
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async create starting...")
-		_, ph.err = n.terraformPluginFrameworkExternalClient.Create(ctx, mg)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Create(ctx, mgCopy)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
@@ -197,6 +201,10 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -211,14 +219,14 @@ func (n *terraformPluginFrameworkAsyncExternalClient) Update(_ context.Context, 
 			n.opTracker.logger.Debug("Async update ended.", "error", err)
 
 			n.opTracker.LastOperation.MarkEnd()
-			if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
+			if cErr := n.callback.Update(mgCopy.GetName())(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
 			}
 		}()
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async update starting...")
-		_, ph.err = n.terraformPluginFrameworkExternalClient.Update(ctx, mg)
+		_, ph.err = n.terraformPluginFrameworkExternalClient.Update(ctx, mgCopy)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginfw_test.go
+++ b/pkg/controller/external_async_tfpluginfw_test.go
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+)
+
+func prepareTerraformPluginFrameworkAsyncExternal(testConfig testConfiguration, fns CallbackFns) *terraformPluginFrameworkAsyncExternalClient {
+	return &terraformPluginFrameworkAsyncExternalClient{
+		terraformPluginFrameworkExternalClient: prepareTPFExternalWithTestConfig(testConfig),
+		callback:                               fns,
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkConnect(t *testing.T) {
+	type args struct {
+		setupFn terraform.SetupFn
+		cfg     *config.Resource
+		ots     *OperationTrackerStore
+		obj     xpresource.Managed
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Successful": {
+			args: args{
+				setupFn: func(_ context.Context, _ client.Client, _ xpresource.Managed) (terraform.Setup, error) {
+					return terraform.Setup{
+						FrameworkProvider: &mockTPFProvider{},
+					}, nil
+				},
+				cfg: newBaseUpjetConfig(),
+				obj: newObjAsync(),
+				ots: ots,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewTerraformPluginFrameworkAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginFrameworkAsyncLogger(logTest))
+			_, err := c.Connect(t.Context(), tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkObserve(t *testing.T) {
+	type want struct {
+		obs managed.ExternalObservation
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"NotExists": {
+			testConfiguration: testConfiguration{
+				r:               newMockBaseTPFResource(),
+				cfg:             newBaseUpjetConfig(),
+				obj:             newBaseObject(),
+				currentStateMap: nil,
+				plannedStateMap: map[string]any{
+					"name": "example",
+				},
+				params: map[string]any{
+					"name": "example",
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          false,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: false,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+			},
+		},
+		"UpToDate": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				params: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+				currentStateMap: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+				plannedStateMap: map[string]any{
+					"id":   "example-id",
+					"name": "example",
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: true,
+					ConnectionDetails:       nil,
+					Diff:                    "",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{})
+			observation, err := terraformPluginFrameworkAsyncExternal.Observe(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
+				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkCreate(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:               newMockBaseTPFResource(),
+				cfg:             newBaseUpjetConfig(),
+				obj:             newBaseObject(),
+				currentStateMap: nil,
+				plannedStateMap: map[string]any{
+					"name": "example",
+				},
+				params: map[string]any{
+					"name": "example",
+				},
+				newStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Create(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Create(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkUpdate(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				currentStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+				plannedStateMap: map[string]any{
+					"name": "example-updated",
+					"id":   "example-id",
+				},
+				params: map[string]any{
+					"name": "example-updated",
+				},
+				newStateMap: map[string]any{
+					"name": "example-updated",
+					"id":   "example-id",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Update(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Update(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+func TestAsyncTerraformPluginFrameworkDelete(t *testing.T) {
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		testConfiguration
+		want
+	}{
+		"Successful": {
+			testConfiguration: testConfiguration{
+				r:   newMockBaseTPFResource(),
+				cfg: newBaseUpjetConfig(),
+				obj: newBaseObject(),
+				currentStateMap: map[string]any{
+					"name": "example",
+					"id":   "example-id",
+				},
+				plannedStateMap: nil,
+				params: map[string]any{
+					"name": "example",
+				},
+				newStateMap: nil,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
+				DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+					return func(err error, ctx context.Context) error {
+						return nil
+					}
+				},
+			})
+			_, err := terraformPluginFrameworkAsyncExternal.Delete(t.Context(), &tc.testConfiguration.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Delete(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+// TestAsyncTerraformPluginFrameworkCreateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Create
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginFrameworkCreateRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:               newMockBaseTPFResource(),
+		cfg:             newBaseUpjetConfig(),
+		currentStateMap: nil,
+		plannedStateMap: map[string]any{
+			"name": "example",
+		},
+		params: map[string]any{
+			"name": "example",
+		},
+		newStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Create(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Create(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginFrameworkUpdateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Update
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginFrameworkUpdateRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:   newMockBaseTPFResource(),
+		cfg: newBaseUpjetConfig(),
+		currentStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+		plannedStateMap: map[string]any{
+			"name": "example-updated",
+			"id":   "example-id",
+		},
+		params: map[string]any{
+			"name": "example-updated",
+		},
+		newStateMap: map[string]any{
+			"name": "example-updated",
+			"id":   "example-id",
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Update(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Update(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginFrameworkDeleteRace is a guard test asserting that
+// upjet's async Delete operation does not concurrently access a managed
+// resource's status while the managed reconciler does.
+// Current async client Delete does not modify MR status or spec.
+// Must be run with `go test -race`.
+func TestAsyncTerraformPluginFrameworkDeleteRace(t *testing.T) {
+	obj := newObjAsync()
+	tc := testConfiguration{
+		r:   newMockBaseTPFResource(),
+		cfg: newBaseUpjetConfig(),
+		currentStateMap: map[string]any{
+			"name": "example",
+			"id":   "example-id",
+		},
+		plannedStateMap: nil,
+		params: map[string]any{
+			"name": "example",
+		},
+		newStateMap: nil,
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
+		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Delete(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Delete(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		// Managed reconciler does not call SetObservation during deletion.
+		// This is an extra check at the moment.
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}

--- a/pkg/controller/external_async_tfpluginfw_test.go
+++ b/pkg/controller/external_async_tfpluginfw_test.go
@@ -8,15 +8,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
-	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
-	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/crossplane/upjet/pkg/config"
+	"github.com/crossplane/upjet/pkg/terraform"
 )
 
 func prepareTerraformPluginFrameworkAsyncExternal(testConfig testConfiguration, fns CallbackFns) *terraformPluginFrameworkAsyncExternalClient {
@@ -56,7 +55,7 @@ func TestAsyncTerraformPluginFrameworkConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginFrameworkAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginFrameworkAsyncLogger(logTest))
-			_, err := c.Connect(t.Context(), tc.args.obj)
+			_, err := c.Connect(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -128,7 +127,7 @@ func TestAsyncTerraformPluginFrameworkObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{})
-			observation, err := terraformPluginFrameworkAsyncExternal.Observe(t.Context(), &tc.testConfiguration.obj)
+			observation, err := terraformPluginFrameworkAsyncExternal.Observe(context.TODO(), &tc.testConfiguration.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
@@ -169,13 +168,13 @@ func TestAsyncTerraformPluginFrameworkCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
-				CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+				CreateFn: func(_ string) terraform.CallbackFn {
 					return func(err error, ctx context.Context) error {
 						return nil
 					}
 				},
 			})
-			_, err := terraformPluginFrameworkAsyncExternal.Create(t.Context(), &tc.testConfiguration.obj)
+			_, err := terraformPluginFrameworkAsyncExternal.Create(context.TODO(), &tc.testConfiguration.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Create(...): -want error, +got error:\n", diff)
 			}
@@ -217,13 +216,13 @@ func TestAsyncTerraformPluginFrameworkUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
-				UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+				UpdateFn: func(_ string) terraform.CallbackFn {
 					return func(err error, ctx context.Context) error {
 						return nil
 					}
 				},
 			})
-			_, err := terraformPluginFrameworkAsyncExternal.Update(t.Context(), &tc.testConfiguration.obj)
+			_, err := terraformPluginFrameworkAsyncExternal.Update(context.TODO(), &tc.testConfiguration.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Update(...): -want error, +got error:\n", diff)
 			}
@@ -259,13 +258,13 @@ func TestAsyncTerraformPluginFrameworkDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginFrameworkAsyncExternal := prepareTerraformPluginFrameworkAsyncExternal(tc.testConfiguration, CallbackFns{
-				DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+				DestroyFn: func(_ string) terraform.CallbackFn {
 					return func(err error, ctx context.Context) error {
 						return nil
 					}
 				},
 			})
-			_, err := terraformPluginFrameworkAsyncExternal.Delete(t.Context(), &tc.testConfiguration.obj)
+			_, err := terraformPluginFrameworkAsyncExternal.Delete(context.TODO(), &tc.testConfiguration.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginFrameworkAsyncExternalClient.Delete(...): -want error, +got error:\n", diff)
 			}
@@ -299,7 +298,7 @@ func TestAsyncTerraformPluginFrameworkCreateRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
-		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		CreateFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -309,7 +308,7 @@ func TestAsyncTerraformPluginFrameworkCreateRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Create(t.Context(), obj); err != nil {
+	if _, err := ext.Create(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Create(...): unexpected error: %v", err)
 	}
 
@@ -356,7 +355,7 @@ func TestAsyncTerraformPluginFrameworkUpdateRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
-		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		UpdateFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -366,7 +365,7 @@ func TestAsyncTerraformPluginFrameworkUpdateRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Update(t.Context(), obj); err != nil {
+	if _, err := ext.Update(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Update(...): unexpected error: %v", err)
 	}
 
@@ -406,7 +405,7 @@ func TestAsyncTerraformPluginFrameworkDeleteRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginFrameworkAsyncExternal(tc, CallbackFns{
-		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		DestroyFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -416,7 +415,7 @@ func TestAsyncTerraformPluginFrameworkDeleteRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Delete(t.Context(), obj); err != nil {
+	if _, err := ext.Delete(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginFrameworkAsyncExternalClient.Delete(...): unexpected error: %v", err)
 	}
 

--- a/pkg/controller/external_async_tfpluginsdk.go
+++ b/pkg/controller/external_async_tfpluginsdk.go
@@ -142,6 +142,10 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -156,14 +160,14 @@ func (n *terraformPluginSDKAsyncExternal) Create(_ context.Context, mg xpresourc
 			n.opTracker.logger.Debug("Async create ended.", "error", err, "tfID", n.opTracker.GetTfID())
 
 			n.opTracker.LastOperation.MarkEnd()
-			if cErr := n.callback.Create(mg.GetName())(err, ctx); cErr != nil {
+			if cErr := n.callback.Create(mgCopy.GetName())(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async create callback failed", "error", cErr.Error())
 			}
 		}()
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async create starting...", "tfID", n.opTracker.GetTfID())
-		_, ph.err = n.terraformPluginSDKExternal.Create(ctx, mg)
+		_, ph.err = n.terraformPluginSDKExternal.Create(ctx, mgCopy)
 	}()
 
 	return managed.ExternalCreation{}, n.opTracker.LastOperation.Error()
@@ -175,6 +179,10 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), n.opTracker.LastOperation.StartTime().Add(defaultAsyncTimeout))
+	// We deep-copy the managed resource to prevent a data race between the
+	// goroutine we are about to start below and the managed reconciler.
+	// Please see: https://github.com/crossplane/upjet/issues/472
+	mgCopy := mg.DeepCopyObject().(xpresource.Managed)
 	go func() {
 		// The order of deferred functions, executed last-in-first-out, is
 		// significant. The context should be canceled last, because it is
@@ -189,14 +197,14 @@ func (n *terraformPluginSDKAsyncExternal) Update(_ context.Context, mg xpresourc
 			n.opTracker.logger.Debug("Async update ended.", "error", err, "tfID", n.opTracker.GetTfID())
 
 			n.opTracker.LastOperation.MarkEnd()
-			if cErr := n.callback.Update(mg.GetName())(err, ctx); cErr != nil {
+			if cErr := n.callback.Update(mgCopy.GetName())(err, ctx); cErr != nil {
 				n.opTracker.logger.Info("Async update callback failed", "error", cErr.Error())
 			}
 		}()
 		defer ph.recoverIfPanic(ctx)
 
 		n.opTracker.logger.Debug("Async update starting...", "tfID", n.opTracker.GetTfID())
-		_, ph.err = n.terraformPluginSDKExternal.Update(ctx, mg)
+		_, ph.err = n.terraformPluginSDKExternal.Update(ctx, mgCopy)
 	}()
 
 	return managed.ExternalUpdate{}, n.opTracker.LastOperation.Error()

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -112,7 +112,7 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginSDKAsyncLogger(logTest))
-			_, err := c.Connect(context.TODO(), tc.args.obj)
+			_, err := c.Connect(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -178,7 +178,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, CallbackFns{})
-			observation, err := terraformPluginSDKAsyncExternal.Observe(context.TODO(), tc.args.obj)
+			observation, err := terraformPluginSDKAsyncExternal.Observe(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
@@ -225,7 +225,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Create(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Create(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Create(...): -want error, +got error:\n", diff)
 			}
@@ -269,7 +269,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Update(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Update(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Update(...): -want error, +got error:\n", diff)
 			}
@@ -313,12 +313,142 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Delete(context.TODO(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Delete(t.Context(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Delete(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
+}
+
+// TestAsyncTerraformPluginSDKCreateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Create
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginSDKCreateRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Create(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Create(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginSDKUpdateRace is a regression test for
+// the data race on a managed resource's status, between upjet's async Update
+// operation and the managed reconciler.
+// Must be run with `go test -race`.
+//
+// Please also see: https://github.com/crossplane/upjet/issues/472.
+func TestAsyncTerraformPluginSDKUpdateRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Update(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Update(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
+}
+
+// TestAsyncTerraformPluginSDKDeleteRace is a guard test asserting that upjet's
+// async Delete operation does not concurrently access a managed resource's
+// status while the managed reconciler does. Current async client Delete
+// implementation does not modify MR status or spec.
+// Must be run with `go test -race`.
+func TestAsyncTerraformPluginSDKDeleteRace(t *testing.T) {
+	obj := newObjAsync()
+	r := mockResource{
+		ApplyFn: func(_ context.Context, _ *tf.InstanceState, _ *tf.InstanceDiff, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			return &tf.InstanceState{ID: "example-id", Attributes: map[string]string{"name": "example"}}, nil
+		},
+	}
+
+	extDone := make(chan struct{})
+	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
+		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+			return func(_ error, _ context.Context) error {
+				// Signal the async operation of the external client has completed.
+				close(extDone)
+				return nil
+			}
+		},
+	})
+	// This call starts the async worker that will race with
+	// the managed reconciler below.
+	if _, err := ext.Delete(t.Context(), obj); err != nil {
+		t.Fatalf("terraformPluginSDKAsyncExternal.Delete(...): unexpected error: %v", err)
+	}
+
+	// Simulate the managed reconciler concurrently writing to the status of
+	// the same MR (obj above).
+	mrDone := make(chan struct{})
+	go func() {
+		_ = obj.DeepCopyObject()
+		// Managed reconciler does not call SetObservation during deletion.
+		// This is an extra check at the moment.
+		_ = obj.SetObservation(map[string]any{"name": "example"})
+		// Signal the managed reconciler has completed.
+		close(mrDone)
+	}()
+	<-extDone
+	<-mrDone
 }
 
 func newObjAsync() *fake.Terraformed {

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -112,7 +112,7 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKAsyncConnector(nil, tc.args.ots, tc.args.setupFn, tc.args.cfg, WithTerraformPluginSDKAsyncLogger(logTest))
-			_, err := c.Connect(t.Context(), tc.args.obj)
+			_, err := c.Connect(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -178,7 +178,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, CallbackFns{})
-			observation, err := terraformPluginSDKAsyncExternal.Observe(t.Context(), tc.args.obj)
+			observation, err := terraformPluginSDKAsyncExternal.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
@@ -225,7 +225,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Create(t.Context(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Create(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Create(...): -want error, +got error:\n", diff)
 			}
@@ -269,7 +269,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Update(t.Context(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Update(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Update(...): -want error, +got error:\n", diff)
 			}
@@ -313,7 +313,7 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
-			_, err := terraformPluginSDKAsyncExternal.Delete(t.Context(), tc.args.obj)
+			_, err := terraformPluginSDKAsyncExternal.Delete(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Delete(...): -want error, +got error:\n", diff)
 			}
@@ -337,7 +337,7 @@ func TestAsyncTerraformPluginSDKCreateRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
-		CreateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		CreateFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -347,7 +347,7 @@ func TestAsyncTerraformPluginSDKCreateRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Create(t.Context(), obj); err != nil {
+	if _, err := ext.Create(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginSDKAsyncExternal.Create(...): unexpected error: %v", err)
 	}
 
@@ -380,7 +380,7 @@ func TestAsyncTerraformPluginSDKUpdateRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
-		UpdateFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		UpdateFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -390,7 +390,7 @@ func TestAsyncTerraformPluginSDKUpdateRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Update(t.Context(), obj); err != nil {
+	if _, err := ext.Update(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginSDKAsyncExternal.Update(...): unexpected error: %v", err)
 	}
 
@@ -422,7 +422,7 @@ func TestAsyncTerraformPluginSDKDeleteRace(t *testing.T) {
 
 	extDone := make(chan struct{})
 	ext := prepareTerraformPluginSDKAsyncExternal(r, cfgAsync, CallbackFns{
-		DestroyFn: func(_ types.NamespacedName) terraform.CallbackFn {
+		DestroyFn: func(_ string) terraform.CallbackFn {
 			return func(_ error, _ context.Context) error {
 				// Signal the async operation of the external client has completed.
 				close(extDone)
@@ -432,7 +432,7 @@ func TestAsyncTerraformPluginSDKDeleteRace(t *testing.T) {
 	})
 	// This call starts the async worker that will race with
 	// the managed reconciler below.
-	if _, err := ext.Delete(t.Context(), obj); err != nil {
+	if _, err := ext.Delete(context.TODO(), obj); err != nil {
 		t.Fatalf("terraformPluginSDKAsyncExternal.Delete(...): unexpected error: %v", err)
 	}
 

--- a/pkg/controller/external_async_tfpluginsdk_test.go
+++ b/pkg/controller/external_async_tfpluginsdk_test.go
@@ -60,20 +60,6 @@ var (
 			return nil, nil
 		}},
 	}
-	objAsync = &fake.Terraformed{
-		Parameterizable: fake.Parameterizable{
-			Parameters: map[string]any{
-				"name": "example",
-				"map": map[string]any{
-					"key": "value",
-				},
-				"list": []any{"elem1", "elem2"},
-			},
-		},
-		Observable: fake.Observable{
-			Observation: map[string]any{},
-		},
-	}
 )
 
 func prepareTerraformPluginSDKAsyncExternal(r Resource, cfg *config.Resource, fns CallbackFns) *terraformPluginSDKAsyncExternal {
@@ -118,7 +104,7 @@ func TestAsyncTerraformPluginSDKConnect(t *testing.T) {
 					return terraform.Setup{}, nil
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				ots: ots,
 			},
 		},
@@ -156,7 +142,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
@@ -176,7 +162,7 @@ func TestAsyncTerraformPluginSDKObserve(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
@@ -225,7 +211,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					CreateFn: func(s string) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -241,7 +227,7 @@ func TestAsyncTerraformPluginSDKCreate(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Create(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Create(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
@@ -269,7 +255,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					UpdateFn: func(s string) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -285,7 +271,7 @@ func TestAsyncTerraformPluginSDKUpdate(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Update(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Update(...): -want error, +got error:\n", diff)
 			}
 		})
 	}
@@ -313,7 +299,7 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 					},
 				},
 				cfg: cfgAsync,
-				obj: objAsync,
+				obj: newObjAsync(),
 				fns: CallbackFns{
 					DestroyFn: func(s string) terraform.CallbackFn {
 						return func(err error, ctx context.Context) error {
@@ -329,8 +315,25 @@ func TestAsyncTerraformPluginSDKDelete(t *testing.T) {
 			terraformPluginSDKAsyncExternal := prepareTerraformPluginSDKAsyncExternal(tc.args.r, tc.args.cfg, tc.args.fns)
 			_, err := terraformPluginSDKAsyncExternal.Delete(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nterraformPluginSDKAsyncExternal.Delete(...): -want error, +got error:\n", diff)
 			}
 		})
+	}
+}
+
+func newObjAsync() *fake.Terraformed {
+	return &fake.Terraformed{
+		Parameterizable: fake.Parameterizable{
+			Parameters: map[string]any{
+				"name": "example",
+				"map": map[string]any{
+					"key": "value",
+				},
+				"list": []any{"elem1", "elem2"},
+			},
+		},
+		Observable: fake.Observable{
+			Observation: map[string]any{},
+		},
 	}
 }

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -503,6 +503,18 @@ func (n *terraformPluginSDKExternal) Observe(ctx context.Context, mg xpresource.
 	} else if diffState != nil {
 		diffState.Attributes = nil
 		diffState.ID = ""
+		// We still need to populate a non-nil RawPlan & RawConfig in InstanceState
+		// as the Terraform provider being called with this state may assume that
+		// they are not nil. An example is Terraform AWS provider's
+		// transparent tagging interceptor, which calls
+		// ResourceDiff.GetRawPlan().GetAttr("tags"), which will panic on the
+		// zero cty.Value with "value is not an object".
+		if diffState.RawPlan.IsNull() {
+			diffState.RawPlan = n.rawConfig
+		}
+		if diffState.RawConfig.IsNull() {
+			diffState.RawConfig = n.rawConfig
+		}
 	}
 
 	n.instanceDiff = nil

--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -212,9 +212,14 @@ func (c *TerraformPluginSDKConnector) applyHCLParserToParam(sc *schema.Schema, p
 			}
 		}
 	case schema.TypeString:
+		paramStr, ok := param.(string)
+		if !ok {
+			c.logger.Debug("expected parameter value to be string", "parameterType", fmt.Sprintf("%T", param))
+			return param
+		}
 		// For String types check if it is an HCL string and process
-		if isHCLSnippetPattern.MatchString(param.(string)) {
-			hclProccessedParam, err := processHCLParam(param.(string))
+		if isHCLSnippetPattern.MatchString(paramStr) {
+			hclProccessedParam, err := processHCLParam(paramStr)
 			if err != nil {
 				c.logger.Debug("could not process param, returning original", "param", sc.GoString())
 			} else {

--- a/pkg/controller/external_tfpluginsdk_test.go
+++ b/pkg/controller/external_tfpluginsdk_test.go
@@ -168,7 +168,7 @@ func TestTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKConnector(nil, tc.args.setupFn, tc.args.cfg, tc.args.ots, WithTerraformPluginSDKLogger(logTest))
-			_, err := c.Connect(t.Context(), &tc.args.obj)
+			_, err := c.Connect(context.TODO(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -271,7 +271,7 @@ func TestTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			observation, err := terraformPluginSDKExternal.Observe(t.Context(), &tc.args.obj)
+			observation, err := terraformPluginSDKExternal.Observe(context.TODO(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
@@ -371,7 +371,7 @@ func TestTerraformPluginSDKObserveNotFound(t *testing.T) {
 				}
 			}()
 
-			_, err := ext.Observe(t.Context(), &obj)
+			_, err := ext.Observe(context.TODO(), &obj)
 			if err != nil {
 				t.Fatalf("Observe(...) returned an unexpected error: %v", err)
 			}
@@ -421,7 +421,7 @@ func TestTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Create(t.Context(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Create(context.TODO(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -457,7 +457,7 @@ func TestTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Update(t.Context(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Update(context.TODO(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -493,7 +493,7 @@ func TestTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Delete(t.Context(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Delete(context.TODO(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}

--- a/pkg/controller/external_tfpluginsdk_test.go
+++ b/pkg/controller/external_tfpluginsdk_test.go
@@ -168,7 +168,7 @@ func TestTerraformPluginSDKConnect(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := NewTerraformPluginSDKConnector(nil, tc.args.setupFn, tc.args.cfg, tc.args.ots, WithTerraformPluginSDKLogger(logTest))
-			_, err := c.Connect(context.TODO(), &tc.args.obj)
+			_, err := c.Connect(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -271,12 +271,109 @@ func TestTerraformPluginSDKObserve(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			observation, err := terraformPluginSDKExternal.Observe(context.TODO(), &tc.args.obj)
+			observation, err := terraformPluginSDKExternal.Observe(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n", diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+			}
+		})
+	}
+}
+
+// TestTerraformPluginSDKObserveNotFound is a regression test
+// for the "value is not an object" panic (e.g., in provider-aws).
+// When Observe calls schema.Diff with an InstanceState whose RawPlan is
+// the zero cty.Value, the AWS provider's setTagsAll() interceptor calls
+// diff.GetRawPlan().GetAttr("tags"), and go-cty's Value.GetAttr panics with
+// "value is not an object" on the nil cty.Value.
+// The same applies to RawConfig.
+func TestTerraformPluginSDKObserveNotFound(t *testing.T) {
+	tagsTimeout := timeout
+	cases := map[string]struct {
+		customizeDiff schema.CustomizeDiffFunc
+		description   string
+	}{
+		"RawConfig": {
+			customizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+				// Calling d.GetRawConfig().GetAttr on a zero RawConfig will panic.
+				_ = d.GetRawConfig().GetAttr("name")
+				return nil
+			},
+			description: "Observed a panic when reading from InstanceState.RawConfig",
+		},
+		"RawPlan": {
+			customizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+				// Calling d.GetRawPlan().GetAttr on a zero RawPlan will panic.
+				_ = d.GetRawPlan().GetAttr("tags")
+				return nil
+			},
+			description: "Observed a panic when reading from InstanceState.RawPlan",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfgWithTags := &config.Resource{
+				TerraformResource: &schema.Resource{
+					Timeouts: &schema.ResourceTimeout{
+						Create: &tagsTimeout,
+						Read:   &tagsTimeout,
+						Update: &tagsTimeout,
+						Delete: &tagsTimeout,
+					},
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"tags_all": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+					CustomizeDiff: tc.customizeDiff,
+				},
+				ExternalName: config.IdentifierFromProvider,
+				Sensitive: config.Sensitive{AdditionalConnectionDetailsFn: func(_ map[string]any) (map[string][]byte, error) {
+					return nil, nil
+				}},
+			}
+
+			notFound := mockResource{
+				RefreshWithoutUpgradeFn: func(_ context.Context, _ *tf.InstanceState, _ interface{}) (*tf.InstanceState, diag.Diagnostics) {
+					// Force into the state where the op tracker cache exists
+					// but resource is not found.
+					return nil, nil
+				},
+			}
+
+			ext := prepareTerraformPluginSDKExternal(notFound, cfgWithTags)
+			ext.opTracker.SetTfState(&tf.InstanceState{
+				ID:         "example-id",
+				Attributes: map[string]string{"name": "example"},
+			})
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%s: %v", tc.description, r)
+				}
+			}()
+
+			_, err := ext.Observe(t.Context(), &obj)
+			if err != nil {
+				t.Fatalf("Observe(...) returned an unexpected error: %v", err)
 			}
 		})
 	}
@@ -324,7 +421,7 @@ func TestTerraformPluginSDKCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Create(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Create(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -360,7 +457,7 @@ func TestTerraformPluginSDKUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Update(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Update(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}
@@ -396,7 +493,7 @@ func TestTerraformPluginSDKDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
-			_, err := terraformPluginSDKExternal.Delete(context.TODO(), &tc.args.obj)
+			_, err := terraformPluginSDKExternal.Delete(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
 			}

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -234,8 +234,8 @@ func storeSensitiveData(ctx context.Context, client SecretClient, tfPath, jsonPa
 					return errors.Wrapf(err, errFmtCannotGetSecretValue, ref)
 				}
 				for key, value := range data {
-					if err = pavedTF.SetValue(fmt.Sprintf("%s.%s", tfPath, key), string(value)); err != nil {
-						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s.%s", tfPath, key))
+					if err = pavedTF.SetValue(fmt.Sprintf("%s[%s]", tfPath, key), string(value)); err != nil {
+						return errors.Wrapf(err, "cannot set string as terraform attribute for fieldpath %q", fmt.Sprintf("%s[%s]", tfPath, key))
 					}
 				}
 				continue

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -1165,6 +1165,85 @@ func TestGetSensitiveParameters(t *testing.T) {
 				},
 			},
 		},
+		// Test for the bug where secret keys containing dots were
+		// incorrectly split by dot notation when building the TF attribute
+		// path, producing a wrong nested structure instead of a dotted map key.
+		// e.g. SetValue("tls_config.tls.crt", v) → {"tls_config":{"tls":{"crt":v}}} (wrong)
+		//      SetValue("tls_config[tls.crt]", v) → {"tls_config":{"tls.crt":v}} (correct)
+		"SecretReferenceWithDottedKeys": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &unstructured.Unstructured{
+					Object: map[string]any{
+						"spec": map[string]any{
+							"forProvider": map[string]any{
+								"tlsSecretRef": map[string]any{
+									"name":      "tls-secret",
+									"namespace": "crossplane-system",
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
+		"SecretReferenceWithDottedKeysInitProvider": {
+			args: args{
+				clientFn: func(client *mocks.MockSecretClient) {
+					client.EXPECT().GetSecretData(gomock.Any(), gomock.Eq(&xpv1.SecretReference{
+						Name:      "tls-secret",
+						Namespace: "crossplane-system",
+					})).Return(map[string][]byte{
+						"tls.crt": []byte("cert_data"),
+						"tls.key": []byte("key_data"),
+					}, nil)
+				},
+				from: &unstructured.Unstructured{
+					Object: map[string]any{
+						"spec": map[string]any{
+							"initProvider": map[string]any{
+								"tlsSecretRef": map[string]any{
+									"name":      "tls-secret",
+									"namespace": "crossplane-system",
+								},
+							},
+						},
+					},
+				},
+				into: map[string]any{},
+				mapping: map[string]string{
+					"tls_config": "spec.forProvider.tlsSecretRef",
+				},
+			},
+			want: want{
+				out: map[string]any{
+					"tls_config": map[string]any{
+						"tls.crt": "cert_data",
+						"tls.key": "key_data",
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		ctrl := gomock.NewController(t)

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -211,7 +211,8 @@ func TestBuilder_generateTypeName(t *testing.T) {
 
 func TestBuild(t *testing.T) {
 	type args struct {
-		cfg *config.Resource
+		cfg       *config.Resource
+		setupFunc func(*config.Resource)
 	}
 	type want struct {
 		forProvider     string
@@ -422,9 +423,49 @@ func TestBuild(t *testing.T) {
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.__namespace__) || (has(self.initProvider) && has(self.initProvider.__namespace__))",message="spec.forProvider.namespace is a required parameter"`,
 			},
 		},
+		// When a field is both marked as required (via MarkAsRequired) and has a
+		// reference configured, NewReferenceField resets f.Required to false because
+		// the field is satisfiable via *Ref/*Selector. No XValidation should be emitted.
+		"Required_Field_With_Reference_Omits_XValidation": {
+			args: args{
+				crdScope: CRDScopeCluster,
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"subnet_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+					References: map[string]config.Reference{
+						"subnet_id": {
+							TerraformName: "aws_subnet",
+						},
+					},
+				},
+				setupFunc: func(r *config.Resource) {
+					r.MarkAsRequired("subnet_id")
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; SubnetID *string "json:\"subnetId,omitempty\" tf:\"subnet_id,omitempty\""; SubnetIDRef *github.com/crossplane/crossplane-runtime/v2/apis/common/v1.Reference "json:\"subnetIdRef,omitempty\" tf:\"-\""; SubnetIDSelector *github.com/crossplane/crossplane-runtime/v2/apis/common/v1.Selector "json:\"subnetIdSelector,omitempty\" tf:\"-\""}`,
+				atProvider:  `type example.Observation struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; SubnetID *string "json:\"subnetId,omitempty\" tf:\"subnet_id,omitempty\""}`,
+				// Only "name" should have an XValidation; "subnet_id" is satisfiable via SubnetIDRef/SubnetIDSelector.
+				validationRules: `
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"`,
+			},
+		},
 	}
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
+			if tc.args.setupFunc != nil {
+				tc.args.setupFunc(tc.args.cfg)
+			}
 			builder := NewBuilder(types.NewPackage("example", ""))
 			g, err := builder.Build(tc.cfg)
 

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -332,6 +332,7 @@ func NewReferenceField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 
 	f.Comment.Reference = *ref
 	f.Schema.Optional = true
+	f.Required = false // referenced fields are satisfiable via *Ref/*Selector; do not force-require
 
 	return f, nil
 }


### PR DESCRIPTION
### Description of your changes

I have:

- [X] Read and followed Upjet's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

~~### How has this code been tested~~


[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
