### PR TITLE
pkg/types: preserve qualified requirement text in field docs

### DIFF
--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -468,10 +468,15 @@ func getDescription(s string) string {
 	// Remove dash
 	s = strings.TrimSpace(s)[strings.Index(s, "-")+1:]
 
-	// Remove 'Reqiured' || 'Optional' information
+	// Remove plain '(Required)' || '(Optional)' markers, but keep
+	// parenthesized content that further qualifies the specification
+	// requirement, e.g. "(Required unless a snapshot_identifier or
+	// replicate_source_db is provided)", since that information is not
+	// otherwise conveyed to the user.
 	matches := parentheses.FindAllString(s, -1)
 	for _, m := range matches {
-		if strings.HasPrefix(strings.ToLower(m), "(optional") || strings.HasPrefix(strings.ToLower(m), "(required") {
+		inner := strings.ToLower(strings.TrimSpace(strings.Trim(m, "()")))
+		if inner == "optional" || inner == "required" {
 			s = strings.ReplaceAll(s, m, "")
 		}
 	}

--- a/pkg/types/field_test.go
+++ b/pkg/types/field_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetDescription(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		arg    string
+		want   string
+	}{
+		"PlainOptional": {
+			reason: "A simple '(Optional)' marker should be stripped entirely.",
+			arg:    "timezone - (Optional) Time zone of the DB instance.",
+			want:   "Time zone of the DB instance.",
+		},
+		"PlainRequired": {
+			reason: "A simple '(Required)' marker should be stripped entirely.",
+			arg:    "name - (Required) Name of the resource.",
+			want:   "Name of the resource.",
+		},
+		"ComplexRequirement": {
+			reason: "A parenthesized requirement that is more specific than " +
+				"'Optional'/'Required' must be preserved, since it conveys " +
+				"information not otherwise available to the user.",
+			arg: "username - (Required unless a snapshot_identifier or replicate_source_db is provided) " +
+				"Username for the master DB user. Cannot be specified for a replica.",
+			want: "(Required unless a snapshot_identifier or replicate_source_db is provided) " +
+				"Username for the master DB user. Cannot be specified for a replica.",
+		},
+		"CaseInsensitiveOptional": {
+			reason: "The '(optional)' marker check must be case-insensitive.",
+			arg:    "field - (optional) Some description.",
+			want:   "Some description.",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := getDescription(tc.arg)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\ngetDescription(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through Upjet's contribution process if this is your first time
opening an Upjet pull request. Find us in
https://crossplane.slack.com/archives/C05T19TB729 if you need any help
contributing.
-->

### Description of your changes

`getDescription` in `pkg/types/field.go` strips parenthesized
specification-requirement text from Terraform argument descriptions before
they're used as CRD field documentation. Previously it stripped *any*
parenthetical whose text started with "(optional" or "(required"
(case-insensitive), which discards qualifying detail beyond a plain
"(Optional)"/"(Required)" marker. For example, AWS RDS's `username` argument
is documented as:

> (Required unless a snapshot_identifier or replicate_source_db is provided)

but the generated CRD field comment previously dropped the entire
parenthetical, leaving users with no indication that `username` has a
conditional requirement until they apply the resource.

This change only strips a parenthetical when its trimmed, lowercased content
is exactly "optional" or "required" (so plain markers like "(Optional)",
"(required)", "( Optional )" are still removed as before), and preserves any
more specific parenthetical content instead.

Fixes #

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added a table-driven unit test, `TestGetDescription` in
`pkg/types/field_test.go`, covering a plain "(Optional)" marker, a plain
"(Required)" marker, a case-insensitive "(optional)" marker, and the
reported complex-requirement case (RDS `username`'s
"(Required unless a snapshot_identifier or replicate_source_db is
provided)"). Verified the new `ComplexRequirement` test case fails against
the pre-fix code (it strips the whole parenthetical) and passes against the
fix.

Ran:
- `go build ./...` — succeeds.
- `go test ./pkg/types/...` — all packages pass.

This is a pure string-processing change with no behavioral impact outside of
generated doc-comment text, so no e2e/dev-stack run was needed or performed.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md

Fixes #457