### PR TITLE
fix: apply TF conversions before filtering initProvider-exclusive diffs

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -328,7 +328,7 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 	}, nil
 }
 
-func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.InstanceDiff) error { //nolint:gocyclo
+func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.InstanceDiff, cfg *config.Resource) error { //nolint:gocyclo
 	if instanceDiff == nil || instanceDiff.Empty() {
 		return nil
 	}
@@ -337,9 +337,17 @@ func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.Instance
 	if err != nil {
 		return errors.Wrap(err, "cannot get spec.forProvider parameters")
 	}
+	paramsForProvider, err = cfg.ApplyTFConversions(paramsForProvider, config.ToTerraform)
+	if err != nil {
+		return errors.Wrap(err, "cannot apply tf conversions to spec.forProvider parameters")
+	}
 	paramsInitProvider, err := tr.GetInitParameters()
 	if err != nil {
 		return errors.Wrap(err, "cannot get spec.initProvider parameters")
+	}
+	paramsInitProvider, err = cfg.ApplyTFConversions(paramsInitProvider, config.ToTerraform)
+	if err != nil {
+		return errors.Wrap(err, "cannot apply tf conversions to spec.initProvider parameters")
 	}
 
 	initProviderExclusiveParamKeys := getTerraformIgnoreChanges(paramsForProvider, paramsInitProvider)
@@ -456,7 +464,7 @@ func (n *terraformPluginSDKExternal) getResourceDataDiff(tr resource.Terraformed
 	}
 
 	if resourceExists {
-		if err := filterInitExclusiveDiffs(tr, instanceDiff); err != nil {
+		if err := filterInitExclusiveDiffs(tr, instanceDiff, n.config); err != nil {
 			return nil, errors.Wrap(err, "failed to filter the diffs exclusive to spec.initProvider in the terraform.InstanceDiff")
 		}
 	}


### PR DESCRIPTION
### Description of your changes

`filterInitExclusiveDiffs` compares field keys from `spec.forProvider` / `spec.initProvider` against the `terraform.InstanceDiff` attribute keys to suppress diffs for fields that are only declared in spec.initProvider. The comparison was broken for providers that reconcile a CRD API version whose schema uses embedded objects (e.g. `v1beta2` pointer fields) for fields that the underlying Terraform schema defines as singleton lists.

`filterInitExclusiveDiffs` reads `forProvider` and `initProvider` directly from the managed resource:

paramsForProvider, _ := tr.GetParameters()    // TFParser.Marshal → CRD schema format
paramsInitProvider, _ := tr.GetInitParameters() // TFParser.Marshal → CRD schema format

These calls serialize the Go struct using the `tf: tag`. The resulting maps reflect the CRD schema, not the Terraform schema. When the reconciled CRD version uses embedded objects for singleton-list fields (as `v1beta2` does), the serialized keys have no list indices:

CRD schema (`v1beta2`):  node_config.advanced_machine_features
TF schema:             node_config.0.advanced_machine_features

`InstanceDiff.Attributes` keys are always in TF list-style because the underlying Terraform provider schema is unchanged. The HasPrefix check therefore never matches and the diff is not removed, causing `Synced=False` error on immutable fields.

### Fix

Pass `cfg *config.Resource` into `filterInitExclusiveDiffs` and apply `ApplyTFConversions(_, config.ToTerraform)` to both `paramsForProvider` and `paramsInitProvider` immediately after reading them, before the ignore-key computation:

```go
paramsForProvider, err = cfg.ApplyTFConversions(paramsForProvider, config.ToTerraform)
...
paramsInitProvider, err = cfg.ApplyTFConversions(paramsInitProvider, config.ToTerraform)
```

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally in the provider-upjet-gcp resources.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
