### PR TITLE
Switch to dynamic storage version migration

### DIFF
--- a/cmd/crdmigrator/example.yaml
+++ b/cmd/crdmigrator/example.yaml
@@ -2,8 +2,18 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+# Static mode: provide explicit CRD-to-storage-version mappings.
+# Used with: crd-migrator migrate --mode static --crd-file example.yaml
 {
   "locations.conditionalaccess.azuread.upbound.io":"v1beta2",
   "invitations.invitations.azuread.upbound.io":"v1beta2",
   "principals.serviceprincipals.azuread.upbound.io":"v1beta2"
 }
+
+# Dynamic mode examples (run directly, no file needed):
+#
+#   Migrate all CRDs under a root group:
+#     crd-migrator migrate --mode dynamic --root-group azuread.upbound.io
+#
+#   Migrate only a specific service group:
+#     crd-migrator migrate --mode dynamic --root-group azuread.upbound.io --short-group conditionalaccess

--- a/cmd/crdmigrator/main.go
+++ b/cmd/crdmigrator/main.go
@@ -27,45 +27,61 @@ import (
 	"github.com/crossplane/upjet/v2/pkg/config"
 )
 
+const (
+	modeStatic  = "static"
+	modeDynamic = "dynamic"
+)
+
 var (
-	app = kingpin.New("crd-migrator", "A CLI tool to manually update CRD storage versions for storage version migration")
+	app = kingpin.New("crd-migrator", "A CLI tool to migrate CRD storage versions. Use --mode static to provide CRD:version pairs explicitly, or --mode dynamic to discover CRDs from the cluster by group.")
 
 	// Global flags
 	kubeconfig = app.Flag("kubeconfig", "Path to kubeconfig file. If not specified, uses in-cluster config or default kubeconfig location").String()
 
-	// Update command
-	updateCmd      = app.Command("update", "Update CRD status to reflect the current storage version")
-	updateCRDNames = updateCmd.Flag("crd-names", "Comma-separated list of <CRD>:<storage version> pairs (e.g., 'buckets.s3.aws.upbound.io:v1beta2,users.iam.aws.upbound.io:v1beta1')").String()
-	updateCRDFile  = updateCmd.Flag("crd-file", "Path to YAML file containing CRD to storage version mappings").String()
-	updateRetries  = updateCmd.Flag("retries", "Number of retry attempts (must be > 0)").Default("10").Int()
-	updateDuration = updateCmd.Flag("retry-duration", "Initial retry duration in seconds (must be > 0)").Default("1").Int()
-	updateFactor   = updateCmd.Flag("retry-factor", "Retry backoff factor (must be > 1.0 for exponential growth)").Default("2.0").Float64()
-	updateJitter   = updateCmd.Flag("retry-jitter", "Retry jitter between 0.0 and 1.0").Default("0.1").Float64()
-	skipPermCheck  = updateCmd.Flag("skip-permission-check", "Skip permission check before updating CRD").Bool()
+	// Migrate command with static and dynamic modes
+	migrateCmd  = app.Command("migrate", "Migrate CRD storage versions. Use --mode static or --mode dynamic.")
+	migrateMode = migrateCmd.Flag("mode", "Migration mode: 'static' (provide CRD:version pairs explicitly) or 'dynamic' (discover CRDs from the cluster by group)").Required().Enum(modeStatic, modeDynamic)
+
+	// Shared retry flags
+	migrateRetries  = migrateCmd.Flag("retries", "Number of retry attempts (must be > 0)").Default("10").Int()
+	migrateDuration = migrateCmd.Flag("retry-duration", "Initial retry duration in seconds (must be > 0)").Default("1").Int()
+	migrateFactor   = migrateCmd.Flag("retry-factor", "Retry backoff factor (must be > 1.0 for exponential growth)").Default("2.0").Float64()
+	migrateJitter   = migrateCmd.Flag("retry-jitter", "Retry jitter between 0.0 and 1.0").Default("0.1").Float64()
+
+	// Static mode flags
+	migrateCRDNames = migrateCmd.Flag("crd-names", "[static] Comma-separated list of <CRD>:<storage version> pairs (e.g., 'buckets.s3.aws.upbound.io:v1beta2,users.iam.aws.upbound.io:v1beta1')").String()
+	migrateCRDFile  = migrateCmd.Flag("crd-file", "[static] Path to YAML file containing CRD to storage version mappings").String()
+	skipPermCheck   = migrateCmd.Flag("skip-permission-check", "[static] Skip permission check before updating CRD status").Bool()
+
+	// Dynamic mode flags
+	migrateRootGroup  = migrateCmd.Flag("root-group", "[dynamic] Root API group of the provider, e.g. 'aws.upbound.io'").String()
+	migrateShortGroup = migrateCmd.Flag("short-group", "[dynamic] Optional single service short group, e.g. 'ec2'. When set, only CRDs in '<short-group>.<root-group>' are migrated. When omitted, all CRDs under the root group are migrated.").String()
 )
 
 func main() {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	if command == updateCmd.FullCommand() {
-		if err := runUpdate(); err != nil {
-			kingpin.FatalIfError(err, "Failed to update CRD storage")
+	if command == migrateCmd.FullCommand() {
+		if err := runMigrate(); err != nil {
+			kingpin.FatalIfError(err, "Failed to migrate CRD storage")
 		}
 	}
 }
 
-func runUpdate() error { //nolint:gocyclo // easier to follow as a unit
+func runMigrate() error {
 	ctx := context.Background()
 	logger := logging.NewLogrLogger(zap.New(zap.UseDevMode(false)).WithName("crd-migrator"))
 
-	// Parse CRD names and versions from flags
-	crdVersionMap, err := parseCRDMappings(*updateCRDNames, *updateCRDFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse CRD mappings")
+	// Validate and configure retry backoff
+	if err := validateRetryConfig(*migrateRetries, *migrateDuration, *migrateFactor, *migrateJitter); err != nil {
+		return errors.Wrap(err, "invalid retry configuration")
 	}
 
-	if len(crdVersionMap) == 0 {
-		return errors.New("no CRD mappings provided. Use --crd-names or --crd-file")
+	retryBackoff := wait.Backoff{
+		Duration: time.Duration(*migrateDuration) * time.Second,
+		Factor:   *migrateFactor,
+		Jitter:   *migrateJitter,
+		Steps:    *migrateRetries,
 	}
 
 	// Build Kubernetes client configuration
@@ -88,16 +104,24 @@ func runUpdate() error { //nolint:gocyclo // easier to follow as a unit
 		return errors.Wrap(err, "failed to create kube client")
 	}
 
-	// Validate and configure retry backoff
-	if err := validateRetryConfig(*updateRetries, *updateDuration, *updateFactor, *updateJitter); err != nil {
-		return errors.Wrap(err, "invalid retry configuration")
+	switch *migrateMode {
+	case modeStatic:
+		return runStaticMigration(ctx, logger, kube, retryBackoff)
+	case modeDynamic:
+		return runDynamicMigration(ctx, logger, kube, retryBackoff)
+	}
+	return nil
+}
+
+func runStaticMigration(ctx context.Context, logger logging.Logger, kube client.Client, retryBackoff wait.Backoff) error {
+	// Parse CRD names and versions from flags
+	crdVersionMap, err := parseCRDMappings(*migrateCRDNames, *migrateCRDFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse CRD mappings")
 	}
 
-	retryBackoff := wait.Backoff{
-		Duration: time.Duration(*updateDuration) * time.Second,
-		Factor:   *updateFactor,
-		Jitter:   *updateJitter,
-		Steps:    *updateRetries,
+	if len(crdVersionMap) == 0 {
+		return errors.New("no CRD mappings provided for static mode. Use --crd-names or --crd-file")
 	}
 
 	logger.Info("Starting CRD storage version migration", "crd-count", len(crdVersionMap))
@@ -142,6 +166,29 @@ func runUpdate() error { //nolint:gocyclo // easier to follow as a unit
 		return errors.Errorf("failed to update %d CRD(s): %v", len(failedCRDs), failedCRDs)
 	}
 
+	return nil
+}
+
+func runDynamicMigration(ctx context.Context, logger logging.Logger, kube client.Client, retryBackoff wait.Backoff) error {
+	if *migrateRootGroup == "" {
+		return errors.New("--root-group is required for dynamic mode")
+	}
+
+	// Build migrator options; short group is optional
+	opts := []config.CRDMigratorOption{config.WithRetryBackoff(retryBackoff)}
+	if *migrateShortGroup != "" {
+		opts = append(opts, config.WithShortGroup(*migrateShortGroup))
+	}
+
+	migrator := config.NewCRDMigrator(*migrateRootGroup, opts...)
+
+	logger.Info("Starting dynamic CRD storage version migration", "root-group", *migrateRootGroup, "short-group", *migrateShortGroup)
+
+	if err := migrator.Run(ctx, logger, kube); err != nil {
+		return errors.Wrap(err, "dynamic CRD migration failed")
+	}
+
+	logger.Info("Dynamic CRD storage version migration completed successfully")
 	return nil
 }
 

--- a/pkg/config/crd_migrator.go
+++ b/pkg/config/crd_migrator.go
@@ -6,7 +6,6 @@ package config
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -15,13 +14,10 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,8 +28,11 @@ import (
 // public package, we can remove the duplication here.
 
 // CRDMigrator makes sure the CRDs are using the latest storage version.
+// It discovers CRDs dynamically at runtime by listing all CRDs in the cluster
+// and filtering them by the configured root group and optional short group.
 type CRDMigrator struct {
-	gvkList      []schema.GroupVersionKind
+	rootGroup    string
+	shortGroup   string
 	retryBackoff wait.Backoff
 }
 
@@ -47,10 +46,23 @@ func WithRetryBackoff(backoff wait.Backoff) CRDMigratorOption {
 	}
 }
 
-// NewCRDMigrator returns a new *CRDMigrator with default retry configuration.
-func NewCRDMigrator(gvkList []schema.GroupVersionKind, opts ...CRDMigratorOption) *CRDMigrator {
+// WithShortGroup restricts migration to CRDs whose API group is exactly
+// shortGroup+"."+rootGroup (e.g. short group "ec2" with root group
+// "aws.upbound.io" matches only "ec2.aws.upbound.io"). When no short group is
+// set, all CRDs whose group equals or ends with the root group are considered.
+func WithShortGroup(shortGroup string) CRDMigratorOption {
+	return func(c *CRDMigrator) {
+		c.shortGroup = shortGroup
+	}
+}
+
+// NewCRDMigrator returns a new *CRDMigrator that dynamically discovers CRDs
+// belonging to rootGroup (e.g. "aws.upbound.io") with default retry
+// configuration. Use WithShortGroup to narrow the scope to a single service
+// group (e.g. "ec2" → only "ec2.aws.upbound.io" CRDs).
+func NewCRDMigrator(rootGroup string, opts ...CRDMigratorOption) *CRDMigrator {
 	c := &CRDMigrator{
-		gvkList: gvkList,
+		rootGroup: rootGroup,
 		retryBackoff: wait.Backoff{
 			Duration: 1 * time.Second,
 			Factor:   2.0,
@@ -66,39 +78,41 @@ func NewCRDMigrator(gvkList []schema.GroupVersionKind, opts ...CRDMigratorOption
 	return c
 }
 
-// Run migrates CRDs to use the latest storage version by listing all resources
-// of the old storage version, patching them to trigger conversion to the new
-// storage version, and updating the CRD status to reflect only the new storage version.
-func (c *CRDMigrator) Run(ctx context.Context, logr logging.Logger, discoveryClient discovery.DiscoveryInterface, kube client.Client) error {
-	// Perform API discovery once before the loop to avoid expensive repeated discovery calls
-	groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
-	if err != nil {
-		return errors.Wrap(err, "failed to get API group resources")
+// matchesGroup returns true if the given CRD API group falls within the
+// migrator's configured root/short group scope.
+func (c *CRDMigrator) matchesGroup(group string) bool {
+	if c.shortGroup == "" {
+		return group == c.rootGroup || strings.HasSuffix(group, "."+c.rootGroup)
 	}
-	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
+	return group == c.shortGroup+"."+c.rootGroup
+}
+
+// Run migrates CRDs to use the latest storage version by dynamically
+// discovering all CRDs that belong to the configured group scope, then for
+// each CRD: listing all resources of the old storage version, patching them to
+// trigger conversion to the new storage version, and updating the CRD status
+// to reflect only the new storage version.
+func (c *CRDMigrator) Run(ctx context.Context, logr logging.Logger, kube client.Client) error {
+	var crdList extv1.CustomResourceDefinitionList
+	if err := kube.List(ctx, &crdList); err != nil {
+		return errors.Wrap(err, "failed to list CRDs")
+	}
 
 	var errs []error
-	for _, gvk := range c.gvkList {
-		if err := c.migrateCRD(ctx, logr, kube, mapper, gvk); err != nil {
+	for i := range crdList.Items {
+		crd := crdList.Items[i]
+		if !c.matchesGroup(crd.Spec.Group) {
+			continue
+		}
+		if err := c.migrateCRD(ctx, logr, kube, crd); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func (c *CRDMigrator) migrateCRD(ctx context.Context, logr logging.Logger, kube client.Client, mapper meta.RESTMapper, gvk schema.GroupVersionKind) error { //nolint:gocyclo // easier to follow as a unit
-	crdName, err := GetCRDNameFromGVK(mapper, gvk)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to get CRD name from GVK %s", gvk.Kind))
-	}
-
-	var crd extv1.CustomResourceDefinition
-	if err := kube.Get(ctx, client.ObjectKey{Name: crdName}, &crd); err != nil {
-		if kerrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "cannot get %s crd", crdName)
-	}
+func (c *CRDMigrator) migrateCRD(ctx context.Context, logr logging.Logger, kube client.Client, crd extv1.CustomResourceDefinition) error { //nolint:gocyclo // easier to follow as a unit
+	crdName := crd.Name
 
 	// Find the current storage version (the version marked as storage in the spec)
 	var storageVersion string
@@ -122,7 +136,7 @@ func (c *CRDMigrator) migrateCRD(ctx context.Context, logr logging.Logger, kube 
 	}
 
 	if !needMigration {
-		logr.Debug("Skipping CRD migration for CRD because it has already been migrated", "crd", crdName)
+		logr.Debug("Skipping CRD migration, storedVersions already matches the current storage version", "crd", crdName)
 		return nil
 	}
 
@@ -178,7 +192,7 @@ func (c *CRDMigrator) migrateCRD(ctx context.Context, logr logging.Logger, kube 
 	}
 
 	if !hasPermission {
-		logr.Info(fmt.Sprintf("This client does not have permission to patch the status of the CRD %s", crdName))
+		logr.Info("This client does not have permission to patch the CRD status", "crd", crdName)
 		return nil
 	}
 
@@ -202,17 +216,6 @@ func isRetryable(err error) bool {
 		kerrors.IsConflict(err)
 }
 
-// GetCRDNameFromGVK returns the CRD name (e.g., "resources.group.example.com") for a given GroupVersionKind
-// by using the provided REST mapper to find the REST mapping.
-func GetCRDNameFromGVK(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (string, error) {
-	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return "", errors.Wrap(err, "cannot get REST mapping")
-	}
-
-	return mapping.Resource.Resource + "." + mapping.Resource.Group, nil
-}
-
 // UpdateCRDStorageVersion updates the CRD status to reflect only the specified storage version.
 // It retries the update with exponential backoff and verifies the update was successful.
 func UpdateCRDStorageVersion(ctx context.Context, kube client.Client, retryBackoff wait.Backoff, crdName, storageVersion string) error {
@@ -229,7 +232,7 @@ func UpdateCRDStorageVersion(ctx context.Context, kube client.Client, retryBacko
 		return kube.Status().Patch(ctx, &crd, client.MergeFrom(origCrd))
 	})
 	if statusUpdateErr != nil {
-		return errors.Wrapf(statusUpdateErr, "couldn't update %s crd", crd.Name)
+		return errors.Wrapf(statusUpdateErr, "couldn't update %s crd", crdName)
 	}
 	return nil
 }
@@ -237,7 +240,7 @@ func UpdateCRDStorageVersion(ctx context.Context, kube client.Client, retryBacko
 // CheckCRDStatusUpdatePermission checks if the current client has permission to update/patch
 // the status subresource of the specified CRD using SelfSubjectAccessReview.
 func CheckCRDStatusUpdatePermission(ctx context.Context, kube client.Client, crdName string) (bool, error) {
-	// Check for both 'patch' verb on the status subresource
+	// Check for 'patch' verb on the status subresource
 	ssar := &authv1.SelfSubjectAccessReview{
 		Spec: authv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authv1.ResourceAttributes{
@@ -258,21 +261,4 @@ func CheckCRDStatusUpdatePermission(ctx context.Context, kube client.Client, crd
 	}
 
 	return ssar.Status.Allowed, nil
-}
-
-// PrepareCRDMigrator scans the provider's resources for any that have previous versions
-// and creates a CRDMigrator to handle storage version migration for those resources.
-// It sets the StorageVersionMigrator field on the Provider with the configured migrator.
-func PrepareCRDMigrator(pc *Provider) {
-	var gvkList []schema.GroupVersionKind
-	for _, r := range pc.Resources {
-		if len(r.PreviousVersions) != 0 {
-			gvkList = append(gvkList, schema.GroupVersionKind{
-				Group:   strings.ToLower(r.ShortGroup + "." + pc.RootGroup),
-				Version: r.CRDStorageVersion(),
-				Kind:    r.Kind,
-			})
-		}
-	}
-	pc.StorageVersionMigrator = NewCRDMigrator(gvkList)
 }

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -211,10 +211,6 @@ type Provider struct {
 	// modify the Provider configuration based on the underlying Terraform
 	// resource schemas.
 	schemaTraversers []traverser.SchemaTraverser
-
-	// StorageVersionMigrator handles the migration of CRD resources from old
-	// storage versions to new storage versions when the CRD schema is updated.
-	StorageVersionMigrator *CRDMigrator
 }
 
 // ReferenceInjector injects cross-resource references across the resources
@@ -371,16 +367,6 @@ func WithSchemaTraversers(traversers ...traverser.SchemaTraverser) ProviderOptio
 func WithExampleManifestConfiguration(emc ExampleManifestConfiguration) ProviderOption {
 	return func(p *Provider) {
 		p.ExampleManifestConfiguration = emc
-	}
-}
-
-// WithStorageVersionMigrator configures a custom CRDMigrator for handling storage
-// version migrations. Use this when you need a manually constructed migrator.
-// For providers that maintain PreviousVersions on their resources, prefer
-// PrepareCRDMigrator which auto-scans and builds the migrator automatically.
-func WithStorageVersionMigrator(migrator *CRDMigrator) ProviderOption {
-	return func(p *Provider) {
-		p.StorageVersionMigrator = migrator
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Follow up #588. Switches to dynamic approach instead of static configuraiton.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in provider-upjet-gcp.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
