### PR TITLE
[release-2.4]: cherry-pick #728

### DIFF
--- a/pkg/controller/external_tfpluginsdk.go
+++ b/pkg/controller/external_tfpluginsdk.go
@@ -328,7 +328,7 @@ func (c *TerraformPluginSDKConnector) Connect(ctx context.Context, mg xpresource
 	}, nil
 }
 
-func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.InstanceDiff) error { //nolint:gocyclo
+func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.InstanceDiff, cfg *config.Resource) error { //nolint:gocyclo
 	if instanceDiff == nil || instanceDiff.Empty() {
 		return nil
 	}
@@ -337,9 +337,17 @@ func filterInitExclusiveDiffs(tr resource.Terraformed, instanceDiff *tf.Instance
 	if err != nil {
 		return errors.Wrap(err, "cannot get spec.forProvider parameters")
 	}
+	paramsForProvider, err = cfg.ApplyTFConversions(paramsForProvider, config.ToTerraform)
+	if err != nil {
+		return errors.Wrap(err, "cannot apply tf conversions to spec.forProvider parameters")
+	}
 	paramsInitProvider, err := tr.GetInitParameters()
 	if err != nil {
 		return errors.Wrap(err, "cannot get spec.initProvider parameters")
+	}
+	paramsInitProvider, err = cfg.ApplyTFConversions(paramsInitProvider, config.ToTerraform)
+	if err != nil {
+		return errors.Wrap(err, "cannot apply tf conversions to spec.initProvider parameters")
 	}
 
 	initProviderExclusiveParamKeys := getTerraformIgnoreChanges(paramsForProvider, paramsInitProvider)
@@ -456,7 +464,7 @@ func (n *terraformPluginSDKExternal) getResourceDataDiff(tr resource.Terraformed
 	}
 
 	if resourceExists {
-		if err := filterInitExclusiveDiffs(tr, instanceDiff); err != nil {
+		if err := filterInitExclusiveDiffs(tr, instanceDiff, n.config); err != nil {
 			return nil, errors.Wrap(err, "failed to filter the diffs exclusive to spec.initProvider in the terraform.InstanceDiff")
 		}
 	}


### PR DESCRIPTION
### Description of your changes

This PR cherry-picks the #728 to release-2.4 branch.

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
