### PR TITLE
Fix resolving namespaced conversions to wrong provider in RoundTrip

### DIFF
--- a/pkg/controller/conversion/functions.go
+++ b/pkg/controller/conversion/functions.go
@@ -43,6 +43,12 @@ func (r *registry) RoundTrip(dst, src resource.Terraformed) error { //nolint:goc
 			src.GetObjectKind().SetGroupVersionKind(gvk)
 		}
 	}
+	// Propagate namespace before any GetConversions call: registry.GetConversions
+	// selects providerCluster vs providerNamespaced based on dst.GetNamespace(),
+	// but dst has an empty ObjectMeta at this point.
+	if src.GetNamespace() != "" {
+		dst.SetNamespace(src.GetNamespace())
+	}
 
 	// first PrioritizedManagedConversions are run in their registration order
 	r.logger.Debug("Running the registered PrioritizedManagedConversions.")


### PR DESCRIPTION
### Description of your changes

`registry.GetConversions` selects between `providerCluster` and `providerNamespaced` by checking `tr.GetNamespace()` on the passed Terraformed object. In RoundTrip, all three conversion stages (`PrioritizedManagedConversion`, `PavedConversion`, `ManagedConversion`) call `GetConversions(dst)`, but `dst` is a freshly constructed object with an empty `ObjectMeta` at the first point, its namespace has not yet been populated. As a result, `GetConversions` always fell through to `providerCluster`, causing namespaced resources to have their conversions resolved from the wrong provider.

The fix copies the namespace from `src` to `dst` before the first `GetConversions` call, mirroring the existing check for `src.GetNamespace() != ""` to keep cluster-scoped resources unaffected. This ensures all three conversion loops operate against the correct provider for namespaced resources.

We did not see this behavior before, because we don't have multi-versions CRDs and conversions for namespaced resources yet.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
