### PR TITLE
fix(controller): retry the async callback status write on conflict

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -127,30 +128,50 @@ func (ac *APICallbacks) callbackFn(nn types.NamespacedName, op asyncOperation, r
 		if kErr := ac.kube.Get(ctx, nn, tr); kErr != nil {
 			return errors.Wrapf(kErr, errGetFmt, tr.GetObjectKind().GroupVersionKind().String(), nn, op)
 		}
-		// For the no-fork architecture, we will need to be able to report
-		// reconciliation errors. The proper place is the `Synced`
-		// status condition but we need changes in the managed reconciler
-		// to do so. So we keep the `LastAsyncOperation` condition.
-		// TODO: move this to the `Synced` condition.
-		tr.SetConditions(resource.LastAsyncOperationCondition(err))
-		if err != nil {
-			wrapMsg := ""
-			switch op {
-			case opCreate:
-				wrapMsg = errXPReconcileCreate
-			case opUpdate:
-				wrapMsg = errXPReconcileUpdate
-			case opDestroy:
-				wrapMsg = errXPReconcileDelete
+		setConditions := func(tr resource.Terraformed) {
+			// For the no-fork architecture, we will need to be able to report
+			// reconciliation errors. The proper place is the `Synced`
+			// status condition but we need changes in the managed reconciler
+			// to do so. So we keep the `LastAsyncOperation` condition.
+			// TODO: move this to the `Synced` condition.
+			tr.SetConditions(resource.LastAsyncOperationCondition(err))
+			if err != nil {
+				wrapMsg := ""
+				switch op {
+				case opCreate:
+					wrapMsg = errXPReconcileCreate
+				case opUpdate:
+					wrapMsg = errXPReconcileUpdate
+				case opDestroy:
+					wrapMsg = errXPReconcileDelete
+				}
+				tr.SetConditions(xpv1.ReconcileError(errors.Wrap(err, wrapMsg)))
+			} else {
+				tr.SetConditions(xpv1.ReconcileSuccess())
 			}
-			tr.SetConditions(xpv1.ReconcileError(errors.Wrap(err, wrapMsg)))
-		} else {
-			tr.SetConditions(xpv1.ReconcileSuccess())
+			if ac.enableStatusUpdates {
+				tr.SetConditions(resource.AsyncOperationFinishedCondition())
+			}
 		}
-		if ac.enableStatusUpdates {
-			tr.SetConditions(resource.AsyncOperationFinishedCondition())
-		}
-		uErr := errors.Wrapf(ac.kube.Status().Update(ctx, tr), errUpdateStatusFmt, tr.GetObjectKind().GroupVersionKind().String(), nn, op)
+		setConditions(tr)
+		// The managed reconciler writes to this object while the async operation is
+		// still in flight -- most visibly removing the finalizer once a delete
+		// completes -- so this status write races it and loses on conflict. These
+		// conditions derive only from the operation result, so re-reading the object
+		// and re-applying them is idempotent.
+		reread := false
+		uErr := errors.Wrapf(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if reread {
+				fresh := ac.newTerraformed()
+				if kErr := ac.kube.Get(ctx, nn, fresh); kErr != nil {
+					return kErr
+				}
+				setConditions(fresh)
+				tr = fresh
+			}
+			reread = true
+			return ac.kube.Status().Update(ctx, tr)
+		}), errUpdateStatusFmt, tr.GetObjectKind().GroupVersionKind().String(), nn, op)
 		if ac.eventHandler != nil && requestReconcile {
 			rateLimiter := handler.NoRateLimiter
 			switch {

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -548,6 +551,78 @@ func TestAPICallbacksDestroyNamespaced(t *testing.T) {
 
 // okManager returns a manager whose client successfully handles Get and
 // Status().Update so that the callback reaches the requestReconcile gate.
+func TestAPICallbacksStatusUpdateConflict(t *testing.T) {
+	conflict := kerrors.NewConflict(schema.GroupResource{Resource: "terraformeds"}, "name", errBoom)
+
+	cases := map[string]struct {
+		reason           string
+		statusUpdateErrs []error
+		getErr           error
+		wantGetCalls     int
+		wantErr          error
+	}{
+		"RetriesAndSucceeds": {
+			reason:           "A conflicting status write must be retried against a re-read object and report success.",
+			statusUpdateErrs: []error{conflict, nil},
+			wantGetCalls:     2,
+		},
+		"RetriesUntilExhausted": {
+			reason:           "A status write that keeps conflicting must surface the conflict once the retries are exhausted.",
+			statusUpdateErrs: []error{conflict, conflict, conflict, conflict, conflict, conflict},
+			wantGetCalls:     retry.DefaultRetry.Steps,
+			wantErr:          errors.Wrapf(conflict, errUpdateStatusFmt, "", ", Kind=//name", opDestroy),
+		},
+		"DoesNotRetryOtherErrors": {
+			reason:           "A non-conflict status write error must not be retried.",
+			statusUpdateErrs: []error{errBoom},
+			wantGetCalls:     1,
+			wantErr:          errors.Wrapf(errBoom, errUpdateStatusFmt, "", ", Kind=//name", opDestroy),
+		},
+		"ReReadFailureSurfaces": {
+			reason:           "When the object cannot be re-read after a conflict, that error must surface.",
+			statusUpdateErrs: []error{conflict, nil},
+			getErr:           errBoom,
+			wantGetCalls:     2,
+			wantErr:          errors.Wrapf(errBoom, errUpdateStatusFmt, "", ", Kind=//name", opDestroy),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			getCalls := 0
+			updateCalls := 0
+			mgr := &xpfake.Manager{
+				Client: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						getCalls++
+						// The first Get is the callback's initial read, which must
+						// keep succeeding; getErr models a failure to re-read.
+						if getCalls > 1 {
+							return tc.getErr
+						}
+						return nil
+					},
+					MockStatusUpdate: func(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+						err := tc.statusUpdateErrs[updateCalls]
+						updateCalls++
+						return err
+					},
+				},
+				Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
+			}
+
+			e := NewAPICallbacks(mgr, xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})))
+			err := e.Destroy(types.NamespacedName{Name: "name"}, false)(nil, context.TODO())
+			if diff := cmp.Diff(tc.wantErr, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDestroy(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if getCalls != tc.wantGetCalls {
+				t.Errorf("\n%s\nDestroy(...): want %d Get calls, got %d", tc.reason, tc.wantGetCalls, getCalls)
+			}
+		})
+	}
+}
+
 func okManager() ctrl.Manager {
 	return &xpfake.Manager{
 		Client: &test.MockClient{


### PR DESCRIPTION
### Description of your changes

The async create/update/destroy callback (`APICallbacks.callbackFn`) reads the
managed resource, sets the operation-result conditions, and writes status. The
managed reconciler writes to that same object while the operation is still in
flight — most visibly removing the finalizer once a delete completes — so the
callback's status write races it and loses on optimistic concurrency:

```
cannot update status of the resource <group>/<version>, Kind=<kind>//<name>
after an async destroy: Operation cannot be fulfilled on <resource>.<group>
"<name>": the object has been modified; please apply your changes to the
latest version and try again
```

The write was not retried, so the conditions for that operation were simply
dropped. It self-heals — the callback requests a reconcile regardless of whether
the status write succeeded, and the next reconcile re-derives the conditions — so
the impact is a lost status update plus log noise rather than a stuck resource.
But it is not rare: deleting many managed resources concurrently makes it
routine, and we see it at O(10k) occurrences/week across several upjet-based
providers, dominated by `destroy`.

This wraps the write in `retry.RetryOnConflict`, re-reading the object and
re-applying the conditions before each attempt. That is safe because the
conditions derive solely from the operation result (`err` and `op`), never from
the object's current contents, so recomputing them against a fresher object is
idempotent — there is no read-modify-write on spec to lose.

Deliberately narrow in scope:

- Non-conflict errors are returned without retrying, so no error path is
  swallowed or newly delayed.
- An exhausted retry still surfaces the original conflict wrapped in
  `errUpdateStatusFmt`, so the existing failure mode remains observable.
- The initial `Get` failure path is untouched and still wrapped in `errGetFmt`.
- `RequestReconcile` still runs after the write attempt, in the same order as
  before, and its failure still takes precedence over the status-update error.

One thing worth reviewers' attention: a racing delete can now surface as a
`NotFound` from the re-read, wrapped in `errUpdateStatusFmt` rather than
`errGetFmt`. I kept that rather than special-casing it, to hold the change to the
conflict behaviour — happy to tolerate `NotFound` on `destroy` instead if you'd
prefer, since the object legitimately disappears in that window.

A backport to the `release-2.x` line would be useful — that is where we hit this.

### How has this code been tested

New table-driven unit test, `TestAPICallbacksStatusUpdateConflict`, covering:

- `RetriesAndSucceeds` — one conflict then success; asserts no error is returned
  and that the object was re-read (2 `Get` calls) rather than the stale copy
  being re-submitted.
- `RetriesUntilExhausted` — conflicts throughout; asserts the conflict surfaces
  wrapped in `errUpdateStatusFmt` and that attempts stop at
  `retry.DefaultRetry.Steps`.
- `DoesNotRetryOtherErrors` — a non-conflict error is returned after a single
  attempt (1 `Get`).
- `ReReadFailureSurfaces` — a failure re-reading the object after a conflict is
  propagated.

The existing `TestAPICallbacks{Create,Update,Destroy}` tests and their
`*Namespaced` and `*RequestReconcile` variants are unchanged and pass, which
covers the happy path, the `errGetFmt` path, and the `RequestReconcile`
precedence behaviour.

`go test ./pkg/controller/...` green; `gofmt -l` and `go vet` clean.
`golangci-lint run ./pkg/controller/...` reports 0 issues.

---

🤖
