### PR TITLE
Revert "[feat]: Surface deletionTimestamp as a printcolumn"

### DIFF
--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -58,7 +58,6 @@ type {{ .CRD.Kind }}Status struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="DELETION TIMESTAMP",type="date",JSONPath=".metadata.deletionTimestamp",priority=1
 // +kubebuilder:resource:scope={{ .CRD.Scope }},categories={crossplane,managed,{{ .Provider.ShortName }}}{{ if .CRD.Path }},path={{ .CRD.Path }}{{ end }}
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Reverts crossplane/upjet#514

Objections raised:
  - Being-deleted is a rare state in a resource's lifecycle; the info is already obtainable via kubectl with extra flags; most Kubernetes resources don't surface this at all; there's no defined policy for what qualifies as a print column, which risks scope creep ("what about other fields people ask for?"). Not strongly opposed, but flags the implications.
  - The approach only works for upjet-based providers' MRs, not CRs generally, and printing a deletion
  column isn't a common CR convention.
  - The Ready condition already sets reason: Deleting when a resource is being deleted. They currently print the
  Ready status (True/False) but not the reason, the Ready condition/reason is a better lifecycle signal than a dedicated column.

Long term proposal is to introduce `crd_types` template similarly as with controller and setup templates