### PR TITLE
Add config.Resource.OverrideScalarFieldType

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -153,8 +153,12 @@ func MarkAsRequired(sch *schema.Resource, fieldpaths ...string) {
 }
 
 // GetSchema returns the schema of the field whose fieldpath is given.
-// Returns nil if Schema is not found at the specified path.
+// Returns nil if the given resource schema is nil or if a Schema is
+// not found at the specified path or subpath.
 func GetSchema(sch *schema.Resource, fieldpath string) *schema.Schema {
+	if sch == nil {
+		return nil
+	}
 	current := sch
 	fields := strings.Split(fieldpath, ".")
 	final := fields[len(fields)-1]
@@ -168,7 +172,7 @@ func GetSchema(sch *schema.Resource, fieldpath string) *schema.Schema {
 			return nil
 		}
 		res, rok := s.Elem.(*schema.Resource)
-		if !rok {
+		if !rok || res == nil {
 			return nil
 		}
 		current = res

--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"go/types"
 	"strings"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
@@ -95,6 +96,7 @@ func DefaultResource(name string, terraformSchema *schema.Resource, terraformPlu
 		Conversions:                      []conversion.Conversion{conversion.NewIdentityConversionExpandPaths(conversion.AllVersions, conversion.AllVersions, nil)},
 		OverrideFieldNames:               map[string]string{},
 		listConversionPaths:              make(map[string]string),
+		overrideGeneratedFieldType:       map[string]types.Type{},
 	}
 	for _, f := range opts {
 		f(r)

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -533,6 +533,38 @@ func TestGetSchema(t *testing.T) {
 				sch: nil,
 			},
 		},
+		"MiddleFieldIsNilResource": {
+			reason: "A nil element resource in the middle of the path is reported as not found instead of panicking.",
+			args: args{
+				fieldpath: "topA.topB.topC",
+				sch: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"topA": {
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"topB": {
+										Elem: (*schema.Resource)(nil),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				sch: nil,
+			},
+		},
+		"NilResourceSchema": {
+			reason: "A nil Terraform resource schema is reported as not found instead of panicking.",
+			args: args{
+				fieldpath: "topA",
+				sch:       nil,
+			},
+			want: want{
+				sch: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -7,6 +7,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"go/types"
 	"strings"
 	"time"
 
@@ -707,6 +708,11 @@ type Resource struct {
 	// the Terraform Plugin SDKv2 client.
 	useTerraformPluginFrameworkClient bool
 
+	// overrideGeneratedFieldType allows to manually override the type for the
+	// generated field of a Resource at the specified Terraform path.
+	// We only support type overrides for scalar fields currently.
+	overrideGeneratedFieldType map[string]types.Type
+
 	// OverrideFieldNames allows to manually override the relevant field name to
 	// avoid possible Go struct name conflicts that may occur after Multiversion
 	// CRDs support. During field generation, there may be fields with the same
@@ -1178,6 +1184,33 @@ func (r *Resource) RemoveSingletonListConversion(tfPath string) bool {
 		}
 	}
 	return false
+}
+
+// OverrideScalarFieldType allows to manually override the type for the
+// generated scalar field of a Resource at the specified Terraform path.
+// The path is a Terraform field path without the wildcard segments, e.g.,
+// "x.y", even if "x" is a collection type.
+// We only support overriding types for scalar fields as of now.
+// Trying to override the type generated for a non-scalar path will result in
+// a generation-time error.
+func (r *Resource) OverrideScalarFieldType(path string, t types.Type) {
+	r.overrideGeneratedFieldType[path] = t
+}
+
+// FieldTypeOverrideConfiguration represents a configuration for a set of type
+// overrides at a specific Terraform path.
+type FieldTypeOverrideConfiguration struct {
+	ParameterTypeOverride types.Type
+}
+
+// FieldTypeOverride returns the type override configuration for the specified
+// path. The path is a Terraform field path without the wildcard segments,
+// e.g., "x.y", even if "x" is a collection type.
+// Note: This accessor is meant to be only used by the code generator.
+func (r *Resource) FieldTypeOverride(path string) FieldTypeOverrideConfiguration {
+	return FieldTypeOverrideConfiguration{
+		ParameterTypeOverride: r.overrideGeneratedFieldType[path],
+	}
 }
 
 // SetEmbeddedObject sets the EmbeddedObject for the specified key.

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -1192,9 +1192,22 @@ func (r *Resource) RemoveSingletonListConversion(tfPath string) bool {
 // "x.y", even if "x" is a collection type.
 // We only support overriding types for scalar fields as of now.
 // Trying to override the type generated for a non-scalar path will result in
-// a generation-time error.
-func (r *Resource) OverrideScalarFieldType(path string, t types.Type) {
-	r.overrideGeneratedFieldType[path] = t
+// an error.
+func (r *Resource) OverrideScalarFieldType(path string, t types.Type) error {
+	if r.TerraformResource == nil {
+		return errors.Errorf("resource %q does not have a valid Terraform resource schema", r.Name)
+	}
+	s := GetSchema(r.TerraformResource, path)
+	if s == nil {
+		return errors.Errorf("path %s is not valid for the Terraform resource schema of %q", path, r.Name)
+	}
+	switch s.Type { //nolint:exhaustive // The default case handles the error cases (non-scalar paths) already.
+	case schema.TypeBool, schema.TypeFloat, schema.TypeInt, schema.TypeString:
+		r.overrideGeneratedFieldType[path] = t
+	default:
+		return errors.Errorf("field at path %q with Terraform type %s is not scalar, only scalar field types can be overridden", path, s.Type.String())
+	}
+	return nil
 }
 
 // FieldTypeOverrideConfiguration represents a configuration for a set of type

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -7,6 +7,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"go/types"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -292,6 +293,83 @@ func TestRemoveSingletonListConversion(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.r().listConversionPaths, r.listConversionPaths); diff != "" {
 				t.Errorf("%s\nRemoveSingletonListConversion(tfPath): -wantConversionPaths, +gotConversionPaths: \n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestFieldTypeOverride(t *testing.T) {
+	strType := types.Typ[types.String]
+	type args struct {
+		r    func() *Resource
+		path string
+	}
+	type want struct {
+		// parameterType is the expected ParameterTypeOverride.String(), or the
+		// empty string when no usable override is expected for the path.
+		parameterType string
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"OverrideConfigured": {
+			reason: "A scalar type override set for a path is returned for that path.",
+			args: args{
+				path: "x.y",
+				r: func() *Resource {
+					r := DefaultResource("test_resource", nil, nil, nil)
+					r.OverrideScalarFieldType("x.y", strType)
+					return r
+				},
+			},
+			want: want{parameterType: "string"},
+		},
+		"DifferentPath": {
+			reason: "A path without a configured override has no parameter type override.",
+			args: args{
+				path: "a.b",
+				r: func() *Resource {
+					r := DefaultResource("test_resource", nil, nil, nil)
+					r.OverrideScalarFieldType("x.y", strType)
+					return r
+				},
+			},
+			want: want{parameterType: ""},
+		},
+		"NoOverrides": {
+			reason: "A resource with no configured overrides has no parameter type override for any path.",
+			args: args{
+				path: "x.y",
+				r: func() *Resource {
+					return DefaultResource("test_resource", nil, nil, nil)
+				},
+			},
+			want: want{parameterType: ""},
+		},
+		"NilOverrideIgnored": {
+			reason: "A nil type override is indistinguishable from no override for the path.",
+			args: args{
+				path: "x.y",
+				r: func() *Resource {
+					r := DefaultResource("test_resource", nil, nil, nil)
+					r.OverrideScalarFieldType("x.y", nil)
+					return r
+				},
+			},
+			want: want{parameterType: ""},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			got := tc.args.r().FieldTypeOverride(tc.args.path).ParameterTypeOverride
+			gotStr := ""
+			if got != nil {
+				gotStr = got.String()
+			}
+			if diff := cmp.Diff(tc.want.parameterType, gotStr); diff != "" {
+				t.Errorf("%s\nFieldTypeOverride(%q): -want, +got:\n%s", tc.reason, tc.args.path, diff)
 			}
 		})
 	}

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -298,16 +299,73 @@ func TestRemoveSingletonListConversion(t *testing.T) {
 	}
 }
 
+// scalarAtXY returns a Terraform resource schema where x is
+// a collection type (list) and x.y is a scalar (int).
+func scalarAtXY() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"x": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"y": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// scalarAtXYZ returns a Terraform resource schema where x & x.y are
+// a collection types (list) and x.y.z is a scalar (int).
+func scalarAtXYZ() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"x": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"y": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"z": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestFieldTypeOverride(t *testing.T) {
 	strType := types.Typ[types.String]
 	type args struct {
-		r    func() *Resource
+		r func() *Resource
+		// overridePath is the path passed to Resource.OverrideScalarFieldType.
+		overridePath string
+		// overrideType is the type passed to Resource.OverrideScalarFieldType.
+		overrideType types.Type
+		// path is the path queried via Resource.FieldTypeOverride.
 		path string
 	}
 	type want struct {
-		// parameterType is the expected ParameterTypeOverride.String(), or the
-		// empty string when no usable override is expected for the path.
+		// parameterType is the expected ParameterTypeOverride.String(),
+		// or the empty string when there's no override configured.
 		parameterType string
+		// err is the expected error from Resource.OverrideScalarFieldType.
+		err error
 	}
 	cases := map[string]struct {
 		reason string
@@ -317,11 +375,11 @@ func TestFieldTypeOverride(t *testing.T) {
 		"OverrideConfigured": {
 			reason: "A scalar type override set for a path is returned for that path.",
 			args: args{
-				path: "x.y",
+				path:         "x.y",
+				overridePath: "x.y",
+				overrideType: strType,
 				r: func() *Resource {
-					r := DefaultResource("test_resource", nil, nil, nil)
-					r.OverrideScalarFieldType("x.y", strType)
-					return r
+					return DefaultResource("test_resource", scalarAtXY(), nil, nil)
 				},
 			},
 			want: want{parameterType: "string"},
@@ -329,11 +387,11 @@ func TestFieldTypeOverride(t *testing.T) {
 		"DifferentPath": {
 			reason: "A path without a configured override has no parameter type override.",
 			args: args{
-				path: "a.b",
+				path:         "a.b",
+				overridePath: "x.y",
+				overrideType: strType,
 				r: func() *Resource {
-					r := DefaultResource("test_resource", nil, nil, nil)
-					r.OverrideScalarFieldType("x.y", strType)
-					return r
+					return DefaultResource("test_resource", scalarAtXY(), nil, nil)
 				},
 			},
 			want: want{parameterType: ""},
@@ -343,27 +401,92 @@ func TestFieldTypeOverride(t *testing.T) {
 			args: args{
 				path: "x.y",
 				r: func() *Resource {
-					return DefaultResource("test_resource", nil, nil, nil)
+					return DefaultResource("test_resource", scalarAtXY(), nil, nil)
 				},
 			},
 			want: want{parameterType: ""},
+		},
+		"OverrideCollectionPath": {
+			reason: "A scalar type override configured with a path without the wildcard segments is returned for that path, even if an intermediate path segment is a collection type.",
+			args: args{
+				path:         "x.y.z",
+				overridePath: "x.y.z",
+				overrideType: strType,
+				r: func() *Resource {
+					return DefaultResource("test_resource", scalarAtXYZ(), nil, nil)
+				},
+			},
+			want: want{parameterType: "string"},
 		},
 		"NilOverrideIgnored": {
 			reason: "A nil type override is indistinguishable from no override for the path.",
 			args: args{
-				path: "x.y",
+				path:         "x.y",
+				overridePath: "x.y",
+				overrideType: nil,
 				r: func() *Resource {
-					r := DefaultResource("test_resource", nil, nil, nil)
-					r.OverrideScalarFieldType("x.y", nil)
-					return r
+					return DefaultResource("test_resource", scalarAtXY(), nil, nil)
 				},
 			},
 			want: want{parameterType: ""},
 		},
+		"PathNotInSchema": {
+			reason: "A path that does not exist in the Terraform resource schema cannot be configured with a type override.",
+			args: args{
+				path:         "a.b",
+				overridePath: "a.b",
+				overrideType: strType,
+				r: func() *Resource {
+					return DefaultResource("test_resource", scalarAtXY(), nil, nil)
+				},
+			},
+			want: want{
+				parameterType: "",
+				err:           errors.Errorf("path a.b is not valid for the Terraform resource schema of %q", "test_resource"),
+			},
+		},
+		"NoTerraformResourceSchema": {
+			reason: "A type override cannot be configured for a resource without a Terraform resource schema to validate the path against.",
+			args: args{
+				path:         "x.y",
+				overridePath: "x.y",
+				overrideType: strType,
+				r: func() *Resource {
+					return DefaultResource("test_resource", nil, nil, nil)
+				},
+			},
+			want: want{
+				parameterType: "",
+				err:           errors.Errorf("resource %q does not have a valid Terraform resource schema", "test_resource"),
+			},
+		},
+		"PathNotScalar": {
+			reason: "A path whose Terraform type is not scalar cannot be configured with a type override.",
+			args: args{
+				path:         "x.y",
+				overridePath: "x.y",
+				overrideType: strType,
+				r: func() *Resource {
+					return DefaultResource("test_resource", scalarAtXYZ(), nil, nil)
+				},
+			},
+			want: want{
+				parameterType: "",
+				err:           errors.Errorf("field at path %q with Terraform type %s is not scalar, only scalar field types can be overridden", "x.y", schema.TypeList.String()),
+			},
+		},
 	}
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			got := tc.args.r().FieldTypeOverride(tc.args.path).ParameterTypeOverride
+			r := tc.args.r()
+			var gotErr error
+			if tc.args.overridePath != "" {
+				gotErr = r.OverrideScalarFieldType(tc.args.overridePath, tc.args.overrideType)
+			}
+			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nOverrideScalarFieldType(%q): -want error, +got error:\n%s", tc.reason, tc.args.overridePath, diff)
+			}
+			got := r.FieldTypeOverride(tc.args.path).ParameterTypeOverride
 			gotStr := ""
 			if got != nil {
 				gotStr = got.String()

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -225,7 +225,7 @@ func (g *Builder) buildSchema(f *Field, cfg *config.Resource, names []string, cp
 			return o.ParameterTypeOverride, nil, nil
 		default:
 			return nil, nil, errors.Errorf(
-				"OverrideScalarFieldType at %q is only supported for scalar fields, got Terraform type %s",
+				"field at path %q with Terraform type %s specified for OverrideScalarFieldType is not scalar, only scalar field types can be overridden",
 				cpath, f.Schema.Type.String())
 		}
 	}

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -10,9 +10,9 @@ import (
 	"go/types"
 	"sort"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	twtypes "github.com/muvaf/typewriter/pkg/types"
-	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
@@ -219,6 +219,17 @@ func (g *Builder) AddToBuilder(typeNames *TypeNames, r *resource) (*types.Named,
 }
 
 func (g *Builder) buildSchema(f *Field, cfg *config.Resource, names []string, cpath string, r *resource) (types.Type, types.Type, error) { //nolint:gocyclo
+	if o := cfg.FieldTypeOverride(cpath); o.ParameterTypeOverride != nil {
+		switch f.Schema.Type { //nolint:exhaustive // The default case handles the error cases (non-scalar paths) already.
+		case schema.TypeBool, schema.TypeFloat, schema.TypeInt, schema.TypeString:
+			return o.ParameterTypeOverride, nil, nil
+		default:
+			return nil, nil, errors.Errorf(
+				"OverrideScalarFieldType at %q is only supported for scalar fields, got Terraform type %s",
+				cpath, f.Schema.Type.String())
+		}
+	}
+
 	switch f.Schema.Type {
 	case schema.TypeBool:
 		return types.NewPointer(types.Universe.Lookup("bool").Type()), nil, nil

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
 )
@@ -869,6 +869,98 @@ func TestBuild(t *testing.T) {
 				t.Run(checkName, func(t *testing.T) {
 					checkFn(t, g.Comments)
 				})
+			}
+		})
+	}
+}
+
+func TestBuildFieldTypeOverride(t *testing.T) {
+	type want struct {
+		forProvider  string
+		initProvider string
+		observation  string
+		errContains  string
+	}
+	cases := map[string]struct {
+		reason string
+		cfg    func() *config.Resource
+		want   want
+	}{
+		"ScalarOverrideAppliesToAllAPIs": {
+			reason: "Overriding a scalar field's type replaces it across forProvider, initProvider and observation.",
+			cfg: func() *config.Resource {
+				r := config.DefaultResource("test_resource", &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				}, nil, nil)
+				r.Kind = ""
+				r.OverrideScalarFieldType("enabled", NewStringOrBoolType())
+				return r
+			},
+			want: want{
+				forProvider:  `type example.Parameters struct{Enabled *github.com/crossplane/upjet/v2/pkg/types.StringOrBool "json:\"enabled,omitempty\" tf:\"enabled,omitempty\""}`,
+				initProvider: `type example.InitParameters struct{Enabled *github.com/crossplane/upjet/v2/pkg/types.StringOrBool "json:\"enabled,omitempty\" tf:\"enabled,omitempty\""}`,
+				observation:  `type example.Observation struct{Enabled *github.com/crossplane/upjet/v2/pkg/types.StringOrBool "json:\"enabled,omitempty\" tf:\"enabled,omitempty\""}`,
+			},
+		},
+		"NonScalarOverrideErrors": {
+			reason: "Overriding a non-scalar (collection) field's type is a generation-time error.",
+			cfg: func() *config.Resource {
+				r := config.DefaultResource("test_resource", &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"size": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				}, nil, nil)
+				r.Kind = ""
+				r.OverrideScalarFieldType("settings", NewStringOrBoolType())
+				return r
+			},
+			want: want{
+				errContains: `OverrideScalarFieldType at "settings" is only supported for scalar fields, got Terraform type TypeList`,
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			builder := NewBuilder(types.NewPackage("example", ""), CRDScopeCluster)
+			g, err := builder.Build(tc.cfg())
+
+			if tc.want.errContains != "" {
+				if err == nil {
+					t.Fatalf("%s\nBuild(...): expected an error containing %q, got nil", tc.reason, tc.want.errContains)
+				}
+				if !strings.Contains(err.Error(), tc.want.errContains) {
+					t.Errorf("%s\nBuild(...): error %q does not contain %q", tc.reason, err.Error(), tc.want.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("%s\nBuild(...): unexpected error: %v", tc.reason, err)
+			}
+			if diff := cmp.Diff(tc.want.forProvider, g.ForProviderType.Obj().String()); diff != "" {
+				t.Errorf("%s\nBuild(...): -want forProvider, +got forProvider:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.initProvider, g.InitProviderType.Obj().String()); diff != "" {
+				t.Errorf("%s\nBuild(...): -want initProvider, +got initProvider:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.observation, g.AtProviderType.Obj().String()); diff != "" {
+				t.Errorf("%s\nBuild(...): -want observation, +got observation:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -883,12 +883,12 @@ func TestBuildFieldTypeOverride(t *testing.T) {
 	}
 	cases := map[string]struct {
 		reason string
-		cfg    func() *config.Resource
+		cfg    func(t *testing.T) *config.Resource
 		want   want
 	}{
 		"ScalarOverrideAppliesToAllAPIs": {
 			reason: "Overriding a scalar field's type replaces it across forProvider, initProvider and observation.",
-			cfg: func() *config.Resource {
+			cfg: func(t *testing.T) *config.Resource {
 				r := config.DefaultResource("test_resource", &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -898,7 +898,9 @@ func TestBuildFieldTypeOverride(t *testing.T) {
 					},
 				}, nil, nil)
 				r.Kind = ""
-				r.OverrideScalarFieldType("enabled", NewStringOrBoolType())
+				if err := r.OverrideScalarFieldType("enabled", NewStringOrBoolType()); err != nil {
+					t.Fatalf("cannot override the type of the scalar field at path %q: %v", "enabled", err)
+				}
 				return r
 			},
 			want: want{
@@ -909,25 +911,37 @@ func TestBuildFieldTypeOverride(t *testing.T) {
 		},
 		"NonScalarOverrideErrors": {
 			reason: "Overriding a non-scalar (collection) field's type is a generation-time error.",
-			cfg: func() *config.Resource {
-				r := config.DefaultResource("test_resource", &schema.Resource{
+			cfg: func(t *testing.T) *config.Resource {
+				sch := &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"settings": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeString,
 							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"size": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-								},
+						},
+					},
+				}
+				r := config.DefaultResource("test_resource", sch, nil, nil)
+				r.Kind = ""
+				if err := r.OverrideScalarFieldType("settings", NewStringOrBoolType()); err != nil {
+					t.Fatalf("cannot override the type of the field at path %q: %v", "settings", err)
+				}
+				// config.Resource.OverrideScalarFieldType rejects the
+				// non-scalar paths, so the field is turned into a collection
+				// only after the override has been configured to exercise the
+				// generation-time check. This could happen due to a schema traverser
+				// or due to other Terraform schema mutators.
+				sch.Schema["settings"] = &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"size": {
+								Type:     schema.TypeInt,
+								Optional: true,
 							},
 						},
 					},
-				}, nil, nil)
-				r.Kind = ""
-				r.OverrideScalarFieldType("settings", NewStringOrBoolType())
+				}
 				return r
 			},
 			want: want{
@@ -938,7 +952,7 @@ func TestBuildFieldTypeOverride(t *testing.T) {
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
 			builder := NewBuilder(types.NewPackage("example", ""), CRDScopeCluster)
-			g, err := builder.Build(tc.cfg())
+			g, err := builder.Build(tc.cfg(t))
 
 			if tc.want.errContains != "" {
 				if err == nil {

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -931,7 +931,7 @@ func TestBuildFieldTypeOverride(t *testing.T) {
 				return r
 			},
 			want: want{
-				errContains: `OverrideScalarFieldType at "settings" is only supported for scalar fields, got Terraform type TypeList`,
+				errContains: `field at path "settings" with Terraform type TypeList specified for OverrideScalarFieldType is not scalar, only scalar field types can be overridden`,
 			},
 		},
 	}

--- a/pkg/types/internal/string.go
+++ b/pkg/types/internal/string.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+)
+
+const (
+	errInvalidValue = "value must be a JSON string or %T, got %s"
+)
+
+// Primitive is a type constraint that represents the supported primitive types
+// for StringOrPrimitive.
+type Primitive interface {
+	~bool |
+		~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// StringOrPrimitive is stored canonically as a string, but can decode
+// from other primitive values such as ints and bools.
+type StringOrPrimitive[T Primitive] string
+
+func (b *StringOrPrimitive[T]) UnmarshalJSON(data []byte) error {
+	// first try as a string value.
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*b = StringOrPrimitive[T](s)
+		return nil
+	}
+
+	// if not a string value, try as a value of the specified type parameter.
+	var v T
+	if err := json.Unmarshal(data, &v); err == nil {
+		*b = StringOrPrimitive[T](fmt.Sprint(v))
+		return nil
+	}
+
+	return errors.Errorf(errInvalidValue, v, string(data))
+}
+
+func (b *StringOrPrimitive[T]) MarshalJSON() ([]byte, error) {
+	// Always write back as string in the new canonical format.
+	return json.Marshal(*b)
+}

--- a/pkg/types/internal/string_test.go
+++ b/pkg/types/internal/string_test.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// stringOrPrimitiveIO captures the primitive-specific inputs/outputs for a
+// single StringOrPrimitive type parameter. The type-independent behaviour
+// (decoding a JSON string, error handling, ...) is asserted by
+// runStringOrPrimitiveSuite for every T.
+type stringOrPrimitiveIO struct {
+	// fromPrimitive is the JSON encoding of a native value of the primitive
+	// type parameter, e.g. "true", "42" or "0.5".
+	fromPrimitive string
+	// canonical is the canonical string form StringOrPrimitive stores for
+	// fromPrimitive, i.e. fmt.Sprint(v).
+	canonical string
+}
+
+// runStringOrPrimitiveSuite exercises UnmarshalJSON and MarshalJSON for a
+// single primitive type parameter T, in both directions.
+func runStringOrPrimitiveSuite[T Primitive](t *testing.T, io stringOrPrimitiveIO) {
+	t.Helper()
+
+	// Unmarshalling a JSON string is type-independent: the raw string is
+	// stored verbatim as the canonical value regardless of T.
+	t.Run("UnmarshalJSONString", func(t *testing.T) {
+		const in = `"already-a-string"`
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON([]byte(in)); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", in, err)
+		}
+		if diff := cmp.Diff("already-a-string", string(got)); diff != "" {
+			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", in, diff)
+		}
+	})
+
+	// Unmarshalling the native primitive encoding coerces it into its
+	// canonical string form.
+	t.Run("UnmarshalJSONPrimitive", func(t *testing.T) {
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON([]byte(io.fromPrimitive)); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", io.fromPrimitive, err)
+		}
+		if diff := cmp.Diff(io.canonical, string(got)); diff != "" {
+			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", io.fromPrimitive, diff)
+		}
+	})
+
+	// Marshalling always emits the canonical string form, never the original
+	// primitive encoding.
+	t.Run("MarshalJSON", func(t *testing.T) {
+		b := StringOrPrimitive[T](io.canonical)
+		got, err := b.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
+		}
+		want, err := json.Marshal(io.canonical)
+		if err != nil {
+			t.Fatalf("json.Marshal(%q): unexpected error: %v", io.canonical, err)
+		}
+		if diff := cmp.Diff(string(want), string(got)); diff != "" {
+			t.Errorf("MarshalJSON(): -want, +got:\n%s", diff)
+		}
+	})
+
+	// A canonical value survives a marshal -> unmarshal round-trip unchanged.
+	t.Run("RoundTrip", func(t *testing.T) {
+		want := StringOrPrimitive[T](io.canonical)
+		data, err := want.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
+		}
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON(data); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", data, err)
+		}
+		if diff := cmp.Diff(string(want), string(got)); diff != "" {
+			t.Errorf("round-trip: -want, +got:\n%s", diff)
+		}
+	})
+}
+
+// TestStringOrPrimitive covers every primitive type in the Primitive
+// constraint (plus a named ~float64 type) in both directions.
+func TestStringOrPrimitive(t *testing.T) {
+	cases := map[string]func(t *testing.T){
+		"Bool": func(t *testing.T) {
+			runStringOrPrimitiveSuite[bool](t, stringOrPrimitiveIO{fromPrimitive: "true", canonical: "true"})
+		},
+		"Int": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int](t, stringOrPrimitiveIO{fromPrimitive: "-1", canonical: "-1"})
+		},
+		"Int8": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int8](t, stringOrPrimitiveIO{fromPrimitive: "-128", canonical: "-128"})
+		},
+		"Int16": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int16](t, stringOrPrimitiveIO{fromPrimitive: "32767", canonical: "32767"})
+		},
+		"Int32": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int32](t, stringOrPrimitiveIO{fromPrimitive: "-2147483648", canonical: "-2147483648"})
+		},
+		"Int64": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int64](t, stringOrPrimitiveIO{fromPrimitive: "9223372036854775807", canonical: "9223372036854775807"})
+		},
+		"Uint": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint](t, stringOrPrimitiveIO{fromPrimitive: "1", canonical: "1"})
+		},
+		"Uint8": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint8](t, stringOrPrimitiveIO{fromPrimitive: "255", canonical: "255"})
+		},
+		"Uint16": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint16](t, stringOrPrimitiveIO{fromPrimitive: "65535", canonical: "65535"})
+		},
+		"Uint32": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint32](t, stringOrPrimitiveIO{fromPrimitive: "4294967295", canonical: "4294967295"})
+		},
+		"Uint64": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint64](t, stringOrPrimitiveIO{fromPrimitive: "18446744073709551615", canonical: "18446744073709551615"})
+		},
+	}
+	for name, run := range cases {
+		t.Run(name, run)
+	}
+}
+
+// TestStringOrPrimitiveUnmarshalJSONEdgeCases covers UnmarshalJSON inputs whose
+// handling does not depend on the primitive type parameter; int is used as a
+// representative T.
+func TestStringOrPrimitiveUnmarshalJSONEdgeCases(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		data   string
+		want   string
+	}{
+		"EmptyString": {
+			reason: "An empty JSON string decodes to an empty canonical value.",
+			data:   `""`,
+			want:   "",
+		},
+		"Null": {
+			reason: "A JSON null is a no-op for the string decode path and yields an empty canonical value.",
+			data:   `null`,
+			want:   "",
+		},
+		"EscapedString": {
+			reason: "Escape sequences in a JSON string are decoded before being stored.",
+			data:   `"a\"b\tc"`,
+			want:   "a\"b\tc",
+		},
+		"WhitespacePreserved": {
+			reason: "Surrounding whitespace within a JSON string is preserved.",
+			data:   `"  spaced  "`,
+			want:   "  spaced  ",
+		},
+		"NumericString": {
+			reason: "A quoted number is treated as a string and stored verbatim.",
+			data:   `"42"`,
+			want:   "42",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got StringOrPrimitive[int]
+			if err := got.UnmarshalJSON([]byte(tc.data)); err != nil {
+				t.Fatalf("UnmarshalJSON(%s): unexpected error: %v\nreason: %s", tc.data, err, tc.reason)
+			}
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s\nreason: %s", tc.data, diff, tc.reason)
+			}
+		})
+	}
+}
+
+// TestStringOrPrimitiveUnmarshalJSONErrors covers inputs that are neither a
+// JSON string nor a valid value of the type parameter; int is used as a
+// representative T.
+func TestStringOrPrimitiveUnmarshalJSONErrors(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		data   string
+	}{
+		"JSONArray": {
+			reason: "A JSON array is neither a string nor an int.",
+			data:   `[1,2,3]`,
+		},
+		"JSONObject": {
+			reason: "A JSON object is neither a string nor an int.",
+			data:   `{"a":1}`,
+		},
+		"TypeMismatch": {
+			reason: "A JSON boolean cannot be decoded into an int type parameter.",
+			data:   `true`,
+		},
+		"FloatIntoInt": {
+			reason: "A JSON floating-point number cannot be decoded into an int type parameter.",
+			data:   `1.5`,
+		},
+		"MalformedJSON": {
+			reason: "Malformed JSON fails both the string and the primitive decode attempts.",
+			data:   `{`,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got StringOrPrimitive[int]
+			err := got.UnmarshalJSON([]byte(tc.data))
+			if err == nil {
+				t.Fatalf("UnmarshalJSON(%s): expected an error, got nil\nreason: %s", tc.data, tc.reason)
+			}
+			if want := "value must be a JSON string"; !strings.Contains(err.Error(), want) {
+				t.Errorf("UnmarshalJSON(%s): error %q does not contain %q\nreason: %s", tc.data, err.Error(), want, tc.reason)
+			}
+		})
+	}
+}

