### PR TITLE
fix(types): make secret reference fields optional in initProvider

### DIFF
--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -309,6 +309,7 @@ func TestBuild(t *testing.T) {
 	}
 	type want struct {
 		forProvider     string
+		initProvider    string
 		atProvider      string
 		validationRules string
 		err             error
@@ -420,8 +421,12 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key2SecretRef\" tf:\"-\""; Key3SecretRef []github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key3SecretRef\" tf:\"-\""}`,
-				atProvider:  `type example.Observation struct{}`,
+				forProvider: `type example.Parameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key2SecretRef,omitempty\" tf:\"-\""; Key3SecretRef *[]github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key3SecretRef,omitempty\" tf:\"-\""}`,
+				// initProvider fields must always be optional, even for secret
+				// reference fields backed by a required Terraform field (Key2):
+				// https://github.com/crossplane/upjet/issues/456
+				initProvider: `type example.InitParameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.SecretKeySelector "json:\"key2SecretRef,omitempty\" tf:\"-\""; Key3 []string "json:\"key3SecretRef,omitempty\" tf:\"-\""}`,
+				atProvider:   `type example.Observation struct{}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key2SecretRef)",message="spec.forProvider.key2SecretRef is a required parameter"
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key3SecretRef)",message="spec.forProvider.key3SecretRef is a required parameter"`,
@@ -627,8 +632,9 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key2SecretRef\" tf:\"-\""; Key3SecretRef []github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key3SecretRef\" tf:\"-\""}`,
-				atProvider:  `type example.Observation struct{}`,
+				forProvider:  `type example.Parameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key2SecretRef,omitempty\" tf:\"-\""; Key3SecretRef *[]github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key3SecretRef,omitempty\" tf:\"-\""}`,
+				initProvider: `type example.InitParameters struct{Key1SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef *github.com/crossplane/crossplane/apis/v2/core/v2.LocalSecretKeySelector "json:\"key2SecretRef,omitempty\" tf:\"-\""; Key3 []string "json:\"key3SecretRef,omitempty\" tf:\"-\""}`,
+				atProvider:   `type example.Observation struct{}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key2SecretRef)",message="spec.forProvider.key2SecretRef is a required parameter"
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key3SecretRef)",message="spec.forProvider.key3SecretRef is a required parameter"`,
@@ -860,6 +866,11 @@ func TestBuild(t *testing.T) {
 			if g.AtProviderType != nil {
 				if diff := cmp.Diff(tc.want.atProvider, g.AtProviderType.Obj().String()); diff != "" {
 					t.Fatalf("Build(...): -want atProvider, +got atProvider: %s", diff)
+				}
+			}
+			if tc.want.initProvider != "" && g.InitProviderType != nil {
+				if diff := cmp.Diff(tc.want.initProvider, g.InitProviderType.Obj().String()); diff != "" {
+					t.Fatalf("Build(...): -want initProvider, +got initProvider: %s", diff)
 				}
 			}
 			if diff := cmp.Diff(tc.want.validationRules, g.ValidationRules); diff != "" {

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -331,10 +331,15 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 	}
 	f.TransformedName = name.NewFromCamel(f.FieldNameCamel).LowerCamelComputed
 	f.JSONTag = structtag.NewJSON(structtag.WithName(f.TransformedName))
-	if f.Schema.Optional {
-		f.FieldType = types.NewPointer(f.FieldType)
-		f.JSONTag.SetOmit(structtag.OmitEmpty)
-	}
+	// Note: Secret reference fields must always be optional (pointer type with
+	// omitempty), regardless of whether the underlying Terraform field is
+	// required. initProvider fields are always optional (see addInitField),
+	// and this Field's type and JSON tag are shared between the forProvider
+	// and initProvider structs, so making this conditional on
+	// f.Schema.Optional would incorrectly mark the initProvider secret
+	// reference as required whenever the source field is required upstream.
+	f.FieldType = types.NewPointer(f.FieldType)
+	f.JSONTag.SetOmit(structtag.OmitEmpty)
 
 	return f, false, nil
 }


### PR DESCRIPTION
Fixes #456

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Extended the table-driven `TestBuild` cases `Sensitive_Fields` and `Sensitive_Fields_namespaced` in `pkg/types/builder_test.go` to assert on the generated `initProvider` struct, not just `forProvider`. Confirmed via `git stash` on `pkg/types/field.go` alone that these assertions FAIL against the pre-fix code and PASS with the fix applied:

```
go test ./pkg/types/... -run TestBuild -v
```

Also ran, all passing:

```
go build ./...
go vet ./pkg/...
go test ./pkg/...
```

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md

---
AI assistance: this change was drafted with Claude Code.