### PR TITLE
fix(controller): use destroy-only diff on delete

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -801,11 +801,24 @@ func (n *terraformPluginSDKExternal) Update(ctx context.Context, mg xpresource.M
 
 func (n *terraformPluginSDKExternal) Delete(ctx context.Context, _ xpresource.Managed) (managed.ExternalDelete, error) {
 	n.logger.Debug("Deleting the external resource")
-	if n.instanceDiff == nil {
-		n.instanceDiff = tf.NewInstanceDiff()
+	// Terraform destroys an instance with a destroy-only diff carrying no
+	// attribute changes (see the destroy handling in the plugin SDK's
+	// helper/schema gRPC provider server). Reusing the diff computed during
+	// Observe is unsafe here: the SDK overlays its attribute changes on the
+	// state handed to the resource's delete function, so a pending change
+	// makes the deletion target the desired values instead of the actual
+	// ones, and if any of those changes is ForceNew, Resource.Apply proceeds
+	// from the destroy to a re-create with a stateless ResourceData in which
+	// every unchanged argument reads as its zero value. Only the operation
+	// timeouts are carried over from the computed diff.
+	deleteDiff := tf.NewInstanceDiff()
+	deleteDiff.Destroy = true
+	if n.instanceDiff != nil && n.instanceDiff.Meta != nil {
+		if timeouts, ok := n.instanceDiff.Meta[schema.TimeoutKey]; ok {
+			deleteDiff.Meta = map[string]any{schema.TimeoutKey: timeouts}
+		}
 	}
-
-	n.instanceDiff.Destroy = true
+	n.instanceDiff = deleteDiff
 	start := time.Now()
 	newState, diag := n.resourceSchema.Apply(ctx, n.opTracker.GetTfState(), n.instanceDiff, n.ts.Meta)
 	metrics.ExternalAPITime.WithLabelValues("delete").Observe(time.Since(start).Seconds())

--- a/pkg/controller/external_tfpluginsdk_test.go
+++ b/pkg/controller/external_tfpluginsdk_test.go
@@ -14,6 +14,7 @@ import (
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tf "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -466,13 +467,22 @@ func TestTerraformPluginSDKUpdate(t *testing.T) {
 }
 
 func TestTerraformPluginSDKDelete(t *testing.T) {
+	var appliedDiff *tf.InstanceDiff
+	applyRecorder := mockResource{
+		ApplyFn: func(ctx context.Context, s *tf.InstanceState, d *tf.InstanceDiff, meta interface{}) (*tf.InstanceState, diag.Diagnostics) {
+			appliedDiff = d
+			return &tf.InstanceState{ID: "example-id"}, nil
+		},
+	}
 	type args struct {
-		r   Resource
-		cfg *config.Resource
-		obj fake.Terraformed
+		r            Resource
+		cfg          *config.Resource
+		obj          fake.Terraformed
+		instanceDiff *tf.InstanceDiff
 	}
 	type want struct {
-		err error
+		err         error
+		appliedDiff *tf.InstanceDiff
 	}
 	cases := map[string]struct {
 		args
@@ -480,22 +490,55 @@ func TestTerraformPluginSDKDelete(t *testing.T) {
 	}{
 		"Successful": {
 			args: args{
-				r: mockResource{
-					ApplyFn: func(ctx context.Context, s *tf.InstanceState, d *tf.InstanceDiff, meta interface{}) (*tf.InstanceState, diag.Diagnostics) {
-						return &tf.InstanceState{ID: "example-id"}, nil
-					},
-				},
+				r:   applyRecorder,
 				cfg: cfg,
 				obj: obj,
+			},
+			want: want{
+				appliedDiff: &tf.InstanceDiff{
+					Attributes: map[string]*tf.ResourceAttrDiff{},
+					Destroy:    true,
+				},
+			},
+		},
+		// A diff computed during Observe may carry pending attribute changes,
+		// e.g. for a ForceNew argument whose desired value changed. The
+		// destroy call must not carry them into Resource.Apply, which would
+		// otherwise overlay them on the state handed to the resource's delete
+		// function and proceed from the destroy to a re-create with a
+		// stateless ResourceData. Only the operation timeouts must be kept.
+		"PendingForceNewDiffNotCarriedIntoDestroy": {
+			args: args{
+				r:   applyRecorder,
+				cfg: cfg,
+				obj: obj,
+				instanceDiff: &tf.InstanceDiff{
+					Attributes: map[string]*tf.ResourceAttrDiff{
+						"name": {Old: "example", New: "example-new", RequiresNew: true},
+					},
+					Meta: map[string]any{schema.TimeoutKey: map[string]any{"delete": timeout.Nanoseconds()}},
+				},
+			},
+			want: want{
+				appliedDiff: &tf.InstanceDiff{
+					Attributes: map[string]*tf.ResourceAttrDiff{},
+					Destroy:    true,
+					Meta:       map[string]any{schema.TimeoutKey: map[string]any{"delete": timeout.Nanoseconds()}},
+				},
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			appliedDiff = nil
 			terraformPluginSDKExternal := prepareTerraformPluginSDKExternal(tc.args.r, tc.args.cfg)
+			terraformPluginSDKExternal.instanceDiff = tc.args.instanceDiff
 			_, err := terraformPluginSDKExternal.Delete(t.Context(), &tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nConnect(...): -want error, +got error:\n", diff)
+				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n", diff)
+			}
+			if diff := cmp.Diff(tc.want.appliedDiff, appliedDiff, cmpopts.IgnoreUnexported(tf.InstanceDiff{}), cmpopts.IgnoreFields(tf.InstanceDiff{}, "RawConfig", "RawState", "RawPlan")); diff != "" {
+				t.Errorf("\n%s\nDelete(...): -want applied instance diff, +got applied instance diff:\n", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes
The Terraform plugin SDK external client reused the instance diff computed during Observe for the destroy call, only setting Destroy on it. When that diff carried a pending ForceNew attribute change, the SDK's Resource.Apply overlaid the desired values on the state handed to the resource's delete function (targeting the desired values instead of the actual ones) and then proceeded from the destroy to a re-create with a stateless ResourceData in which every unchanged argument reads as its zero value. For GCP *IAMMember resources this leaks the live IAM binding and permanently sticks the MR in Terminating with 'Import id "" doesn't match any of the accepted formats'.

Queue a fresh destroy-only diff instead, carrying over only the operation timeouts. This mirrors how the plugin SDK's helper/schema gRPC provider server constructs destroy diffs.

Fixes crossplane-contrib/provider-upjet-gcp#936

I have:

- [X] Read and followed Upjet's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

### How has this code been tested
Added tests

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