--- a/pkg/types/string.go
+++ b/pkg/types/string.go
@@ -5,47 +5,39 @@
 package types
 
 import (
-	"encoding/json"
-	"fmt"
+	"go/token"
+	"go/types"
 
-	"github.com/pkg/errors"
+	"github.com/crossplane/upjet/v2/pkg/types/internal"
 )
 
 const (
-	errInvalidValue = "value must be a JSON string or %T, got %s"
+	packageName = "types"
+	packagePath = "github.com/crossplane/upjet/v2/pkg/" + packageName
 )
 
-// Primitive is a type constraint that represents the supported primitive types
-// for StringOrPrimitive.
-type Primitive interface {
-	~bool |
-		~int | ~int8 | ~int16 | ~int32 | ~int64 |
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+// StringOrBool is stored canonically as a string, but can also decode
+// from bools.
+type StringOrBool string
+
+func (b *StringOrBool) UnmarshalJSON(data []byte) error {
+	g := internal.StringOrPrimitive[bool](*b)
+	if err := g.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*b = StringOrBool(g)
+	return nil
 }
 
-// StringOrPrimitive is stored canonically as a string, but can decode
-// from other primitive values such as ints, floats, bools, etc.
-type StringOrPrimitive[T Primitive] string
-
-func (b *StringOrPrimitive[T]) UnmarshalJSON(data []byte) error {
-	// first try as a string value.
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		*b = StringOrPrimitive[T](s)
-		return nil
-	}
-
-	// if not a string value, try as a value of the specified type parameter.
-	var v T
-	if err := json.Unmarshal(data, &v); err == nil {
-		*b = StringOrPrimitive[T](fmt.Sprint(v))
-		return nil
-	}
-
-	return errors.Errorf(errInvalidValue, v, string(data))
+func (b *StringOrBool) MarshalJSON() ([]byte, error) {
+	g := internal.StringOrPrimitive[bool](*b)
+	return g.MarshalJSON()
 }
 
-func (b *StringOrPrimitive[T]) MarshalJSON() ([]byte, error) {
-	// Always write back as string in the new canonical format.
-	return json.Marshal(*b)
+// NewStringOrBoolType returns a types.Type representing the StringOrBool type.
+// The returned type is a pointer type.
+func NewStringOrBoolType() types.Type {
+	tn := types.NewTypeName(token.NoPos, types.NewPackage(packagePath, packageName), "StringOrBool", nil)
+	t := types.NewNamed(tn, types.Universe.Lookup("string").Type(), nil)
+	return types.NewPointer(t)
 }

--- a/pkg/types/string.go
+++ b/pkg/types/string.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	errInvalidValue = "value must be a JSON string or %T, got %s"
+)
+
+// Primitive is a type constraint that represents the supported primitive types
+// for StringOrPrimitive.
+type Primitive interface {
+	~bool |
+		~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// StringOrPrimitive is stored canonically as a string, but can decode
+// from other primitive values such as ints, floats, bools, etc.
+type StringOrPrimitive[T Primitive] string
+
+func (b *StringOrPrimitive[T]) UnmarshalJSON(data []byte) error {
+	// first try as a string value.
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*b = StringOrPrimitive[T](s)
+		return nil
+	}
+
+	// if not a string value, try as a value of the specified type parameter.
+	var v T
+	if err := json.Unmarshal(data, &v); err == nil {
+		*b = StringOrPrimitive[T](fmt.Sprint(v))
+		return nil
+	}
+
+	return errors.Errorf(errInvalidValue, v, string(data))
+}
+
+func (b *StringOrPrimitive[T]) MarshalJSON() ([]byte, error) {
+	// Always write back as string in the new canonical format.
+	return json.Marshal(*b)
+}

--- a/pkg/types/string_test.go
+++ b/pkg/types/string_test.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// stringOrPrimitiveIO captures the primitive-specific inputs/outputs for a
+// single StringOrPrimitive type parameter. The type-independent behaviour
+// (decoding a JSON string, error handling, ...) is asserted by
+// runStringOrPrimitiveSuite for every T.
+type stringOrPrimitiveIO struct {
+	// fromPrimitive is the JSON encoding of a native value of the primitive
+	// type parameter, e.g. "true", "42" or "0.5".
+	fromPrimitive string
+	// canonical is the canonical string form StringOrPrimitive stores for
+	// fromPrimitive, i.e. fmt.Sprint(v).
+	canonical string
+}
+
+// runStringOrPrimitiveSuite exercises UnmarshalJSON and MarshalJSON for a
+// single primitive type parameter T, in both directions.
+func runStringOrPrimitiveSuite[T Primitive](t *testing.T, io stringOrPrimitiveIO) {
+	t.Helper()
+
+	// Unmarshalling a JSON string is type-independent: the raw string is
+	// stored verbatim as the canonical value regardless of T.
+	t.Run("UnmarshalJSONString", func(t *testing.T) {
+		const in = `"already-a-string"`
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON([]byte(in)); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", in, err)
+		}
+		if diff := cmp.Diff("already-a-string", string(got)); diff != "" {
+			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", in, diff)
+		}
+	})
+
+	// Unmarshalling the native primitive encoding coerces it into its
+	// canonical string form.
+	t.Run("UnmarshalJSONPrimitive", func(t *testing.T) {
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON([]byte(io.fromPrimitive)); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", io.fromPrimitive, err)
+		}
+		if diff := cmp.Diff(io.canonical, string(got)); diff != "" {
+			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", io.fromPrimitive, diff)
+		}
+	})
+
+	// Marshalling always emits the canonical string form, never the original
+	// primitive encoding.
+	t.Run("MarshalJSON", func(t *testing.T) {
+		b := StringOrPrimitive[T](io.canonical)
+		got, err := b.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
+		}
+		want, err := json.Marshal(io.canonical)
+		if err != nil {
+			t.Fatalf("json.Marshal(%q): unexpected error: %v", io.canonical, err)
+		}
+		if diff := cmp.Diff(string(want), string(got)); diff != "" {
+			t.Errorf("MarshalJSON(): -want, +got:\n%s", diff)
+		}
+	})
+
+	// A canonical value survives a marshal -> unmarshal round-trip unchanged.
+	t.Run("RoundTrip", func(t *testing.T) {
+		want := StringOrPrimitive[T](io.canonical)
+		data, err := want.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
+		}
+		var got StringOrPrimitive[T]
+		if err := got.UnmarshalJSON(data); err != nil {
+			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", data, err)
+		}
+		if diff := cmp.Diff(string(want), string(got)); diff != "" {
+			t.Errorf("round-trip: -want, +got:\n%s", diff)
+		}
+	})
+}
+
+// TestStringOrPrimitive covers every primitive type in the Primitive
+// constraint (plus a named ~float64 type) in both directions.
+func TestStringOrPrimitive(t *testing.T) {
+	cases := map[string]func(t *testing.T){
+		"Bool": func(t *testing.T) {
+			runStringOrPrimitiveSuite[bool](t, stringOrPrimitiveIO{fromPrimitive: "true", canonical: "true"})
+		},
+		"Int": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int](t, stringOrPrimitiveIO{fromPrimitive: "-1", canonical: "-1"})
+		},
+		"Int8": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int8](t, stringOrPrimitiveIO{fromPrimitive: "-128", canonical: "-128"})
+		},
+		"Int16": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int16](t, stringOrPrimitiveIO{fromPrimitive: "32767", canonical: "32767"})
+		},
+		"Int32": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int32](t, stringOrPrimitiveIO{fromPrimitive: "-2147483648", canonical: "-2147483648"})
+		},
+		"Int64": func(t *testing.T) {
+			runStringOrPrimitiveSuite[int64](t, stringOrPrimitiveIO{fromPrimitive: "9223372036854775807", canonical: "9223372036854775807"})
+		},
+		"Uint": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint](t, stringOrPrimitiveIO{fromPrimitive: "1", canonical: "1"})
+		},
+		"Uint8": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint8](t, stringOrPrimitiveIO{fromPrimitive: "255", canonical: "255"})
+		},
+		"Uint16": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint16](t, stringOrPrimitiveIO{fromPrimitive: "65535", canonical: "65535"})
+		},
+		"Uint32": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint32](t, stringOrPrimitiveIO{fromPrimitive: "4294967295", canonical: "4294967295"})
+		},
+		"Uint64": func(t *testing.T) {
+			runStringOrPrimitiveSuite[uint64](t, stringOrPrimitiveIO{fromPrimitive: "18446744073709551615", canonical: "18446744073709551615"})
+		},
+	}
+	for name, run := range cases {
+		t.Run(name, run)
+	}
+}
+
+// TestStringOrPrimitiveUnmarshalJSONEdgeCases covers UnmarshalJSON inputs whose
+// handling does not depend on the primitive type parameter; int is used as a
+// representative T.
+func TestStringOrPrimitiveUnmarshalJSONEdgeCases(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		data   string
+		want   string
+	}{
+		"EmptyString": {
+			reason: "An empty JSON string decodes to an empty canonical value.",
+			data:   `""`,
+			want:   "",
+		},
+		"Null": {
+			reason: "A JSON null is a no-op for the string decode path and yields an empty canonical value.",
+			data:   `null`,
+			want:   "",
+		},
+		"EscapedString": {
+			reason: "Escape sequences in a JSON string are decoded before being stored.",
+			data:   `"a\"b\tc"`,
+			want:   "a\"b\tc",
+		},
+		"WhitespacePreserved": {
+			reason: "Surrounding whitespace within a JSON string is preserved.",
+			data:   `"  spaced  "`,
+			want:   "  spaced  ",
+		},
+		"NumericString": {
+			reason: "A quoted number is treated as a string and stored verbatim.",
+			data:   `"42"`,
+			want:   "42",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got StringOrPrimitive[int]
+			if err := got.UnmarshalJSON([]byte(tc.data)); err != nil {
+				t.Fatalf("UnmarshalJSON(%s): unexpected error: %v\nreason: %s", tc.data, err, tc.reason)
+			}
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s\nreason: %s", tc.data, diff, tc.reason)
+			}
+		})
+	}
+}
+
+// TestStringOrPrimitiveUnmarshalJSONErrors covers inputs that are neither a
+// JSON string nor a valid value of the type parameter; int is used as a
+// representative T.
+func TestStringOrPrimitiveUnmarshalJSONErrors(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		data   string
+	}{
+		"JSONArray": {
+			reason: "A JSON array is neither a string nor an int.",
+			data:   `[1,2,3]`,
+		},
+		"JSONObject": {
+			reason: "A JSON object is neither a string nor an int.",
+			data:   `{"a":1}`,
+		},
+		"TypeMismatch": {
+			reason: "A JSON boolean cannot be decoded into an int type parameter.",
+			data:   `true`,
+		},
+		"FloatIntoInt": {
+			reason: "A JSON floating-point number cannot be decoded into an int type parameter.",
+			data:   `1.5`,
+		},
+		"MalformedJSON": {
+			reason: "Malformed JSON fails both the string and the primitive decode attempts.",
+			data:   `{`,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got StringOrPrimitive[int]
+			err := got.UnmarshalJSON([]byte(tc.data))
+			if err == nil {
+				t.Fatalf("UnmarshalJSON(%s): expected an error, got nil\nreason: %s", tc.data, tc.reason)
+			}
+			if want := "value must be a JSON string"; !strings.Contains(err.Error(), want) {
+				t.Errorf("UnmarshalJSON(%s): error %q does not contain %q\nreason: %s", tc.data, err.Error(), want, tc.reason)
+			}
+		})
+	}
+}

