### PR TITLE
fw-external-client: fix TF unexpected identity change errors at Observe

### DIFF
--- a/pkg/config/externalname.go
+++ b/pkg/config/externalname.go
@@ -229,7 +229,7 @@ func FrameworkResourceWithComputedIdentifier(identifier, placeholder string) Ext
 		WithGetExternalNameFn(func(fn GetExternalNameFn, tfState map[string]any) (string, error) {
 			if id, ok := tfState[identifier]; ok {
 				idStr := fmt.Sprintf("%v", id)
-				if len(idStr) > 0 {
+				if len(idStr) > 0 && idStr != placeholder {
 					return idStr, nil
 				}
 			}

--- a/pkg/config/externalname_test.go
+++ b/pkg/config/externalname_test.go
@@ -277,6 +277,82 @@ func TestTemplatedGetIDFn(t *testing.T) {
 	}
 }
 
+func TestFrameworkResourceWithComputedIdentifierGetExternalNameFn(t *testing.T) {
+	const (
+		identifier  = "arn"
+		placeholder = "upjet-placeholder-id"
+	)
+	type args struct {
+		tfstate map[string]any
+	}
+	type want struct {
+		name string
+		err  error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ComputedIdentifier": {
+			reason: "Should return the identifier attribute when it holds a real value.",
+			args: args{
+				tfstate: map[string]any{
+					identifier: "arn:aws:service:region:account:resource/real-id",
+				},
+			},
+			want: want{
+				name: "arn:aws:service:region:account:resource/real-id",
+			},
+		},
+		"PlaceholderIdentifier": {
+			reason: "Should error out when the identifier attribute still holds the placeholder value, instead of returning the placeholder as external name.",
+			args: args{
+				tfstate: map[string]any{
+					identifier: placeholder,
+				},
+			},
+			want: want{
+				err: errors.Errorf("cannot find attribute %q in tfstate", identifier),
+			},
+		},
+		"MissingIdentifier": {
+			reason: "Should error out when the identifier attribute is not present in the tfstate.",
+			args: args{
+				tfstate: map[string]any{
+					"another": "value",
+				},
+			},
+			want: want{
+				err: errors.Errorf("cannot find attribute %q in tfstate", identifier),
+			},
+		},
+		"EmptyIdentifier": {
+			reason: "Should error out when the identifier attribute is present but empty.",
+			args: args{
+				tfstate: map[string]any{
+					identifier: "",
+				},
+			},
+			want: want{
+				err: errors.Errorf("cannot find attribute %q in tfstate", identifier),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			n, err := FrameworkResourceWithComputedIdentifier(identifier, placeholder).
+				GetExternalNameFn(tc.args.tfstate)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("\n%s\nFrameworkResourceWithComputedIdentifier.GetExternalNameFn(...): -want, +got: %s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.name, n); diff != "" {
+				t.Fatalf("\n%s\nFrameworkResourceWithComputedIdentifier.GetExternalNameFn(...): -want, +got: %s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestTemplatedGetExternalNameFn(t *testing.T) {
 	type args struct {
 		tmpl    string

--- a/pkg/controller/external_tfpluginfw.go
+++ b/pkg/controller/external_tfpluginfw.go
@@ -618,6 +618,20 @@ func (n *terraformPluginFrameworkExternalClient) Observe(ctx context.Context, mg
 		} else {
 			stateValueMap = conv.(map[string]any)
 		}
+	} else if n.supportsIdentity() {
+		// For FW resources that use stub/placeholder identifiers
+		// in their external name, the initial Observe returns a
+		// "not-found" with nil TF state as expected, however they might
+		// return a non-empty TF identity with the placeholder identifier.
+		// Discard the TF identity for non-existent resource observations
+		// otherwise subsequent reconciles detect a superfluous TF identity
+		// change, failing the Observe.
+		//
+		// This also clears the TF identity for other not-found cases
+		// like resource was fully established but was deleted out-of-band.
+		// This is fine as Upjet in fact does not rely on TF resource
+		// identities and rehydrates them in subsequent reconciles
+		n.opTracker.SetFrameworkIdentity(nil)
 	}
 
 	// TODO(cem): Consider skipping diff calculation to avoid potential config
@@ -742,9 +756,15 @@ func (n *terraformPluginFrameworkExternalClient) Create(ctx context.Context, mg 
 		// In the following reconciles, this helps to track the external
 		// resource, rather than try to recreate that might cause leaking.
 		n.opTracker.SetFrameworkTFState(applyResponse.NewState)
-		if n.supportsIdentity() {
-			n.opTracker.SetFrameworkIdentity(applyResponse.NewIdentity)
-		}
+		// note: do not store returned TF Framework Identity here.
+		// https://github.com/crossplane-contrib/provider-upjet-aws/issues/2135
+		// The returned TF identity might be partial/garbage (missing some fields).
+		// When subsequent observe recovers the resource via state, it detects an
+		// superfluous identity change garbage->valid and errors out.
+		//
+		// Instead, ignore the returned TF identity and let subsequent
+		// reconciliations rehydrate TF identity via state
+
 		return managed.ExternalCreation{}, errors.Wrap(fatalDiags, "resource creation call returned error diags")
 	}
 

--- a/pkg/controller/external_tfpluginfw_test.go
+++ b/pkg/controller/external_tfpluginfw_test.go
@@ -634,6 +634,45 @@ func TestTPFObserveIdentityPropagation(t *testing.T) {
 			t.Error("Tracker identity should be nil when response has no identity")
 		}
 	})
+
+	t.Run("ObserveClearsIdentityWhenResourceNotFound", func(t *testing.T) {
+		// Regression test for the placeholder-identifier case: on the initial
+		// Observe the resource does not exist (nil state), but the provider may
+		// still return a non-empty identity carrying the placeholder id.
+		// Persisting it caused subsequent reconciles to detect a superfluous
+		// identity change and fail the read. The identity must be discarded for
+		// not-found observations.
+		placeholderIdentity := newTestIdentityData("placeholder-id")
+
+		tc := testConfiguration{
+			r:               newMockTPFResourceWithIdentity(),
+			cfg:             newBaseUpjetConfig(),
+			obj:             obj,
+			currentStateMap: nil,
+			plannedStateMap: map[string]any{
+				"name": "example",
+			},
+			params: map[string]any{
+				"name": "example",
+			},
+			// provider returns an identity even though the resource is absent
+			readNewIdentity: placeholderIdentity,
+		}
+		tpfExternal := prepareTPFExternalWithTestConfig(tc)
+		// Pre-set a stale identity on the tracker as well.
+		tpfExternal.opTracker.SetFrameworkIdentity(placeholderIdentity)
+
+		obs, err := tpfExternal.Observe(context.TODO(), &tc.obj)
+		if err != nil {
+			t.Fatalf("Observe returned unexpected error: %v", err)
+		}
+		if obs.ResourceExists {
+			t.Fatal("resource should not exist for this observation")
+		}
+		if tpfExternal.opTracker.GetFrameworkIdentity() != nil {
+			t.Error("tracker identity should be cleared when the resource is not found")
+		}
+	})
 }
 
 func TestTPFCreateIdentityPropagation(t *testing.T) {
@@ -681,8 +720,15 @@ func TestTPFCreateIdentityPropagation(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateStoresIdentityEvenOnDiagError", func(t *testing.T) {
-		newIdentity := newTestIdentityData("partial-id")
+	t.Run("CreateDoesNotStoreIdentityOnDiagError", func(t *testing.T) {
+		// Regression test for
+		// https://github.com/crossplane-contrib/provider-upjet-aws/issues/2135
+		// On a partial-create error, the returned TF identity might be
+		// partial/garbage. Storing it caused a subsequent Observe (which
+		// recovers a valid identity from state) to detect a superfluous
+		// garbage->valid identity change and fail. The identity must NOT be
+		// stored here; it is rehydrated from state on later reconciles.
+		partialIdentity := newTestIdentityData("partial-id")
 
 		tc := testConfiguration{
 			r:               newMockTPFResourceWithIdentity(),
@@ -703,7 +749,7 @@ func TestTPFCreateIdentityPropagation(t *testing.T) {
 					Detail:   "resource partially created",
 				},
 			},
-			applyNewIdentity: newIdentity,
+			applyNewIdentity: partialIdentity,
 		}
 		tpfExternal := prepareTPFExternalWithTestConfig(tc)
 
@@ -711,10 +757,14 @@ func TestTPFCreateIdentityPropagation(t *testing.T) {
 		if err == nil {
 			t.Fatal("Create should have returned an error on diag error")
 		}
-		// Identity should still be stored even on error (like state is)
-		storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity()
-		if storedIdentity != newIdentity {
-			t.Error("NewIdentity should be stored in tracker even when apply returns error diags")
+		// Identity must NOT be stored on the error path.
+		if storedIdentity := tpfExternal.opTracker.GetFrameworkIdentity(); storedIdentity != nil {
+			t.Error("NewIdentity should not be stored in tracker when apply returns error diags")
+		}
+		// The (partial) state, however, is still preserved so the external
+		// resource can be tracked on subsequent reconciles.
+		if !tpfExternal.opTracker.HasFrameworkTFState() {
+			t.Error("partial framework state should be preserved when apply returns error diags")
 		}
 	})
 }

--- a/pkg/controller/nofork_store.go
+++ b/pkg/controller/nofork_store.go
@@ -217,6 +217,7 @@ func (a *AsyncTracker) ResetReconstructedFrameworkTFState() {
 	defer a.mu.Unlock()
 	if a.stateMark == reconstructedState {
 		a.fwState = nil
+		a.fwIdentity = nil
 		a.stateMark = defaultState
 	}
 }

--- a/pkg/controller/nofork_store_test.go
+++ b/pkg/controller/nofork_store_test.go
@@ -6,6 +6,8 @@ package controller
 
 import (
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
 // newTestIdentityData is defined in external_tfpluginfw_test.go
@@ -51,6 +53,42 @@ func TestAsyncTrackerFrameworkIdentity(t *testing.T) {
 		got := tracker.GetFrameworkIdentity()
 		if got != id2 {
 			t.Error("GetFrameworkIdentity should return the most recently set identity")
+		}
+	})
+}
+
+func TestResetReconstructedFrameworkTFState(t *testing.T) {
+	t.Run("ClearsReconstructedStateAndIdentity", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		// Simulate a reconstructed state (e.g. rehydrated after a restart)
+		// together with an identity that was set on the same reconcile.
+		tracker.SetReconstructedFrameworkTFState(&tfprotov6.DynamicValue{})
+		tracker.SetFrameworkIdentity(newTestIdentityData("reconstructed-id"))
+
+		tracker.ResetReconstructedFrameworkTFState()
+
+		if tracker.HasFrameworkTFState() {
+			t.Error("expected reconstructed framework state to be cleared")
+		}
+		if tracker.GetFrameworkIdentity() != nil {
+			t.Error("expected framework identity to be cleared alongside reconstructed state")
+		}
+	})
+
+	t.Run("NoOpForNonReconstructedState", func(t *testing.T) {
+		tracker := NewAsyncTracker()
+		// A non-reconstructed (normal) state and identity must be preserved.
+		tracker.SetFrameworkTFState(&tfprotov6.DynamicValue{})
+		identity := newTestIdentityData("live-id")
+		tracker.SetFrameworkIdentity(identity)
+
+		tracker.ResetReconstructedFrameworkTFState()
+
+		if !tracker.HasFrameworkTFState() {
+			t.Error("expected non-reconstructed framework state to be preserved")
+		}
+		if tracker.GetFrameworkIdentity() != identity {
+			t.Error("expected non-reconstructed framework identity to be preserved")
 		}
 	})
 }


### PR DESCRIPTION
### Description of your changes

Fixes spurious "unexpected identity change" errors raised by
TF provider during `Observe` for Plugin Framework resources that support
[resource identity](https://developer.hashicorp.com/terraform/plugin/framework/resources/identity)

### Root cause

During `Observe` calls, TF Plugin Framework resource identity is fed to TF `ReadResource` RPC (as `CurrentIdentity`) and TF `ReadResourceResponse` returns the `NewIdentity`
When the current identity does not match the returned NewIdentity, TF `ReadResource` RPC fails the read with an "unexpected identity change" diagnostics.

- Some code paths can produce incomplete/invalid identities, e.g. the external API Create operation failed for some reason, say due to a permission/config issue eventually got resolved.
- these incomplete/invalid identities are stored as the CurrentIdentity in the opTracker cache
- Subsequent reconciles use it
- Say at some point, the original API failure reason is resolved (e.g. external API become available or user fixed their MR spec/config)
- This results in subsequent `Observe` operations to fail due to a spurious "identity change", even if the newly returned identity is valid (i.e invalid prior identity -> valid  identity transition)
- The MR becomes stuck at `Observe` step

A provider restart fixes it by rehydrating the cache, but still inconvenient.
An example reported issue is https://github.com/crossplane-contrib/provider-upjet-aws/issues/2135

This only affects the following resources in following particular conditions:
- TF plugin framework resource using TF framework external client
- Resource supports TF Resource Identity
- Resource encounters an external API failure during create
- Produces an incomplete/stale identity as a result of failure
  - has an indeterministic provider-assigned identifier 

### Fix

Reset or do not store potentially invalid TF resource identities.

- During XP `Create` after `ApplyResource` RPC calls with fatal diagnostics: Treat the returned identity as invalid/partial. Still preserves the returned (partial) state, so that is still available for recovery, rehydration
- At `Observe` resource not found case: this is to cover the case for
 FW resources with `FrameworkResourceWithComputedIdentifier`, that uses a stub/placeholder identifier for the very-first `Observe` to trigger an initial not-found. This expectedly returns a nil state, but can return a non-empty FW Identity with placeholder value. We don't want to store this, otherwise when the resource is actually created, this will cause an identity change from `placeholder -> real` identity.
- At `ResetReconstructedState`: This now also clear the associated identity of a reconstructed state.
- At `FrameworkResourceWithComputedIdentifier`: This is a complementary change. Do not return the placeholder value as a valid external-name at `GetExternalNameFn`. Placeholder identifiers can only exist at "input states" of TF Observe, should never exist in resulting TF states (after Read or Apply ), which `GetExternalNameFn` is only called for in FW resources. Instead error out if found.

Addresses https://github.com/crossplane-contrib/provider-upjet-aws/issues/2135

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Added unit tests
- test branch at provider-aws https://github.com/crossplane-contrib/provider-upjet-aws/pull/2148
  - uptest all FW resources with Identity Support
- Manually reproduce https://github.com/crossplane-contrib/provider-upjet-aws/issues/2135 and tested recovery without a pod restart

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
