### PR TITLE
Skip no-op tag updates and prevent creation conflicts

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -362,8 +363,20 @@ func (t *Tagger) Initialize(ctx context.Context, mg xpresource.Managed) error {
 	if err != nil {
 		return err
 	}
+	// Note that the unmarshal below merges the external tags into the
+	// existing tags map instead of replacing it, so the user's own tags are
+	// preserved. This also means we cannot compare the paved bytes to decide
+	// whether anything changed; we have to compare the managed resource
+	// itself, before and after the merge.
+	before := mg.DeepCopyObject()
 	if err := json.Unmarshal(pavedByte, mg); err != nil {
 		return err
+	}
+	if equality.Semantic.DeepEqual(before, mg) {
+		// The external tags are already in the spec. Initialize is called on
+		// every reconcile, so without this check we would issue a no-op update
+		// request for every managed resource on every poll.
+		return nil
 	}
 	if err := t.kube.Update(ctx, mg); err != nil {
 		return err

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -15,8 +15,13 @@ import (
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,45 +31,165 @@ const (
 	provider = "ACoolProvider"
 )
 
+// taggedManaged is a managed resource with a spec.forProvider.tags field, i.e.
+// what the Tagger initializer is actually used with. fake.Managed alone has no
+// such field, so unmarshalling the tags into it would be a no-op.
+type taggedManaged struct {
+	metav1.TypeMeta
+	fake.Managed
+	fake.TypedProviderConfigReferencer
+
+	Spec taggedSpec `json:"spec"`
+}
+
+type taggedSpec struct {
+	ForProvider taggedParameters `json:"forProvider"`
+}
+
+type taggedParameters struct {
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// GetObjectKind disambiguates between the embedded TypeMeta and fake.Managed,
+// and makes the resource report a real kind so that the external tags have
+// realistic values.
+func (t *taggedManaged) GetObjectKind() k8sschema.ObjectKind { return &t.TypeMeta }
+
+// DeepCopyObject is what the fix relies on, so it has to actually deep copy the
+// tags map, just like the generated DeepCopyObject of a real managed resource.
+func (t *taggedManaged) DeepCopyObject() runtime.Object {
+	out := *t
+	if t.Spec.ForProvider.Tags != nil {
+		out.Spec.ForProvider.Tags = make(map[string]*string, len(t.Spec.ForProvider.Tags))
+		for k, v := range t.Spec.ForProvider.Tags {
+			if v == nil {
+				out.Spec.ForProvider.Tags[k] = nil
+				continue
+			}
+			out.Spec.ForProvider.Tags[k] = ptr.To(*v)
+		}
+	}
+	return &out
+}
+
 func TestTaggerInitialize(t *testing.T) {
 	errBoom := errors.New("boom")
 
+	// The tags the Tagger will want to see in spec.forProvider.tags, given the
+	// kind, name and provider config reference set by newTagged below.
+	externalTags := func() map[string]*string {
+		return map[string]*string{
+			xpresource.ExternalResourceTagKeyKind:     ptr.To("acoolservice"),
+			xpresource.ExternalResourceTagKeyName:     ptr.To(name),
+			xpresource.ExternalResourceTagKeyProvider: ptr.To(provider),
+		}
+	}
+	withTags := func(extra map[string]*string) map[string]*string {
+		tags := externalTags()
+		for k, v := range extra {
+			tags[k] = v
+		}
+		return tags
+	}
+	newTagged := func(tags map[string]*string, policies ...xpv2.ManagementAction) *taggedManaged {
+		mg := &taggedManaged{}
+		mg.TypeMeta = metav1.TypeMeta{Kind: kind, APIVersion: "v1beta1"}
+		mg.SetName(name)
+		mg.SetProviderConfigReference(&xpv2.ProviderConfigReference{Name: provider})
+		mg.SetManagementPolicies(policies)
+		mg.Spec.ForProvider.Tags = tags
+		return mg
+	}
+
 	type args struct {
-		mg   xpresource.Managed
-		kube client.Client
+		mg        *taggedManaged
+		updateErr error
 	}
 	type want struct {
 		err error
+		// updates is the number of calls the Tagger is expected to make to
+		// kube.Update.
+		updates int
+		// tags, if set, is the expected spec.forProvider.tags after Initialize.
+		tags map[string]*string
 	}
 	cases := map[string]struct {
+		reason string
 		args
 		want
 	}{
-		"Successful": {
-			args: args{
-				mg:   &fake.Managed{},
-				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
-			},
+		"FirstReconcileTagsAbsent": {
+			reason: "The external tags are missing, so they should be set and persisted.",
+			args:   args{mg: newTagged(nil)},
 			want: want{
-				err: nil,
+				updates: 1,
+				tags:    externalTags(),
 			},
 		},
-		"Failure": {
-			args: args{
-				mg:   &fake.Managed{},
-				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
-			},
+		"FirstReconcileUpdateFailed": {
+			reason: "An error from the API server should be returned to the caller.",
+			args:   args{mg: newTagged(nil), updateErr: errBoom},
 			want: want{
-				err: errBoom,
+				err:     errBoom,
+				updates: 1,
+				tags:    externalTags(),
+			},
+		},
+		"SteadyStateTagsAlreadySet": {
+			reason: "The external tags are already in the spec, so there is nothing to update.",
+			args:   args{mg: newTagged(externalTags())},
+			want: want{
+				updates: 0,
+				tags:    externalTags(),
+			},
+		},
+		"SteadyStateWithUserTags": {
+			reason: "Tags the user set themselves must not trigger an update, and must survive it.",
+			args:   args{mg: newTagged(withTags(map[string]*string{"owner": ptr.To("team-a")}))},
+			want: want{
+				updates: 0,
+				tags:    withTags(map[string]*string{"owner": ptr.To("team-a")}),
+			},
+		},
+		"ExternalTagChanged": {
+			reason: "An external tag with a stale value should be corrected and persisted.",
+			args: args{mg: newTagged(withTags(map[string]*string{
+				xpresource.ExternalResourceTagKeyName: ptr.To("some-old-name"),
+			}))},
+			want: want{
+				updates: 1,
+				tags:    externalTags(),
+			},
+		},
+		"ObserveOnly": {
+			reason: "Observe-only resources should not have their spec touched at all.",
+			args:   args{mg: newTagged(nil, xpv2.ManagementActionObserve)},
+			want: want{
+				updates: 0,
+				tags:    nil,
 			},
 		},
 	}
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			tagger := NewTagger(tc.kube, "tags")
-			gotErr := tagger.Initialize(context.TODO(), tc.mg)
+			updates := 0
+			kube := &test.MockClient{
+				MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+					updates++
+					return tc.args.updateErr
+				},
+			}
+
+			tagger := NewTagger(kube, "tags")
+			gotErr := tagger.Initialize(context.TODO(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
-				t.Fatalf("generateTypeName(...): -want error, +got error: %s", diff)
+				t.Errorf("Initialize(...): %s: -want error, +got error: %s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.updates, updates); diff != "" {
+				t.Errorf("Initialize(...): %s: -want update calls, +got update calls: %s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.tags, tc.args.mg.Spec.ForProvider.Tags); diff != "" {
+				t.Errorf("Initialize(...): %s: -want tags, +got tags: %s", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Supersedes #476, which was auto-closed when I synchronized my fork's `main`.
Same patch, now on a dedicated branch.

The managed reconciler calls `Initialize` on every pass, and the `Tagger`
initializer ends with an unconditional `kube.Update`. After the first reconcile
the external tags are already in `spec.forProvider.tags`, so from then on we
issue a full spec update per taggable managed resource per poll interval that
changes nothing.

The API server byte-compares the object and discards the identical update before
it reaches etcd, so this is not an etcd write problem. It is an API call that
shows up as an audit event with a request body, at a higher audit level than a
read. On a cluster with a few thousand managed resources and audit logs shipped
somewhere that bills for ingest, that is a continuous and pointless cost.

It also produces a spurious error on every resource creation:

```
2025-03-06T09:21:58+01:00       DEBUG   provider-aws    Cannot initialize managed resource      {"controller": "managed/ec2.aws.upbound.io/v1beta1, kind=securitygroup",
    "request": {"name":"example4"},
    "uid": "6110a508-2be7-470c-8d00-10302dc9c270",
    "version": "101685",
    "external-name": "",
    "error": "Operation cannot be fulfilled on securitygroups.ec2.aws.upbound.io \"example4\": the object has been modified; please apply your changes to the latest version and try again"}
```

This change compares the managed resource before and after the tags are merged
in and returns early when nothing changed, which removes both the redundant API
call and the error above.

Note on the implementation: the comparison has to be on the managed resource and
not on the paved bytes. `setExternalTagsWithPaved` replaces the tags map in the
paved object with just the three external tags, and the user's own tags only
survive because the subsequent `json.Unmarshal` merges into the existing map.
Comparing the paved bytes would therefore report a change on every call for any
resource that has user tags.

Fixes #741

I have:

- [x] Read and followed Upjet's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests added in `pkg/config/resource_test.go` covering the no-op and
changed-tags paths.

Manually reproduced and verified against a live cluster:

Used `crossplane/upjet-provider-template` (hashicorp/null provider, no cloud
credentials needed).

1. Added custom Tagger initializer using the `"triggers"` field in both config files:
   ```go
   r.InitializerFns = append(r.InitializerFns, func(c client.Client) managed.Initializer {
       return ujconfig.NewTagger(c, "triggers")
   })
   ```
2. Enabled `r.UseAsync = true` — enables async status updates that create
   realistic concurrency (like real cloud providers).
3. Added `time.Sleep(500 * time.Millisecond)` in `TerraformSetupBuilder` —
   simulates slow provider setup (cloud API auth, etc.).
4. Added `replace github.com/crossplane/upjet/v2 => ../upjet` to `go.mod`.
5. Regenerated controllers and deployed via `make local-deploy`.

[contribution process]: https://github.com/crossplane/upjet/blob/main/CONTRIBUTING.md