--- a/pkg/types/string_test.go
+++ b/pkg/types/string_test.go
@@ -6,219 +6,259 @@ package types
 
 import (
 	"encoding/json"
+	"go/types"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-// stringOrPrimitiveIO captures the primitive-specific inputs/outputs for a
-// single StringOrPrimitive type parameter. The type-independent behaviour
-// (decoding a JSON string, error handling, ...) is asserted by
-// runStringOrPrimitiveSuite for every T.
-type stringOrPrimitiveIO struct {
-	// fromPrimitive is the JSON encoding of a native value of the primitive
-	// type parameter, e.g. "true", "42" or "0.5".
-	fromPrimitive string
-	// canonical is the canonical string form StringOrPrimitive stores for
-	// fromPrimitive, i.e. fmt.Sprint(v).
-	canonical string
-}
-
-// runStringOrPrimitiveSuite exercises UnmarshalJSON and MarshalJSON for a
-// single primitive type parameter T, in both directions.
-func runStringOrPrimitiveSuite[T Primitive](t *testing.T, io stringOrPrimitiveIO) {
-	t.Helper()
-
-	// Unmarshalling a JSON string is type-independent: the raw string is
-	// stored verbatim as the canonical value regardless of T.
-	t.Run("UnmarshalJSONString", func(t *testing.T) {
-		const in = `"already-a-string"`
-		var got StringOrPrimitive[T]
-		if err := got.UnmarshalJSON([]byte(in)); err != nil {
-			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", in, err)
-		}
-		if diff := cmp.Diff("already-a-string", string(got)); diff != "" {
-			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", in, diff)
-		}
-	})
-
-	// Unmarshalling the native primitive encoding coerces it into its
-	// canonical string form.
-	t.Run("UnmarshalJSONPrimitive", func(t *testing.T) {
-		var got StringOrPrimitive[T]
-		if err := got.UnmarshalJSON([]byte(io.fromPrimitive)); err != nil {
-			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", io.fromPrimitive, err)
-		}
-		if diff := cmp.Diff(io.canonical, string(got)); diff != "" {
-			t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s", io.fromPrimitive, diff)
-		}
-	})
-
-	// Marshalling always emits the canonical string form, never the original
-	// primitive encoding.
-	t.Run("MarshalJSON", func(t *testing.T) {
-		b := StringOrPrimitive[T](io.canonical)
-		got, err := b.MarshalJSON()
-		if err != nil {
-			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
-		}
-		want, err := json.Marshal(io.canonical)
-		if err != nil {
-			t.Fatalf("json.Marshal(%q): unexpected error: %v", io.canonical, err)
-		}
-		if diff := cmp.Diff(string(want), string(got)); diff != "" {
-			t.Errorf("MarshalJSON(): -want, +got:\n%s", diff)
-		}
-	})
-
-	// A canonical value survives a marshal -> unmarshal round-trip unchanged.
-	t.Run("RoundTrip", func(t *testing.T) {
-		want := StringOrPrimitive[T](io.canonical)
-		data, err := want.MarshalJSON()
-		if err != nil {
-			t.Fatalf("MarshalJSON(): unexpected error: %v", err)
-		}
-		var got StringOrPrimitive[T]
-		if err := got.UnmarshalJSON(data); err != nil {
-			t.Fatalf("UnmarshalJSON(%s): unexpected error: %v", data, err)
-		}
-		if diff := cmp.Diff(string(want), string(got)); diff != "" {
-			t.Errorf("round-trip: -want, +got:\n%s", diff)
-		}
-	})
-}
-
-// TestStringOrPrimitive covers every primitive type in the Primitive
-// constraint (plus a named ~float64 type) in both directions.
-func TestStringOrPrimitive(t *testing.T) {
-	cases := map[string]func(t *testing.T){
-		"Bool": func(t *testing.T) {
-			runStringOrPrimitiveSuite[bool](t, stringOrPrimitiveIO{fromPrimitive: "true", canonical: "true"})
-		},
-		"Int": func(t *testing.T) {
-			runStringOrPrimitiveSuite[int](t, stringOrPrimitiveIO{fromPrimitive: "-1", canonical: "-1"})
-		},
-		"Int8": func(t *testing.T) {
-			runStringOrPrimitiveSuite[int8](t, stringOrPrimitiveIO{fromPrimitive: "-128", canonical: "-128"})
-		},
-		"Int16": func(t *testing.T) {
-			runStringOrPrimitiveSuite[int16](t, stringOrPrimitiveIO{fromPrimitive: "32767", canonical: "32767"})
-		},
-		"Int32": func(t *testing.T) {
-			runStringOrPrimitiveSuite[int32](t, stringOrPrimitiveIO{fromPrimitive: "-2147483648", canonical: "-2147483648"})
-		},
-		"Int64": func(t *testing.T) {
-			runStringOrPrimitiveSuite[int64](t, stringOrPrimitiveIO{fromPrimitive: "9223372036854775807", canonical: "9223372036854775807"})
-		},
-		"Uint": func(t *testing.T) {
-			runStringOrPrimitiveSuite[uint](t, stringOrPrimitiveIO{fromPrimitive: "1", canonical: "1"})
-		},
-		"Uint8": func(t *testing.T) {
-			runStringOrPrimitiveSuite[uint8](t, stringOrPrimitiveIO{fromPrimitive: "255", canonical: "255"})
-		},
-		"Uint16": func(t *testing.T) {
-			runStringOrPrimitiveSuite[uint16](t, stringOrPrimitiveIO{fromPrimitive: "65535", canonical: "65535"})
-		},
-		"Uint32": func(t *testing.T) {
-			runStringOrPrimitiveSuite[uint32](t, stringOrPrimitiveIO{fromPrimitive: "4294967295", canonical: "4294967295"})
-		},
-		"Uint64": func(t *testing.T) {
-			runStringOrPrimitiveSuite[uint64](t, stringOrPrimitiveIO{fromPrimitive: "18446744073709551615", canonical: "18446744073709551615"})
-		},
+// TestStringOrBoolUnmarshalJSON covers decoding into StringOrBool, which accepts
+// either a JSON string (stored verbatim) or a JSON boolean (coerced to its
+// canonical string form), and errors on anything else.
+func TestStringOrBoolUnmarshalJSON(t *testing.T) {
+	type want struct {
+		val StringOrBool
+		err bool
 	}
-	for name, run := range cases {
-		t.Run(name, run)
-	}
-}
-
-// TestStringOrPrimitiveUnmarshalJSONEdgeCases covers UnmarshalJSON inputs whose
-// handling does not depend on the primitive type parameter; int is used as a
-// representative T.
-func TestStringOrPrimitiveUnmarshalJSONEdgeCases(t *testing.T) {
 	cases := map[string]struct {
 		reason string
 		data   string
-		want   string
+		want   want
 	}{
+		"StringTrue": {
+			reason: "A JSON string is stored verbatim, even when its content looks like a boolean.",
+			data:   `"true"`,
+			want:   want{val: "true"},
+		},
+		"StringFalse": {
+			reason: "A JSON string is stored verbatim, even when its content looks like a boolean.",
+			data:   `"false"`,
+			want:   want{val: "false"},
+		},
+		"StringArbitrary": {
+			reason: "Any JSON string content is stored verbatim.",
+			data:   `"hello world"`,
+			want:   want{val: "hello world"},
+		},
 		"EmptyString": {
 			reason: "An empty JSON string decodes to an empty canonical value.",
 			data:   `""`,
-			want:   "",
+			want:   want{val: ""},
+		},
+		"BoolTrue": {
+			reason: "A JSON boolean true is coerced to its canonical string form.",
+			data:   `true`,
+			want:   want{val: "true"},
+		},
+		"BoolFalse": {
+			reason: "A JSON boolean false is coerced to its canonical string form.",
+			data:   `false`,
+			want:   want{val: "false"},
 		},
 		"Null": {
 			reason: "A JSON null is a no-op for the string decode path and yields an empty canonical value.",
 			data:   `null`,
-			want:   "",
+			want:   want{val: ""},
 		},
-		"EscapedString": {
-			reason: "Escape sequences in a JSON string are decoded before being stored.",
-			data:   `"a\"b\tc"`,
-			want:   "a\"b\tc",
+		"Number": {
+			reason: "A JSON number is neither a string nor a boolean.",
+			data:   `42`,
+			want:   want{err: true},
 		},
-		"WhitespacePreserved": {
-			reason: "Surrounding whitespace within a JSON string is preserved.",
-			data:   `"  spaced  "`,
-			want:   "  spaced  ",
+		"Float": {
+			reason: "A JSON floating-point number is neither a string nor a boolean.",
+			data:   `1.5`,
+			want:   want{err: true},
 		},
-		"NumericString": {
-			reason: "A quoted number is treated as a string and stored verbatim.",
-			data:   `"42"`,
-			want:   "42",
+		"Array": {
+			reason: "A JSON array is neither a string nor a boolean.",
+			data:   `[true]`,
+			want:   want{err: true},
+		},
+		"Object": {
+			reason: "A JSON object is neither a string nor a boolean.",
+			data:   `{"a":true}`,
+			want:   want{err: true},
+		},
+		"Malformed": {
+			reason: "Malformed JSON fails both the string and the boolean decode attempts.",
+			data:   `{`,
+			want:   want{err: true},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			var got StringOrPrimitive[int]
-			if err := got.UnmarshalJSON([]byte(tc.data)); err != nil {
+			var got StringOrBool
+			err := got.UnmarshalJSON([]byte(tc.data))
+			if tc.want.err {
+				if err == nil {
+					t.Fatalf("UnmarshalJSON(%s): expected an error, got nil\nreason: %s", tc.data, tc.reason)
+				}
+				// The error originates from the delegated generic decoder and
+				// must identify the accepted boolean type parameter.
+				if wantSub := "value must be a JSON string or bool"; !strings.Contains(err.Error(), wantSub) {
+					t.Errorf("UnmarshalJSON(%s): error %q does not contain %q\nreason: %s", tc.data, err.Error(), wantSub, tc.reason)
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("UnmarshalJSON(%s): unexpected error: %v\nreason: %s", tc.data, err, tc.reason)
 			}
-			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+			if diff := cmp.Diff(tc.want.val, got); diff != "" {
 				t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s\nreason: %s", tc.data, diff, tc.reason)
 			}
 		})
 	}
 }
 
-// TestStringOrPrimitiveUnmarshalJSONErrors covers inputs that are neither a
-// JSON string nor a valid value of the type parameter; int is used as a
-// representative T.
-func TestStringOrPrimitiveUnmarshalJSONErrors(t *testing.T) {
+// TestStringOrBoolUnmarshalJSONOverwrite verifies that decoding always replaces
+// any pre-existing value, including the null case which clears it.
+func TestStringOrBoolUnmarshalJSONOverwrite(t *testing.T) {
 	cases := map[string]struct {
 		reason string
 		data   string
+		want   StringOrBool
 	}{
-		"JSONArray": {
-			reason: "A JSON array is neither a string nor an int.",
-			data:   `[1,2,3]`,
+		"BoolOverwrites": {
+			reason: "Decoding a boolean overwrites the previous value.",
+			data:   `false`,
+			want:   "false",
 		},
-		"JSONObject": {
-			reason: "A JSON object is neither a string nor an int.",
-			data:   `{"a":1}`,
-		},
-		"TypeMismatch": {
-			reason: "A JSON boolean cannot be decoded into an int type parameter.",
-			data:   `true`,
-		},
-		"FloatIntoInt": {
-			reason: "A JSON floating-point number cannot be decoded into an int type parameter.",
-			data:   `1.5`,
-		},
-		"MalformedJSON": {
-			reason: "Malformed JSON fails both the string and the primitive decode attempts.",
-			data:   `{`,
+		"NullClears": {
+			reason: "Decoding a JSON null clears the previous value to empty.",
+			data:   `null`,
+			want:   "",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			var got StringOrPrimitive[int]
-			err := got.UnmarshalJSON([]byte(tc.data))
-			if err == nil {
-				t.Fatalf("UnmarshalJSON(%s): expected an error, got nil\nreason: %s", tc.data, tc.reason)
+			got := StringOrBool("preset")
+			if err := got.UnmarshalJSON([]byte(tc.data)); err != nil {
+				t.Fatalf("UnmarshalJSON(%s): unexpected error: %v\nreason: %s", tc.data, err, tc.reason)
 			}
-			if want := "value must be a JSON string"; !strings.Contains(err.Error(), want) {
-				t.Errorf("UnmarshalJSON(%s): error %q does not contain %q\nreason: %s", tc.data, err.Error(), want, tc.reason)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("UnmarshalJSON(%s): -want, +got:\n%s\nreason: %s", tc.data, diff, tc.reason)
 			}
 		})
+	}
+}
+
+// TestStringOrBoolMarshalJSON covers encoding, which always emits the canonical
+// string form regardless of the stored content.
+func TestStringOrBoolMarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		val    StringOrBool
+		want   string
+	}{
+		"True": {
+			reason: "The canonical boolean value is emitted as a JSON string.",
+			val:    "true",
+			want:   `"true"`,
+		},
+		"False": {
+			reason: "The canonical boolean value is emitted as a JSON string.",
+			val:    "false",
+			want:   `"false"`,
+		},
+		"Empty": {
+			reason: "An empty value is emitted as an empty JSON string.",
+			val:    "",
+			want:   `""`,
+		},
+		"Arbitrary": {
+			reason: "Arbitrary content is emitted verbatim as a JSON string.",
+			val:    "custom",
+			want:   `"custom"`,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.val.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON(): unexpected error: %v\nreason: %s", err, tc.reason)
+			}
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Errorf("MarshalJSON(): -want, +got:\n%s\nreason: %s", diff, tc.reason)
+			}
+		})
+	}
+}
+
+// TestStringOrBoolJSONRoundTrip exercises the type through the standard encoding/json
+// package via a pointer struct field, mirroring how the generated CRD types use it.
+// It confirms that a JSON boolean is canonicalized to a JSON string on the way back out.
+func TestStringOrBoolJSONRoundTrip(t *testing.T) {
+	type holder struct {
+		V *StringOrBool `json:"v"`
+	}
+	cases := map[string]struct {
+		reason string
+		in     string
+		want   string
+	}{
+		"BoolTrueBecomesString": {
+			reason: "A JSON boolean true is canonicalized to a JSON string on re-marshal.",
+			in:     `{"v":true}`,
+			want:   `{"v":"true"}`,
+		},
+		"BoolFalseBecomesString": {
+			reason: "A JSON boolean false is canonicalized to a JSON string on re-marshal.",
+			in:     `{"v":false}`,
+			want:   `{"v":"false"}`,
+		},
+		"StringPreserved": {
+			reason: "A JSON string round-trips unchanged.",
+			in:     `{"v":"custom"}`,
+			want:   `{"v":"custom"}`,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var h holder
+			if err := json.Unmarshal([]byte(tc.in), &h); err != nil {
+				t.Fatalf("json.Unmarshal(%s): unexpected error: %v\nreason: %s", tc.in, err, tc.reason)
+			}
+			got, err := json.Marshal(h)
+			if err != nil {
+				t.Fatalf("json.Marshal(): unexpected error: %v\nreason: %s", err, tc.reason)
+			}
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Errorf("round-trip(%s): -want, +got:\n%s\nreason: %s", tc.in, diff, tc.reason)
+			}
+		})
+	}
+}
+
+// TestNewStringOrBoolType verifies the go/types.Type emitted for overridden
+// fields: a pointer to a named "StringOrBool" type, declared in this package,
+// whose underlying type is string.
+func TestNewStringOrBoolType(t *testing.T) {
+	got := NewStringOrBoolType()
+
+	if diff := cmp.Diff("*"+packagePath+".StringOrBool", got.String()); diff != "" {
+		t.Errorf("NewStringOrBoolType(): string representation: -want, +got:\n%s", diff)
+	}
+
+	ptr, ok := got.(*types.Pointer)
+	if !ok {
+		t.Fatalf("NewStringOrBoolType(): want *types.Pointer, got %T", got)
+	}
+	named, ok := ptr.Elem().(*types.Named)
+	if !ok {
+		t.Fatalf("NewStringOrBoolType(): pointer element: want *types.Named, got %T", ptr.Elem())
+	}
+	if diff := cmp.Diff("StringOrBool", named.Obj().Name()); diff != "" {
+		t.Errorf("NewStringOrBoolType(): type name: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(packagePath, named.Obj().Pkg().Path()); diff != "" {
+		t.Errorf("NewStringOrBoolType(): package path: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(packageName, named.Obj().Pkg().Name()); diff != "" {
+		t.Errorf("NewStringOrBoolType(): package name: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff("string", named.Underlying().String()); diff != "" {
+		t.Errorf("NewStringOrBoolType(): underlying type: -want, +got:\n%s", diff)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This PR adds the `config.Resource.OverrideScalarFieldType` configuration method that allows the generated type of a scalar CRD field at a given Terraform path to be overridden. An example invocation is:
```go
func Configure(p *config.Provider) {
	p.AddResourceConfigurator("azuread_application", func(r *config.Resource) {
		r.OverrideScalarFieldType("prevent_duplicate_names", types.NewStringOrBoolType())
                 ...
```

The Terraform field path should omit any wildcards, e.g., `x.y` even `x` is a collection type.

Breaking CRD scalar field type changes in upjet-based providers, such as bool->string or int->string are common, when the underlying Terraform provider makes changes in the Terraform resource's schema. For instance, in [crossplane-contrib/provider-upjet-aws:v1.19.0](https://github.com/crossplane-contrib/provider-upjet-aws/releases/tag/v1.19.0), the Terraform provider changed the type of the `at_rest_encryption_enabled` field from a bool to a nullable bool (which is a string type). The provider did not publish a new CRD API version with the necessary API converters and the Terraform runtime converters (probably because that introduces some extra complexity) and instead documented the breaking changes in its release notes.

It's also a common practice not to introduce new CRD API versions with the major version bumps of the providers when the API versioning policies allow such breaking changes.

However, when the CR field is stored in etcd as a different type than what the CRD Go struct type now declares in a new version of the provider, the UX is seriously broken. The provider simply fails to start its informer cache as it cannot decode the object it reads from etcd, fails with something like:
```
json: cannot unmarshal bool into Go struct field ReplicationGroupParameters.items.spec.forProvider.atRestEncryptionEnabled
```

This PR introduces the internal generic `StringOrPrimitive` type and the public `StringOrBool` type so that provider authors can better handle such breaking changes with a much better and expected UX. When the provider configures (either through manual means, or via the means of the auto-registration framework) a type override for the affected field, the controller-runtime then becomes able to properly decode the (now) broken object into its new memory representation and no fatal errors will be observed. Clients of the affected CRD API will though still need to be migrated to use the new type, this will only prevent a crash loop of the provider.

The existing API clients will fail as expected with the proper API validation errors when they try to use the old field type, until they are migrated to use the new type for the affected field.

**Note**: The current implementation only supports overriding the generated types for scalar fields; collections and composites are currently not supported. It's a build time error to specify a Terraform path that points to a collection or composite when calling `OverrideScalarFieldType`. 

In the future, we may consider adding support for other primitive type overrides and/or adding support for type overrides of collections/composites. Supporting overrides for non-scalars is more complex to handle in upjet's code generation pipelines and is not needed as of now.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against `crossplane-contrib/provider-upjet-azure`. The runtime behavior of the provider has been tested successfully for an update with a breaking scalar field type change (bool -> string as discussed above). The provider no longer crashes as intended.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
